### PR TITLE
Sampling in the backend abstraction + one-key deploy script

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,44 +17,55 @@ Tinker Client --> FastAPI --> BackendFactory --> Miles or NeMo RL --> Ray + Mega
 
 ## Quickstart (NeMo RL)
 
-### 1. Build
+### 1. Deploy
 
-From the monorepo root (parent of `tinker-cloud/`, `RL/`, `tinker_gmi/`, `tinker-cookbook/`):
+One command via `scripts/deploy_tinkercloud.sh` — clones the four repos
+(tinker-cloud, RL, tinker_gmi, tinker-cookbook) at pinned refs, creates the
+pod/container, installs the code, starts Ray and the API server, and
+health-checks it:
 
 ```bash
-cd tinker-cloud
-./docker/build_dev.sh --backend nemo_rl
+# Onto a Kubernetes GPU cluster
+HF_TOKEN_FILE=~/.hf_token ./scripts/deploy_tinkercloud.sh --source git --target k8s
+
+# Onto a docker GPU box
+HF_TOKEN_FILE=~/.hf_token ./scripts/deploy_tinkercloud.sh --source git --target docker
+
+# Redeploy code + restart the server on an existing pod/container
+./scripts/deploy_tinkercloud.sh --source git --code-only
 ```
 
-### 2. Run
+Both targets run the same in-container setup (`scripts/lib/setup_container.sh`),
+so k8s and docker deployments cannot drift. (Developers working in the
+tinker-nemorl monorepo can pass `--source dev` to bundle their local working
+trees, uncommitted changes included.)
+
+Common knobs (env vars):
+
+| Var | Meaning |
+|---|---|
+| `HF_TOKEN_FILE` | Local file with the HuggingFace token (required on first deploy) |
+| `GPUS` | GPUs to request / declare to Ray (default 4) |
+| `IMAGE` | Base image (default `nvcr.io/nvidia/nemo-rl:v0.5.0`) |
+| `TINKER_CLOUD_REF`, `RL_REF`, `TINKER_GMI_REF`, `COOKBOOK_REF` | Pinned git refs, default `main` (`*_REPO` to override URLs) |
+| `KUBECONFIG`, `NS`, `POD`, `NODE` | k8s target placement: kubeconfig path, namespace, pod name, node name |
+| `CONTAINER`, `DATA_DIR`, `DOCKER` | docker target: container name, host data dir mounted at `/data`, docker command (`DOCKER="sg docker -c"` if your shell lacks the docker group) |
+
+k8s note: `GPUS` must fit the node's *unallocated* `nvidia.com/gpu` (idle pods
+still hold their allocation), or kubelet rejects the pod.
+
+### 2. Run a recipe
 
 ```bash
-docker run -d --name tinkercloud-nemo-rl \
-  --gpus all \
-  -v /path/to/models:/data/models \
-  --network host \
-  --shm-size=16g \
-  -e ALLOW_PARTIAL_BATCHES=true \
-  -e NCCL_NVLS_ENABLE=1 \
-  -e NCCL_SHM_DISABLE=1 \
-  -e NCCL_IGNORE_DISABLED_P2P=1 \
-  gmicloudai/tinkercloud:dev-nemo-rl
-```
-
-The entrypoint starts Ray (auto-detects GPUs) and the training API on port 8000.
-
-### 3. Run a recipe
-
-```bash
-docker exec -d tinkercloud-nemo-rl bash -c '
+# docker target (k8s: same command via kubectl -n <namespace> exec <pod> -- bash -c '...')
+docker exec -d tinkercloud-nemorl bash -c '
+export TINKER_API_KEY=tml-dev-key TINKER_BASE_URL=http://localhost:8000
 python -m tinker_cookbook.recipes.math_rl.train \
-  model_name=/data/models/Llama-3.2-1B \
-  base_url=http://localhost:8000 \
-  group_size=4 \
-  groups_per_batch=100 \
+  model_name=meta-llama/Llama-3.2-1B \
+  group_size=16 \
+  groups_per_batch=8 \
   learning_rate=1e-4 \
-  lora_rank=32 \
-  log_path=/tmp/math_rl
+  log_path=/data/trajectories/math_rl
 '
 ```
 

--- a/scripts/deploy_tinkercloud.sh
+++ b/scripts/deploy_tinkercloud.sh
@@ -1,0 +1,225 @@
+#!/usr/bin/env bash
+# One-key deploy of a TinkerCloud NeMo RL server (k8s pod or docker container).
+#
+#   deploy_tinkercloud.sh [--source dev|git] [--target k8s|docker] [--code-only]
+#
+# Sources
+#   dev  (default when run inside the tinker-nemorl monorepo)
+#        Bundle the LOCAL working trees — including uncommitted changes — of
+#        tinker-cloud, RL, tinker_gmi, tinker-cookbook (monorepo siblings).
+#   git  Self-contained: shallow-clone all four repos at pinned refs. Needs no
+#        monorepo checkout; this is the user-facing path.
+#        Override refs/URLs via env: TINKER_CLOUD_REPO/TINKER_CLOUD_REF,
+#        RL_REPO/RL_REF, TINKER_GMI_REPO/TINKER_GMI_REF, COOKBOOK_REPO/COOKBOOK_REF.
+#
+# Targets (mirrored: same image, same in-container setup, only transport differs)
+#   k8s     Pod on the kubecluster. Env: KUBECONFIG, NS, POD, NODE, GPUS.
+#   docker  Local container on a GPU box. Env: CONTAINER, DATA_DIR, GPUS,
+#           DOCKER (e.g. DOCKER="sg docker -c" when the shell lacks docker group).
+#
+# --code-only  Skip pod/container creation; redeploy code + restart server.
+#
+# HF token: HF_TOKEN_FILE=<path> (copied to /tmp/hf_token.txt in the target;
+# if unset, an existing /tmp/hf_token.txt inside the target is reused).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+SOURCE=dev
+TARGET=k8s
+CODE_ONLY=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --source) SOURCE="$2"; shift 2 ;;
+    --target) TARGET="$2"; shift 2 ;;
+    --code-only) CODE_ONLY=1; shift ;;
+    *) echo "unknown arg: $1"; exit 1 ;;
+  esac
+done
+
+# --- shared config ---------------------------------------------------------
+GPUS="${GPUS:-4}"
+IMAGE="${IMAGE:-nvcr.io/nvidia/nemo-rl:v0.5.0}"
+SERVER_LOG="${SERVER_LOG:-/data/server1.log}"
+HF_TOKEN_FILE="${HF_TOKEN_FILE:-}"
+# k8s
+export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/ns.config}"
+NS="${NS:-tinkercloud-nemorl}"
+POD="${POD:-tinkercloud-nemorl-m02}"
+NODE="${NODE:-master-02}"
+# docker
+CONTAINER="${CONTAINER:-tinkercloud-nemorl}"
+DATA_DIR="${DATA_DIR:-/opt/dlami/nvme/$USER}"
+DOCKER="${DOCKER:-docker}"
+
+# git-mode repos/refs
+TINKER_CLOUD_REPO="${TINKER_CLOUD_REPO:-https://github.com/GMISWE/tinker-cloud.git}"
+TINKER_CLOUD_REF="${TINKER_CLOUD_REF:-main}"
+RL_REPO="${RL_REPO:-https://github.com/GavinZhu-GMI/RL.git}"
+RL_REF="${RL_REF:-main}"
+TINKER_GMI_REPO="${TINKER_GMI_REPO:-https://github.com/GMISWE/tinker_gmi.git}"
+TINKER_GMI_REF="${TINKER_GMI_REF:-main}"
+COOKBOOK_REPO="${COOKBOOK_REPO:-https://github.com/GMISWE/tinker-cookbook.git}"
+COOKBOOK_REF="${COOKBOOK_REF:-main}"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# --- transport abstraction: CP <local> <remote-path>, EX "<script>" --------
+if [ "$TARGET" = k8s ]; then
+  CP() { kubectl -n "$NS" cp "$1" "$POD:$2"; }
+  EX() { kubectl -n "$NS" exec "$POD" -- bash -c "$1"; }
+  EX_TIMEOUT() { timeout 30 kubectl -n "$NS" exec "$POD" -- bash -c "$1" || true; }
+elif [ "$TARGET" = docker ]; then
+  CP() { $DOCKER cp "$1" "$CONTAINER:$2"; }
+  EX() { $DOCKER exec "$CONTAINER" bash -c "$1"; }
+  EX_TIMEOUT() { timeout 30 $DOCKER exec "$CONTAINER" bash -c "$1" || true; }
+else
+  echo "unknown --target $TARGET"; exit 1
+fi
+
+# --- 1. create the pod / container -----------------------------------------
+if [ "$CODE_ONLY" = 0 ]; then
+  if [ "$TARGET" = k8s ]; then
+    echo "==> [1/6] creating pod $POD on $NODE"
+    cat > "$TMP/pod.yaml" <<EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  labels: {app: tinkercloud-nemorl}
+  name: $POD
+  namespace: $NS
+spec:
+  nodeName: $NODE          # bypasses scheduler; NoSchedule taints don't block
+  restartPolicy: Never
+  runtimeClassName: nvidia # MANDATORY: without it vLLM dies (no NVML)
+  tolerations:
+  - {key: node.kubernetes.io/unschedulable, operator: Exists, effect: NoSchedule}
+  containers:
+  - name: tinkercloud
+    image: $IMAGE
+    command: [sleep, infinity]
+    env:
+    - {name: PYTHONUNBUFFERED, value: "1"}
+    - {name: TOKENIZERS_PARALLELISM, value: "false"}
+    - {name: TINKER_API_KEY, value: tml-dev-key}
+    - {name: TINKERCLOUD_BACKEND, value: nemo_rl}
+    - {name: ALLOW_PARTIAL_BATCHES, value: "true"}
+    - {name: HF_HOME, value: /data/.cache/huggingface}
+    - {name: CUDA_DEVICE_MAX_CONNECTIONS, value: "1"}
+    - {name: NCCL_NVLS_ENABLE, value: "0"}
+    - {name: NCCL_IGNORE_DISABLED_P2P, value: "1"}
+    resources:
+      requests: {cpu: "16", memory: 128Gi, nvidia.com/gpu: $GPUS}
+      limits: {cpu: "48", memory: 256Gi, nvidia.com/gpu: $GPUS}
+    volumeMounts:
+    - {mountPath: /dev/shm, name: shm}
+    - {mountPath: /data, name: data}
+  volumes:
+  - name: shm
+    emptyDir: {medium: Memory, sizeLimit: 32Gi}
+  - name: data
+    emptyDir: {}
+EOF
+    kubectl apply -f "$TMP/pod.yaml"
+    echo "==> waiting for Ready (image pull can take ~5-10 min on a cold node)"
+    # NB: GPUS must be <= the node's UNALLOCATED nvidia.com/gpu (idle pods still
+    # hold their allocation); otherwise kubelet rejects with UnexpectedAdmissionError.
+    for _ in $(seq 1 240); do
+      PHASE=$(kubectl -n "$NS" get pod "$POD" -o jsonpath='{.status.phase}')
+      READY=$(kubectl -n "$NS" get pod "$POD" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
+      [ "$READY" = True ] && break
+      if [ "$PHASE" = Failed ]; then
+        echo "ERROR: pod admission failed:"; kubectl -n "$NS" get pod "$POD" -o jsonpath='{.status.message}'; echo
+        exit 1
+      fi
+      sleep 5
+    done
+    [ "$READY" = True ] || { echo "ERROR: pod not Ready after 20 min"; exit 1; }
+  else
+    echo "==> [1/6] starting container $CONTAINER (data: $DATA_DIR)"
+    $DOCKER run -d --name "$CONTAINER" --init --gpus all --network host \
+      --shm-size=32g -v "$DATA_DIR:/data" \
+      -e PYTHONUNBUFFERED=1 -e TOKENIZERS_PARALLELISM=false \
+      -e TINKER_API_KEY=tml-dev-key -e TINKERCLOUD_BACKEND=nemo_rl \
+      -e ALLOW_PARTIAL_BATCHES=true -e HF_HOME=/data/.cache/huggingface \
+      -e CUDA_DEVICE_MAX_CONNECTIONS=1 -e NCCL_NVLS_ENABLE=0 \
+      -e NCCL_IGNORE_DISABLED_P2P=1 \
+      "$IMAGE" sleep infinity
+  fi
+else
+  echo "==> [1/6] --code-only: restarting server on existing $TARGET target"
+  EX "pkill -f 'python3 -m trainin[g]' || true; sleep 8" || true
+fi
+
+# --- 2. gather code ---------------------------------------------------------
+echo "==> [2/6] gathering code (source=$SOURCE)"
+if [ "$SOURCE" = dev ]; then
+  # monorepo layout: tinker-cloud/scripts/ -> monorepo root is two dirs up
+  MONOREPO="$(cd "$SCRIPT_DIR/../.." && pwd)"
+  for d in tinker-cloud RL tinker_gmi tinker-cookbook; do
+    [ -d "$MONOREPO/$d" ] || { echo "ERROR: $MONOREPO/$d missing (dev mode needs the monorepo)"; exit 1; }
+  done
+  SRC="$MONOREPO"
+elif [ "$SOURCE" = git ]; then
+  echo "    cloning: tinker-cloud@$TINKER_CLOUD_REF RL@$RL_REF tinker_gmi@$TINKER_GMI_REF tinker-cookbook@$COOKBOOK_REF"
+  git clone -q --depth 1 --branch "$TINKER_CLOUD_REF" "$TINKER_CLOUD_REPO" "$TMP/src/tinker-cloud"
+  git clone -q --depth 1 --branch "$RL_REF"           "$RL_REPO"           "$TMP/src/RL"
+  git clone -q --depth 1 --branch "$TINKER_GMI_REF"   "$TINKER_GMI_REPO"   "$TMP/src/tinker_gmi"
+  git clone -q --depth 1 --branch "$COOKBOOK_REF"     "$COOKBOOK_REPO"     "$TMP/src/tinker-cookbook"
+  SRC="$TMP/src"
+else
+  echo "unknown --source $SOURCE"; exit 1
+fi
+tar -C "$SRC" -czf "$TMP/code.tar.gz" \
+  --exclude='.git' --exclude='__pycache__' --exclude='*.pyc' --exclude='.pytest_cache' \
+  --exclude='tinker-cookbook/attic' \
+  tinker-cloud/training tinker-cloud/tests \
+  RL/nemo_rl \
+  tinker_gmi/src tinker_gmi/pyproject.toml tinker_gmi/README.md \
+  tinker-cookbook/tinker_cookbook tinker-cookbook/pyproject.toml tinker-cookbook/README.md
+echo "    bundle: $(du -h "$TMP/code.tar.gz" | cut -f1)"
+
+# --- 3. copy in --------------------------------------------------------------
+echo "==> [3/6] copying code + token into target"
+CP "$TMP/code.tar.gz" /tmp/code.tar.gz
+CP "$SCRIPT_DIR/lib/setup_container.sh" /tmp/setup_container.sh
+if [ -n "$HF_TOKEN_FILE" ]; then
+  CP "$HF_TOKEN_FILE" /tmp/hf_token.txt
+fi
+EX "test -s /tmp/hf_token.txt" || {
+  echo "ERROR: no HF token in target; pass HF_TOKEN_FILE=<path>"; exit 1; }
+
+# --- 4. in-container setup ---------------------------------------------------
+echo "==> [4/6] running shared in-container setup"
+EX "bash /tmp/setup_container.sh"
+
+# --- 5. ray head -------------------------------------------------------------
+echo "==> [5/6] ensuring Ray head is up"
+EX "ray status >/dev/null 2>&1 || { ray start --head --num-gpus $GPUS --disable-usage-stats > /tmp/ray_start.log 2>&1 < /dev/null; sleep 5; }
+ray status 2>/dev/null | grep GPU || true"
+
+# --- 6. server ---------------------------------------------------------------
+echo "==> [6/6] starting API server (log: $SERVER_LOG)"
+# NB: the detached child must have ALL fds redirected or the exec hangs (143);
+# even then the launch usually succeeded — verified below with a fresh probe.
+EX_TIMEOUT "
+export PYTHONPATH=/app NUM_GPUS=$GPUS RAY_ADDRESS=ray://localhost:10001
+export HF_TOKEN=\$(cat /tmp/hf_token.txt) HF_HOME=/data/.cache/huggingface \
+       TINKER_API_KEY=tml-dev-key TINKERCLOUD_BACKEND=nemo_rl ALLOW_PARTIAL_BATCHES=true
+cd /app && setsid nohup python3 -m training > $SERVER_LOG 2>&1 < /dev/null &
+sleep 2; echo LAUNCHED"
+
+CODE=000
+for _ in $(seq 1 20); do
+  CODE=$(EX "curl -s -o /dev/null -w '%{http_code}' --max-time 3 http://localhost:8000/health" || echo 000)
+  [ "$CODE" = 200 ] && break
+  sleep 5
+done
+if [ "$CODE" = 200 ]; then
+  echo "==> DONE: TinkerCloud healthy (target=$TARGET, source=$SOURCE, log=$SERVER_LOG)"
+else
+  echo "==> FAILED health check; last server log lines:"
+  EX "tail -20 $SERVER_LOG"
+  exit 1
+fi

--- a/scripts/lib/setup_container.sh
+++ b/scripts/lib/setup_container.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Shared in-container setup for TinkerCloud NeMo RL dev environments.
+# Runs INSIDE the k8s pod or docker container after /tmp/code.tar.gz is in place.
+# Single source of truth so the k8s and docker deployments cannot drift.
+set -euo pipefail
+
+cd /tmp && tar xzf code.tar.gz
+mkdir -p /app /work /data/metadata /data/trajectories /data/.cache/huggingface
+
+# TinkerCloud server -> /app (run via PYTHONPATH=/app python3 -m training)
+rm -rf /app/training /app/tests /work/tinker_gmi /work/tinker-cookbook
+mv /tmp/tinker-cloud/training /app/training
+mv /tmp/tinker-cloud/tests /app/tests
+
+# NeMo RL worker overlay onto the image's install (picked up at next create_model)
+PKG=$(python3 -c 'import nemo_rl, os; print(os.path.dirname(nemo_rl.__file__))')
+cp -r /tmp/RL/nemo_rl/. "$PKG/"
+
+# SDK + cookbook editable installs
+mv /tmp/tinker_gmi /work/tinker_gmi
+mv /tmp/tinker-cookbook /work/tinker-cookbook
+pip install -e /work/tinker_gmi --no-deps -q
+# dev-mode bundles may lack .git -> setuptools-scm needs a pretend version
+SETUPTOOLS_SCM_PRETEND_VERSION=${SETUPTOOLS_SCM_PRETEND_VERSION:-0.1.0} \
+  pip install -e /work/tinker-cookbook --no-deps -q
+
+# deps missing from the nemo-rl image that --no-deps skips
+# (distro: SDK; chz/termcolor/blobfile/tiktoken: cookbook;
+#  sympy/pylatexenc/math-verify: math_rl recipe extras)
+pip install -q distro chz termcolor blobfile tiktoken cloudpickle rich anyio \
+  'httpx[http2]' sympy pylatexenc math-verify
+
+python3 -c 'import tinker, tinker_cookbook, nemo_rl; print("imports OK")'
+PYTHONPATH=/app python3 -c 'import training; print("training OK")'
+echo SETUP_DONE

--- a/tests/test_backend_interface.py
+++ b/tests/test_backend_interface.py
@@ -135,12 +135,53 @@ class TestTrainingBackendABC:
             "create_model", "forward", "forward_backward",
             "apply_optimizer_step", "update_inference_weights",
             "save_checkpoint", "load_checkpoint", "delete_model",
-            "get_logprobs",
+            "get_logprobs", "sample", "prepare_for_generation",
         ]
         for method_name in required:
             assert hasattr(TrainingBackend, method_name), (
                 f"TrainingBackend missing required method: {method_name}"
             )
+
+
+class TestSamplingContract:
+    """Test sample()/prepare_for_generation() error contracts (no GPU needed)."""
+
+    def test_miles_sample_without_router_raises(self):
+        from tinkercloud.training.backends.miles.backend import MilesBackend, MilesHandle
+        backend = MilesBackend()
+        handle = MilesHandle(model_id="test", backend_type="miles")
+        with pytest.raises(BackendError, match="router not available"):
+            asyncio.run(backend.sample(handle, "req-1", [1, 2, 3], num_samples=1))
+
+    def test_miles_prepare_without_router_raises(self):
+        from tinkercloud.training.backends.miles.backend import MilesBackend, MilesHandle
+        backend = MilesBackend()
+        handle = MilesHandle(model_id="test", backend_type="miles")
+        with pytest.raises(BackendError, match="router not available"):
+            asyncio.run(backend.prepare_for_generation(handle))
+
+    def test_nemo_rl_sample_without_generation_raises(self):
+        from tinkercloud.training.backends.nemo_rl.backend import NemoRLBackend, NemoRLHandle
+        backend = NemoRLBackend()
+        handle = NemoRLHandle(model_id="test", backend_type="nemo_rl")
+        with pytest.raises(BackendError, match="generation engine not initialized"):
+            asyncio.run(backend.sample(handle, "req-1", [1, 2, 3], num_samples=1))
+
+    def test_nemo_rl_prepare_without_generation_raises(self):
+        from tinkercloud.training.backends.nemo_rl.backend import NemoRLBackend, NemoRLHandle
+        backend = NemoRLBackend()
+        handle = NemoRLHandle(model_id="test", backend_type="nemo_rl")
+        with pytest.raises(BackendError, match="generation engine not initialized"):
+            asyncio.run(backend.prepare_for_generation(handle))
+
+    def test_nemo_rl_delete_model_drops_accumulator(self):
+        from tinkercloud.training.backends.nemo_rl.backend import NemoRLBackend, NemoRLHandle
+        from tinkercloud.training.backends.nemo_rl.generation import NemoRLBatchAccumulator
+        backend = NemoRLBackend()
+        handle = NemoRLHandle(model_id="test", backend_type="nemo_rl")
+        backend._batch_accumulators["test"] = NemoRLBatchAccumulator()
+        asyncio.run(backend.delete_model(handle))
+        assert "test" not in backend._batch_accumulators
 
 
 # ---------------------------------------------------------------------------

--- a/training/api.py
+++ b/training/api.py
@@ -187,7 +187,7 @@ def create_app(config: Optional[TrainingConfig] = None) -> FastAPI:
         application.state.model_service = ModelService(backend=backend)
         application.state.training_service = TrainingService(backend=backend)
         application.state.checkpoint_service = CheckpointService(backend=backend)
-        application.state.sampling_service = SamplingService()
+        application.state.sampling_service = SamplingService(backend=backend)
         # Initialize SessionService with storage for persistence
         application.state.session_service = SessionService(storage=session_storage)
 

--- a/training/backends/base.py
+++ b/training/backends/base.py
@@ -239,6 +239,58 @@ class TrainingBackend(ABC):
         """
         ...
 
+    @abstractmethod
+    async def sample(
+        self,
+        handle: BackendHandle,
+        request_id: str,
+        prompt_tokens: List[int],
+        num_samples: int,
+        sampling_params: Optional[Dict[str, Any]] = None,
+        prompt_logprobs: bool = False,
+    ) -> Dict[str, Any]:
+        """
+        Generate num_samples completions for one prompt via the backend's
+        inference engine.
+
+        Backend behavior:
+        - Miles: per-sample HTTP calls to the SGLang router.
+        - NeMo RL: requests are batch-accumulated and flushed as a single
+          Policy.generate() call (PERF-002).
+
+        Returns:
+            {
+                "sequences": [
+                    {"tokens": [...], "logprobs": [...],
+                     "text": Optional[str], "stop_reason": "stop" | "length"},
+                    ...
+                ],
+                "prompt_logprobs": Optional[List],  # [None, lp1, ...] when requested
+            }
+
+        Raises:
+            BackendError: If the inference engine is unavailable.
+        """
+        ...
+
+    @abstractmethod
+    async def prepare_for_generation(
+        self,
+        handle: BackendHandle,
+    ) -> None:
+        """
+        Ensure the inference engine is ready to serve sampling requests.
+
+        Backend behavior:
+        - Miles: validates the SGLang router is available (no state change).
+        - NeMo RL: safety-net refit + wake if the engine was left in
+          training state (fast no-op when already generation-ready).
+
+        Raises:
+            BackendError: If the engine cannot be made ready.
+        """
+        ...
+
 
 class UnsupportedFeatureError(BackendError):
     """Raised when a backend-specific feature is requested on the wrong backend."""

--- a/training/backends/miles/backend.py
+++ b/training/backends/miles/backend.py
@@ -522,3 +522,54 @@ class MilesBackend(TrainingBackend):
             lp = output.get("logprobs", {})
             logprobs_list.append(lp.get("data", []))
         return logprobs_list
+
+    async def sample(
+        self,
+        handle: BackendHandle,
+        request_id: str,
+        prompt_tokens: List[int],
+        num_samples: int,
+        sampling_params: Optional[Dict[str, Any]] = None,
+        prompt_logprobs: bool = False,
+    ) -> Dict[str, Any]:
+        """Sample via per-request HTTP calls to the SGLang router."""
+        from ...utils.sglang_client import SGLangClient
+
+        h: MilesHandle = handle  # type: ignore[assignment]
+        if not h.router_ip or not h.router_port:
+            raise BackendError(
+                "SGLang router not available",
+                backend="miles", operation="sample",
+            )
+        client = SGLangClient(base_url=f"http://{h.router_ip}:{h.router_port}")
+
+        sequences = []
+        prompt_logprobs_result = None
+        for _ in range(num_samples):
+            result = await client.generate(
+                input_ids=prompt_tokens,
+                sampling_params=sampling_params or {},
+                prompt_logprobs=prompt_logprobs,
+            )
+            sequences.append({
+                "tokens": result["tokens"],
+                "logprobs": result["logprobs"],
+                "text": result.get("text"),
+                "stop_reason": result.get("stop_reason", "length"),
+            })
+            if prompt_logprobs and prompt_logprobs_result is None:
+                prompt_logprobs_result = result.get("prompt_logprobs")
+
+        return {
+            "sequences": sequences,
+            "prompt_logprobs": prompt_logprobs_result,
+        }
+
+    async def prepare_for_generation(self, handle: BackendHandle) -> None:
+        """SGLang router is always live for Miles — just validate it exists."""
+        h: MilesHandle = handle  # type: ignore[assignment]
+        if not h.router_ip or not h.router_port:
+            raise BackendError(
+                "SGLang router not available",
+                backend="miles", operation="prepare_for_generation",
+            )

--- a/training/backends/nemo_rl/backend.py
+++ b/training/backends/nemo_rl/backend.py
@@ -15,9 +15,12 @@ import asyncio
 import logging
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from ..base import BackendError, BackendHandle, TrainingBackend
+
+if TYPE_CHECKING:
+    from .generation import NemoRLBatchAccumulator
 
 logger = logging.getLogger(__name__)
 
@@ -66,6 +69,8 @@ class NemoRLBackend(TrainingBackend):
         self.overrides = overrides or {}
         self._converter = None
         self._builder = None
+        # PERF-002: per-model batch accumulators for sample()
+        self._batch_accumulators: Dict[str, "NemoRLBatchAccumulator"] = {}
 
     @property
     def converter(self):
@@ -687,6 +692,8 @@ class NemoRLBackend(TrainingBackend):
                 except Exception:
                     pass  # Generation may share resources with policy
 
+            self._batch_accumulators.pop(h.model_id, None)
+
             logger.info("NeMo RL model %s deleted", h.model_id)
 
         except Exception as e:
@@ -706,6 +713,50 @@ class NemoRLBackend(TrainingBackend):
             lp = output.get("logprobs", {})
             logprobs_list.append(lp.get("data", []))
         return logprobs_list
+
+    async def sample(
+        self,
+        handle: BackendHandle,
+        request_id: str,
+        prompt_tokens: List[int],
+        num_samples: int,
+        sampling_params: Optional[Dict[str, Any]] = None,
+        prompt_logprobs: bool = False,
+    ) -> Dict[str, Any]:
+        """Sample via Policy.generate() on vLLM Ray workers.
+
+        PERF-002: requests are batch-accumulated per model and flushed as a
+        single generate() call (~20-30x speedup for RL rollouts).
+        """
+        from .generation import NemoRLBatchAccumulator
+
+        h: NemoRLHandle = handle  # type: ignore[assignment]
+        if h.policy_generation is None:
+            raise BackendError(
+                "generation engine not initialized (debug_train_only mode?)",
+                backend="nemo_rl", operation="sample",
+            )
+        accumulator = self._batch_accumulators.setdefault(
+            h.model_id, NemoRLBatchAccumulator()
+        )
+        return await accumulator.submit(
+            handle=h,
+            request_id=request_id,
+            prompt_tokens=prompt_tokens,
+            num_samples=num_samples,
+            sampling_params=sampling_params or {},
+            prompt_logprobs=prompt_logprobs,
+        )
+
+    async def prepare_for_generation(self, handle: BackendHandle) -> None:
+        """Safety-net refit + wake if the engine was left in training state."""
+        h: NemoRLHandle = handle  # type: ignore[assignment]
+        if h.policy_generation is None:
+            raise BackendError(
+                "generation engine not initialized (debug_train_only mode?)",
+                backend="nemo_rl", operation="prepare_for_generation",
+            )
+        await _ensure_generation_ready(h)
 
 
 # ---------------------------------------------------------------------------

--- a/training/backends/nemo_rl/generation.py
+++ b/training/backends/nemo_rl/generation.py
@@ -1,0 +1,311 @@
+"""
+NeMo RL generation batching.
+
+Accumulates per-sample generation requests and flushes them as a single
+batched Policy.generate() call (PERF-002). Lifted from SamplingService
+so all NeMo RL specifics live behind the backend abstraction (001 review P2).
+"""
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class _PendingGenRequest:
+    """A single sampling request waiting to be batched."""
+    prompt_tokens: List[int]
+    num_samples: int
+    sampling_params: Dict[str, Any]
+    prompt_logprobs: bool
+    future: asyncio.Future = field(default_factory=lambda: asyncio.get_event_loop().create_future())
+
+
+class NemoRLBatchAccumulator:
+    """Accumulates per-sample NeMo RL generation requests and flushes them
+    as a single batched generate() call for dramatically better throughput.
+
+    PERF-002: Without batching, 2048 RL rollouts → 2048 sequential generate(1)
+    calls (~34 min). With batching, one generate(2048) call (~1-2 min).
+    """
+
+    def __init__(self, flush_interval_ms: int = 50, max_batch_size: int = 4096):
+        self._queue: List[_PendingGenRequest] = []
+        self._lock = asyncio.Lock()
+        self._flush_event = asyncio.Event()
+        self._flush_interval = flush_interval_ms / 1000.0
+        self._max_batch_size = max_batch_size
+        self._flush_task: Optional[asyncio.Task] = None
+
+    async def submit(
+        self,
+        handle: Any,
+        request_id: str,
+        prompt_tokens: List[int],
+        num_samples: int,
+        sampling_params: Dict[str, Any],
+        prompt_logprobs: bool,
+    ) -> Dict[str, Any]:
+        """Submit a request for batching. Returns when the batch is flushed."""
+        req = _PendingGenRequest(
+            prompt_tokens=prompt_tokens,
+            num_samples=num_samples,
+            sampling_params=sampling_params,
+            prompt_logprobs=prompt_logprobs,
+        )
+        async with self._lock:
+            self._queue.append(req)
+            queue_len = len(self._queue)
+            if queue_len >= self._max_batch_size:
+                self._flush_event.set()
+            elif self._flush_task is None or self._flush_task.done():
+                self._flush_task = asyncio.create_task(
+                    self._delayed_flush(handle, request_id)
+                )
+        return await req.future
+
+    async def _delayed_flush(self, handle: Any, request_id: str):
+        """Wait for flush_interval or until max_batch_size reached, then flush.
+
+        Loops to drain any requests that arrived during the generate() call.
+        """
+        try:
+            await asyncio.wait_for(
+                self._flush_event.wait(), timeout=self._flush_interval,
+            )
+        except asyncio.TimeoutError:
+            pass
+
+        # Keep flushing until the queue is empty — new requests may arrive
+        # while generate() is running (which takes seconds to minutes).
+        while True:
+            had_work = await self._flush(handle, request_id)
+            if not had_work:
+                break
+
+    async def _flush(self, handle: Any, request_id: str) -> bool:
+        """Flush all queued requests as a single batched generate() call.
+
+        Returns True if work was done, False if queue was empty.
+        """
+        async with self._lock:
+            if not self._queue:
+                return False
+            batch = self._queue[:]
+            self._queue.clear()
+            self._flush_event.clear()
+
+        try:
+            results = await _batched_nemo_rl_generate(handle, request_id, batch)
+            for req, result in zip(batch, results):
+                if not req.future.done():
+                    req.future.set_result(result)
+        except Exception as e:
+            for req in batch:
+                if not req.future.done():
+                    req.future.set_exception(e)
+        return True
+
+
+async def _batched_nemo_rl_generate(
+    handle: Any,
+    request_id: str,
+    batch: List[_PendingGenRequest],
+) -> List[Dict[str, Any]]:
+    """Generate completions for a batch of requests in a single vLLM call.
+
+    Combines all prompts into one BatchedDataDict, calls generate() once,
+    then splits results back to per-request responses.
+    """
+    import torch
+    from nemo_rl.distributed.batched_data_dict import BatchedDataDict
+    from .backend import _ensure_generation_ready
+
+    # Expand requests: each request with num_samples>1 becomes multiple rows
+    expanded_prompts = []
+    expanded_params = []
+    request_indices = []  # maps expanded index → (request_idx, sample_idx)
+    for req_idx, req in enumerate(batch):
+        for sample_idx in range(req.num_samples):
+            expanded_prompts.append(req.prompt_tokens)
+            expanded_params.append(req.sampling_params)
+            request_indices.append((req_idx, sample_idx))
+
+    total_samples = len(expanded_prompts)
+    if total_samples == 0:
+        return [{} for _ in batch]
+
+    # Find max prompt length and pad with the model's pad token
+    # (verify_right_padding checks that positions after input_length == pad_token_id)
+    tokenizer = handle.tokenizer
+    pad_id = tokenizer.pad_token_id if tokenizer and tokenizer.pad_token_id is not None else 0
+    max_prompt_len = max(len(p) for p in expanded_prompts)
+    input_ids = torch.full((total_samples, max_prompt_len), pad_id, dtype=torch.long)
+    input_lengths = torch.zeros(total_samples, dtype=torch.long)
+    for i, prompt in enumerate(expanded_prompts):
+        plen = len(prompt)
+        input_ids[i, :plen] = torch.tensor(prompt, dtype=torch.long)
+        input_lengths[i] = plen
+
+    # Pad to dp_size
+    dp_size = handle.config.get("dp_size", 1)
+    actual_size = total_samples
+    padded_size = actual_size
+    if actual_size % dp_size != 0:
+        pad_count = dp_size - (actual_size % dp_size)
+        padded_size = actual_size + pad_count
+        input_ids = torch.cat([
+            input_ids,
+            input_ids[-1:].repeat(pad_count, 1),
+        ])
+        input_lengths = torch.cat([
+            input_lengths,
+            input_lengths[-1:].repeat(pad_count),
+        ])
+
+    data = BatchedDataDict({
+        "input_ids": input_ids,
+        "input_lengths": input_lengths,
+    })
+
+    # Extract sampling params from first request (batch assumes uniform params)
+    # For heterogeneous params, use per-sample _tinker_ fields
+    first_params = batch[0].sampling_params or {}
+    max_new_tokens = first_params.get("max_tokens", 256)
+    temperature = first_params.get("temperature", 0.7)
+    top_p = first_params.get("top_p", 0.9)
+    greedy = temperature <= 0.01
+
+    # Per-sample params via _tinker_ fields
+    data["_tinker_max_new_tokens"] = [
+        (expanded_params[i] or {}).get("max_tokens", max_new_tokens)
+        for i in range(actual_size)
+    ] + [max_new_tokens] * (padded_size - actual_size)
+    data["_tinker_temperature"] = [
+        (expanded_params[i] or {}).get("temperature", temperature)
+        for i in range(actual_size)
+    ] + [temperature] * (padded_size - actual_size)
+    data["_tinker_top_p"] = [
+        (expanded_params[i] or {}).get("top_p", top_p)
+        for i in range(actual_size)
+    ] + [top_p] * (padded_size - actual_size)
+
+    # Stop strings
+    raw_stop = first_params.get("stop")
+    stop_strings: List[str] = []
+    if raw_stop is not None:
+        if isinstance(raw_stop, str):
+            stop_strings = [raw_stop]
+        elif isinstance(raw_stop, list) and raw_stop and isinstance(raw_stop[0], str):
+            stop_strings = list(raw_stop)
+    if stop_strings:
+        data["stop_strings"] = [stop_strings] * padded_size
+
+    # Prompt logprobs
+    any_prompt_logprobs = any(req.prompt_logprobs for req in batch)
+    if any_prompt_logprobs:
+        data["_tinker_prompt_logprobs"] = [True] * padded_size
+
+    logger.info(
+        "[%s] Batched NeMo RL generate: %d requests → %d samples (padded to %d)",
+        request_id, len(batch), actual_size, padded_size,
+    )
+
+    # Generate — single call for entire batch
+    await _ensure_generation_ready(handle)
+    result = await asyncio.to_thread(handle.policy_generation.generate, data, greedy)
+
+    # Split results back to per-request responses
+    output_ids = result["output_ids"]
+    gen_lengths = result["generation_lengths"]
+    logprobs_tensor = result["logprobs"]
+    tokenizer = handle.tokenizer
+    eos_id = tokenizer.eos_token_id if tokenizer else None
+
+    # Build per-expanded-sample results
+    sample_results = []
+    for i in range(actual_size):
+        prompt_len = int(input_lengths[i].item())
+        gen_len = int(gen_lengths[i].item())
+        out_tokens = output_ids[i, prompt_len:prompt_len + gen_len].tolist()
+        out_logprobs = logprobs_tensor[i, prompt_len:prompt_len + gen_len].tolist()
+        text = tokenizer.decode(out_tokens) if tokenizer else None
+
+        stop_reason = "length"
+        if out_tokens and eos_id is not None and out_tokens[-1] == eos_id:
+            stop_reason = "stop"
+        elif text and stop_strings:
+            for ss in stop_strings:
+                if ss in text:
+                    stop_reason = "stop"
+                    break
+
+        # Truncate at stop string
+        if text and stop_strings:
+            earliest_pos = len(text)
+            matched_stop = None
+            for ss in stop_strings:
+                pos = text.find(ss)
+                if pos != -1 and pos < earliest_pos:
+                    earliest_pos = pos
+                    matched_stop = ss
+            if matched_stop is not None:
+                truncated_text = text[:earliest_pos + len(matched_stop)]
+                if len(truncated_text) < len(text):
+                    orig_count = len(out_tokens)
+                    trunc_count = orig_count
+                    for t in range(1, orig_count + 1):
+                        decoded = tokenizer.decode(out_tokens[:t], skip_special_tokens=False)
+                        if len(decoded) >= len(truncated_text):
+                            trunc_count = t
+                            break
+                    out_tokens = out_tokens[:trunc_count]
+                    out_logprobs = out_logprobs[:trunc_count]
+                    text = tokenizer.decode(out_tokens)
+                    stop_reason = "stop"
+
+        prompt_logprobs_result = None
+        req_idx, _ = request_indices[i]
+        if batch[req_idx].prompt_logprobs and logprobs_tensor.shape[1] >= prompt_len:
+            raw = logprobs_tensor[i, :prompt_len].tolist()
+            # Only position 0 has no logprob; interior values are real (BUG-013)
+            prompt_logprobs_result = [None] + raw[1:] if raw else []
+
+        sample_results.append({
+            "tokens": out_tokens,
+            "logprobs": out_logprobs,
+            "text": text,
+            "stop_reason": stop_reason,
+            "prompt_logprobs_result": prompt_logprobs_result,
+        })
+
+    # Reassemble per-request responses
+    per_request_results = []
+    for req_idx, req in enumerate(batch):
+        sequences = []
+        prompt_lp = None
+        for exp_idx, (ri, si) in enumerate(request_indices):
+            if ri == req_idx:
+                sr = sample_results[exp_idx]
+                sequences.append({
+                    "tokens": sr["tokens"],
+                    "logprobs": sr["logprobs"],
+                    "text": sr["text"],
+                    "stop_reason": sr["stop_reason"],
+                })
+                if prompt_lp is None:
+                    prompt_lp = sr["prompt_logprobs_result"]
+        per_request_results.append({
+            "sequences": sequences,
+            "prompt_logprobs": prompt_lp,
+        })
+
+    logger.info(
+        "[%s] Batched generate complete: %d requests, avg %.0f tokens/sample",
+        request_id, len(batch),
+        sum(len(s["tokens"]) for s in sample_results) / max(len(sample_results), 1),
+    )
+
+    return per_request_results

--- a/training/services/sampling_service.py
+++ b/training/services/sampling_service.py
@@ -1,333 +1,38 @@
 """
 Sampling Service - Business Logic for Model Sampling
 
-Handles:
-- Async sampling via SGLang (Miles backend)
-- Async sampling via Policy.generate() (NeMo RL backend) with batch accumulation
-- Sync sampling via SGLang
-- SGLang sampling client creation
+Backend-agnostic orchestration only: resolves the target model and delegates
+to TrainingBackend.sample() / prepare_for_generation(). All backend specifics
+(SGLang HTTP for Miles, batched Policy.generate() for NeMo RL) live in the
+backend implementations (001 review P2).
 """
-import asyncio
 import logging
 import uuid
-from dataclasses import dataclass, field
 from typing import Dict, Any, List, Optional
 
-from ..utils.sglang_client import SGLangClient
+from ..backends.base import BackendHandle, TrainingBackend
 from ..utils.helpers import find_model_with_rollout_manager
 
 logger = logging.getLogger(__name__)
 
 
-@dataclass
-class _PendingGenRequest:
-    """A single sampling request waiting to be batched."""
-    prompt_tokens: List[int]
-    num_samples: int
-    sampling_params: Dict[str, Any]
-    prompt_logprobs: bool
-    future: asyncio.Future = field(default_factory=lambda: asyncio.get_event_loop().create_future())
-
-
-class NemoRLBatchAccumulator:
-    """Accumulates per-sample NeMo RL generation requests and flushes them
-    as a single batched generate() call for dramatically better throughput.
-
-    PERF-002: Without batching, 2048 RL rollouts → 2048 sequential generate(1)
-    calls (~34 min). With batching, one generate(2048) call (~1-2 min).
-    """
-
-    def __init__(self, flush_interval_ms: int = 50, max_batch_size: int = 4096):
-        self._queue: List[_PendingGenRequest] = []
-        self._lock = asyncio.Lock()
-        self._flush_event = asyncio.Event()
-        self._flush_interval = flush_interval_ms / 1000.0
-        self._max_batch_size = max_batch_size
-        self._flush_task: Optional[asyncio.Task] = None
-
-    async def submit(
-        self,
-        handle: Any,
-        request_id: str,
-        prompt_tokens: List[int],
-        num_samples: int,
-        sampling_params: Dict[str, Any],
-        prompt_logprobs: bool,
-    ) -> Dict[str, Any]:
-        """Submit a request for batching. Returns when the batch is flushed."""
-        req = _PendingGenRequest(
-            prompt_tokens=prompt_tokens,
-            num_samples=num_samples,
-            sampling_params=sampling_params,
-            prompt_logprobs=prompt_logprobs,
-        )
-        async with self._lock:
-            self._queue.append(req)
-            queue_len = len(self._queue)
-            if queue_len >= self._max_batch_size:
-                self._flush_event.set()
-            elif self._flush_task is None or self._flush_task.done():
-                self._flush_task = asyncio.create_task(
-                    self._delayed_flush(handle, request_id)
-                )
-        return await req.future
-
-    async def _delayed_flush(self, handle: Any, request_id: str):
-        """Wait for flush_interval or until max_batch_size reached, then flush.
-
-        Loops to drain any requests that arrived during the generate() call.
-        """
-        try:
-            await asyncio.wait_for(
-                self._flush_event.wait(), timeout=self._flush_interval,
-            )
-        except asyncio.TimeoutError:
-            pass
-
-        # Keep flushing until the queue is empty — new requests may arrive
-        # while generate() is running (which takes seconds to minutes).
-        while True:
-            had_work = await self._flush(handle, request_id)
-            if not had_work:
-                break
-
-    async def _flush(self, handle: Any, request_id: str) -> bool:
-        """Flush all queued requests as a single batched generate() call.
-
-        Returns True if work was done, False if queue was empty.
-        """
-        async with self._lock:
-            if not self._queue:
-                return False
-            batch = self._queue[:]
-            self._queue.clear()
-            self._flush_event.clear()
-
-        try:
-            results = await _batched_nemo_rl_generate(handle, request_id, batch)
-            for req, result in zip(batch, results):
-                if not req.future.done():
-                    req.future.set_result(result)
-        except Exception as e:
-            for req in batch:
-                if not req.future.done():
-                    req.future.set_exception(e)
-        return True
-
-
-async def _batched_nemo_rl_generate(
-    handle: Any,
-    request_id: str,
-    batch: List[_PendingGenRequest],
-) -> List[Dict[str, Any]]:
-    """Generate completions for a batch of requests in a single vLLM call.
-
-    Combines all prompts into one BatchedDataDict, calls generate() once,
-    then splits results back to per-request responses.
-    """
-    import torch
-    from nemo_rl.distributed.batched_data_dict import BatchedDataDict
-    from ..backends.nemo_rl.backend import _ensure_generation_ready
-
-    # Expand requests: each request with num_samples>1 becomes multiple rows
-    expanded_prompts = []
-    expanded_params = []
-    request_indices = []  # maps expanded index → (request_idx, sample_idx)
-    for req_idx, req in enumerate(batch):
-        for sample_idx in range(req.num_samples):
-            expanded_prompts.append(req.prompt_tokens)
-            expanded_params.append(req.sampling_params)
-            request_indices.append((req_idx, sample_idx))
-
-    total_samples = len(expanded_prompts)
-    if total_samples == 0:
-        return [{} for _ in batch]
-
-    # Find max prompt length and pad with the model's pad token
-    # (verify_right_padding checks that positions after input_length == pad_token_id)
-    tokenizer = handle.tokenizer
-    pad_id = tokenizer.pad_token_id if tokenizer and tokenizer.pad_token_id is not None else 0
-    max_prompt_len = max(len(p) for p in expanded_prompts)
-    input_ids = torch.full((total_samples, max_prompt_len), pad_id, dtype=torch.long)
-    input_lengths = torch.zeros(total_samples, dtype=torch.long)
-    for i, prompt in enumerate(expanded_prompts):
-        plen = len(prompt)
-        input_ids[i, :plen] = torch.tensor(prompt, dtype=torch.long)
-        input_lengths[i] = plen
-
-    # Pad to dp_size
-    dp_size = handle.config.get("dp_size", 1)
-    actual_size = total_samples
-    padded_size = actual_size
-    if actual_size % dp_size != 0:
-        pad_count = dp_size - (actual_size % dp_size)
-        padded_size = actual_size + pad_count
-        input_ids = torch.cat([
-            input_ids,
-            input_ids[-1:].repeat(pad_count, 1),
-        ])
-        input_lengths = torch.cat([
-            input_lengths,
-            input_lengths[-1:].repeat(pad_count),
-        ])
-
-    data = BatchedDataDict({
-        "input_ids": input_ids,
-        "input_lengths": input_lengths,
-    })
-
-    # Extract sampling params from first request (batch assumes uniform params)
-    # For heterogeneous params, use per-sample _tinker_ fields
-    first_params = batch[0].sampling_params or {}
-    max_new_tokens = first_params.get("max_tokens", 256)
-    temperature = first_params.get("temperature", 0.7)
-    top_p = first_params.get("top_p", 0.9)
-    greedy = temperature <= 0.01
-
-    # Per-sample params via _tinker_ fields
-    data["_tinker_max_new_tokens"] = [
-        (expanded_params[i] or {}).get("max_tokens", max_new_tokens)
-        for i in range(actual_size)
-    ] + [max_new_tokens] * (padded_size - actual_size)
-    data["_tinker_temperature"] = [
-        (expanded_params[i] or {}).get("temperature", temperature)
-        for i in range(actual_size)
-    ] + [temperature] * (padded_size - actual_size)
-    data["_tinker_top_p"] = [
-        (expanded_params[i] or {}).get("top_p", top_p)
-        for i in range(actual_size)
-    ] + [top_p] * (padded_size - actual_size)
-
-    # Stop strings
-    raw_stop = first_params.get("stop")
-    stop_strings: List[str] = []
-    if raw_stop is not None:
-        if isinstance(raw_stop, str):
-            stop_strings = [raw_stop]
-        elif isinstance(raw_stop, list) and raw_stop and isinstance(raw_stop[0], str):
-            stop_strings = list(raw_stop)
-    if stop_strings:
-        data["stop_strings"] = [stop_strings] * padded_size
-
-    # Prompt logprobs
-    any_prompt_logprobs = any(req.prompt_logprobs for req in batch)
-    if any_prompt_logprobs:
-        data["_tinker_prompt_logprobs"] = [True] * padded_size
-
-    logger.info(
-        "[%s] Batched NeMo RL generate: %d requests → %d samples (padded to %d)",
-        request_id, len(batch), actual_size, padded_size,
-    )
-
-    # Generate — single call for entire batch
-    await _ensure_generation_ready(handle)
-    result = await asyncio.to_thread(handle.policy_generation.generate, data, greedy)
-
-    # Split results back to per-request responses
-    output_ids = result["output_ids"]
-    gen_lengths = result["generation_lengths"]
-    logprobs_tensor = result["logprobs"]
-    tokenizer = handle.tokenizer
-    eos_id = tokenizer.eos_token_id if tokenizer else None
-
-    # Build per-expanded-sample results
-    sample_results = []
-    for i in range(actual_size):
-        prompt_len = int(input_lengths[i].item())
-        gen_len = int(gen_lengths[i].item())
-        out_tokens = output_ids[i, prompt_len:prompt_len + gen_len].tolist()
-        out_logprobs = logprobs_tensor[i, prompt_len:prompt_len + gen_len].tolist()
-        text = tokenizer.decode(out_tokens) if tokenizer else None
-
-        stop_reason = "length"
-        if out_tokens and eos_id is not None and out_tokens[-1] == eos_id:
-            stop_reason = "stop"
-        elif text and stop_strings:
-            for ss in stop_strings:
-                if ss in text:
-                    stop_reason = "stop"
-                    break
-
-        # Truncate at stop string
-        if text and stop_strings:
-            earliest_pos = len(text)
-            matched_stop = None
-            for ss in stop_strings:
-                pos = text.find(ss)
-                if pos != -1 and pos < earliest_pos:
-                    earliest_pos = pos
-                    matched_stop = ss
-            if matched_stop is not None:
-                truncated_text = text[:earliest_pos + len(matched_stop)]
-                if len(truncated_text) < len(text):
-                    orig_count = len(out_tokens)
-                    trunc_count = orig_count
-                    for t in range(1, orig_count + 1):
-                        decoded = tokenizer.decode(out_tokens[:t], skip_special_tokens=False)
-                        if len(decoded) >= len(truncated_text):
-                            trunc_count = t
-                            break
-                    out_tokens = out_tokens[:trunc_count]
-                    out_logprobs = out_logprobs[:trunc_count]
-                    text = tokenizer.decode(out_tokens)
-                    stop_reason = "stop"
-
-        prompt_logprobs_result = None
-        req_idx, _ = request_indices[i]
-        if batch[req_idx].prompt_logprobs and logprobs_tensor.shape[1] >= prompt_len:
-            raw = logprobs_tensor[i, :prompt_len].tolist()
-            # Only position 0 has no logprob; interior values are real (BUG-013)
-            prompt_logprobs_result = [None] + raw[1:] if raw else []
-
-        sample_results.append({
-            "tokens": out_tokens,
-            "logprobs": out_logprobs,
-            "text": text,
-            "stop_reason": stop_reason,
-            "prompt_logprobs_result": prompt_logprobs_result,
-        })
-
-    # Reassemble per-request responses
-    per_request_results = []
-    for req_idx, req in enumerate(batch):
-        sequences = []
-        prompt_lp = None
-        for exp_idx, (ri, si) in enumerate(request_indices):
-            if ri == req_idx:
-                sr = sample_results[exp_idx]
-                sequences.append({
-                    "tokens": sr["tokens"],
-                    "logprobs": sr["logprobs"],
-                    "text": sr["text"],
-                    "stop_reason": sr["stop_reason"],
-                })
-                if prompt_lp is None:
-                    prompt_lp = sr["prompt_logprobs_result"]
-        per_request_results.append({
-            "sequences": sequences,
-            "prompt_logprobs": prompt_lp,
-        })
-
-    logger.info(
-        "[%s] Batched generate complete: %d requests, avg %.0f tokens/sample",
-        request_id, len(batch),
-        sum(len(s["tokens"]) for s in sample_results) / max(len(sample_results), 1),
-    )
-
-    return per_request_results
-
-
 class SamplingService:
-    """Service for managing model sampling via SGLang."""
+    """Service for model sampling via the backend's inference engine."""
 
-    def __init__(self):
-        """Initialize SamplingService."""
-        # PERF-002: Batch accumulator replaces the old per-request lock.
-        # Collects concurrent sampling requests and flushes them as a single
-        # batched generate() call to vLLM. ~20-30x speedup for RL sampling.
-        self._nemo_rl_batch_accumulator = NemoRLBatchAccumulator()
-        # Keep the lock for _ensure_generation_ready (state machine safety)
-        self._nemo_rl_generate_lock = asyncio.Lock()
+    def __init__(self, backend: TrainingBackend):
+        self.backend = backend
+
+    def _resolve_handle(
+        self, training_clients: Dict[str, Dict[str, Any]]
+    ) -> BackendHandle:
+        """Find the model serving rollouts and return its backend handle."""
+        model_id = find_model_with_rollout_manager(training_clients)
+        if not model_id:
+            raise RuntimeError("No model with RolloutManager found")
+        handle = training_clients[model_id].get("backend_handle")
+        if handle is None:
+            raise RuntimeError(f"No backend handle for model {model_id}")
+        return handle
 
     async def async_sample(
         self,
@@ -339,77 +44,25 @@ class SamplingService:
         training_clients: Dict[str, Dict[str, Any]]
     ) -> Dict[str, Any]:
         """
-        Async sampling via SGLang.
-
-        Args:
-            request_id: Request identifier for logging
-            prompt_tokens: Input prompt tokens
-            num_samples: Number of samples to generate
-            sampling_params: Optional sampling parameters dict
-            prompt_logprobs: Whether to return prompt logprobs
-            training_clients: Global training clients dict
+        Async sampling for a single prompt.
 
         Returns:
             Dict with sequences and optional prompt_logprobs
 
         Raises:
-            RuntimeError: If no model with RolloutManager found or router not available
+            RuntimeError: If no model with RolloutManager found
+            BackendError: If the inference engine is unavailable
         """
-        # Find model with RolloutManager
-        model_id = find_model_with_rollout_manager(training_clients)
-        if not model_id:
-            raise RuntimeError("No model with RolloutManager found")
-
-        client_info = training_clients[model_id]
-
-        logger.info(f"[{request_id}] Async sampling for {model_id}")
-
-        # Check if this is a NeMo RL backend (vLLM via Ray) or Miles (SGLang via HTTP)
-        handle = client_info.get("backend_handle")
-        if handle is not None and getattr(handle, "backend_type", None) == "nemo_rl":
-            return await self._nemo_rl_sample(
-                request_id=request_id,
-                handle=handle,
-                prompt_tokens=prompt_tokens,
-                num_samples=num_samples,
-                sampling_params=sampling_params,
-                prompt_logprobs=prompt_logprobs,
-            )
-
-        # Miles path: SGLang HTTP
-        router_ip = client_info.get("router_ip")
-        router_port = client_info.get("router_port")
-        if not router_ip or not router_port:
-            raise RuntimeError(f"Router address not available for model {model_id}")
-
-        sglang_url = f"http://{router_ip}:{router_port}"
-
-        # Use SGLang client
-        sglang_client = SGLangClient(base_url=sglang_url)
-        sequences = []
-        prompt_logprobs_result = None
-
-        for i in range(num_samples):
-            result = await sglang_client.generate(
-                input_ids=prompt_tokens,
-                sampling_params=sampling_params or {},
-                prompt_logprobs=prompt_logprobs
-            )
-
-            sequences.append({
-                "tokens": result["tokens"],
-                "logprobs": result["logprobs"],
-                "text": result.get("text"),
-                "stop_reason": result.get("stop_reason", "length")
-            })
-
-            if prompt_logprobs and prompt_logprobs_result is None:
-                prompt_logprobs_result = result.get("prompt_logprobs")
-
-        return {
-            "sequences": sequences,
-            "prompt_logprobs": prompt_logprobs_result
-        }
+        handle = self._resolve_handle(training_clients)
+        logger.info(f"[{request_id}] Async sampling for {handle.model_id}")
+        return await self.backend.sample(
+            handle=handle,
+            request_id=request_id,
+            prompt_tokens=prompt_tokens,
+            num_samples=num_samples,
+            sampling_params=sampling_params,
+            prompt_logprobs=prompt_logprobs,
+        )
 
     async def sync_sample(
         self,
@@ -420,75 +73,31 @@ class SamplingService:
         training_clients: Dict[str, Dict[str, Any]]
     ) -> Dict[str, Any]:
         """
-        Synchronous sampling via SGLang.
-
-        Args:
-            request_id: Request identifier for logging
-            prompts: List of prompt token sequences
-            num_samples: Number of samples per prompt
-            sampling_params: Optional sampling parameters dict
-            training_clients: Global training clients dict
+        Synchronous sampling over multiple prompts.
 
         Returns:
-            Dict with sequences list
+            Dict with sequences list (num_samples per prompt, flattened)
 
         Raises:
-            RuntimeError: If no model with RolloutManager found or router not available
+            RuntimeError: If no model with RolloutManager found
+            BackendError: If the inference engine is unavailable
         """
-        # Find model with rollout manager
-        model_id = find_model_with_rollout_manager(training_clients)
-        if not model_id:
-            raise RuntimeError("No model with RolloutManager found")
-
-        client_info = training_clients[model_id]
-
+        handle = self._resolve_handle(training_clients)
         logger.info(f"[{request_id}] Sampling {num_samples} sequences")
 
-        # Check if this is a NeMo RL backend
-        handle = client_info.get("backend_handle")
-        if handle is not None and getattr(handle, "backend_type", None) == "nemo_rl":
-            all_sequences = []
-            for prompt_tokens in prompts:
-                result = await self._nemo_rl_sample(
-                    request_id=request_id,
-                    handle=handle,
-                    prompt_tokens=prompt_tokens,
-                    num_samples=num_samples,
-                    sampling_params=sampling_params,
-                    prompt_logprobs=False,
-                )
-                all_sequences.extend(result["sequences"])
-            logger.info(f"[{request_id}] NeMo RL sampling completed")
-            return {"sequences": all_sequences}
-
-        # Miles path: SGLang HTTP
-        router_ip = client_info.get("router_ip")
-        router_port = client_info.get("router_port")
-        if not router_ip or not router_port:
-            raise RuntimeError("SGLang router not available")
-
-        sglang_url = f"http://{router_ip}:{router_port}"
-        sglang_client = SGLangClient(base_url=sglang_url)
-
-        # Sample from all prompts
         all_sequences = []
         for prompt_tokens in prompts:
-            for _ in range(num_samples):
-                result = await sglang_client.generate(
-                    input_ids=prompt_tokens,
-                    sampling_params=sampling_params or {},
-                    prompt_logprobs=False
-                )
-
-                all_sequences.append({
-                    "tokens": result["tokens"],
-                    "logprobs": result["logprobs"],
-                    "text": result.get("text"),
-                    "stop_reason": result.get("stop_reason", "length")
-                })
+            result = await self.backend.sample(
+                handle=handle,
+                request_id=request_id,
+                prompt_tokens=prompt_tokens,
+                num_samples=num_samples,
+                sampling_params=sampling_params,
+                prompt_logprobs=False,
+            )
+            all_sequences.extend(result["sequences"])
 
         logger.info(f"[{request_id}] Sampling completed")
-
         return {"sequences": all_sequences}
 
     async def create_sampling_client(
@@ -499,90 +108,29 @@ class SamplingService:
         training_clients: Dict[str, Dict[str, Any]]
     ) -> Dict[str, Any]:
         """
-        Create sampling client (SGLang).
-
-        Args:
-            request_id: Request identifier for logging
-            model_path: Optional model path
-            base_model: Optional base model
-            training_clients: Global training clients dict
+        Create a sampling client bound to the serving model.
 
         Returns:
             Dict with sampling_client_id, model_path, status
 
         Raises:
             ValueError: If neither model_path nor base_model provided
-            RuntimeError: If no model with RolloutManager found or router not available
+            RuntimeError: If no model with RolloutManager found
+            BackendError: If the inference engine cannot be made ready
         """
-        # Determine model path
         resolved_model_path = model_path or base_model
         if not resolved_model_path:
             raise ValueError("Either model_path or base_model must be provided")
 
-        # Find model with rollout manager
-        model_id = find_model_with_rollout_manager(training_clients)
-        if not model_id:
-            raise RuntimeError("No model with RolloutManager found")
-
-        client_info = training_clients[model_id]
-
+        handle = self._resolve_handle(training_clients)
         logger.info(f"[{request_id}] Creating sampling client for {resolved_model_path}")
 
-        # NeMo RL backend: no external router needed, sampling goes through Policy.generate()
-        handle = client_info.get("backend_handle")
-        if handle is not None and getattr(handle, "backend_type", None) == "nemo_rl":
-            sampling_client_id = f"sampler_{uuid.uuid4().hex[:8]}"
-            logger.info(f"[{request_id}] NeMo RL sampling client created: {sampling_client_id}")
-            return {
-                "sampling_client_id": sampling_client_id,
-                "model_path": resolved_model_path,
-                "status": "ready",
-            }
+        await self.backend.prepare_for_generation(handle)
 
-        # Miles path: Get SGLang router info
-        router_ip = client_info.get("router_ip")
-        router_port = client_info.get("router_port")
-
-        if not router_ip or not router_port:
-            raise RuntimeError("SGLang router not available")
-
-        # Generate client ID
         sampling_client_id = f"sampler_{uuid.uuid4().hex[:8]}"
-
         logger.info(f"[{request_id}] Sampling client created: {sampling_client_id}")
-
         return {
             "sampling_client_id": sampling_client_id,
             "model_path": resolved_model_path,
-            "status": "ready"
+            "status": "ready",
         }
-
-    async def _nemo_rl_sample(
-        self,
-        request_id: str,
-        handle: Any,
-        prompt_tokens: List[int],
-        num_samples: int,
-        sampling_params: Optional[Dict[str, Any]],
-        prompt_logprobs: bool,
-    ) -> Dict[str, Any]:
-        """
-        Sample via NeMo RL Policy.generate() using vLLM Ray workers.
-
-        PERF-002: Requests are accumulated by the batch accumulator and flushed
-        as a single generate() call. This gives ~20-30x speedup for RL sampling
-        (2048 individual requests → 1 batched call).
-        """
-        if handle.policy_generation is None:
-            raise RuntimeError(
-                "NeMo RL generation engine not initialized (debug_train_only mode?)"
-            )
-
-        return await self._nemo_rl_batch_accumulator.submit(
-            handle=handle,
-            request_id=request_id,
-            prompt_tokens=prompt_tokens,
-            num_samples=num_samples,
-            sampling_params=sampling_params or {},
-            prompt_logprobs=prompt_logprobs,
-        )


### PR DESCRIPTION
## What

- **Sampling lifted into the backend abstraction** (`12a4588`): `TrainingBackend` gains `sample()` / `prepare_for_generation()`; NeMo RL request batching moves to `backends/nemo_rl/generation.py` (accumulators keyed per model, dropped on `delete_model`); Miles SGLang HTTP sampling moves to `MilesBackend.sample()`. `SamplingService` shrinks 588→137 lines and only delegates; router signatures unchanged.
- **One-key deploy** (`79849ff`): `scripts/deploy_tinkercloud.sh` — `--source git` (shallow-clones tinker-cloud/RL/tinker_gmi/tinker-cookbook at pinned refs) or `--source dev` (bundles local monorepo working trees); `--target k8s` or `--target docker`, both running the same `scripts/lib/setup_container.sh`; `--code-only` redeploys onto a live target.
- **README** (`decbd4f`): quickstart rewritten around the deploy script (git source).

## Behavior notes

- Sampling errors now surface as `BackendError` (was `RuntimeError`).
- `create_sampling_client` now calls `prepare_for_generation` (fast no-op when generation-ready; validates the SGLang router on Miles).

## Validation

- Contract tests: 22 passed / 13 env-skipped, incl. 5 new `TestSamplingContract` tests; ruff at the pre-existing baseline.
- Cluster (4×H200, NeMo RL backend): math_rl 100 batches, correct 0.742 → 1.000, zero server errors (sampling path); DPO 50+ steps error-free with live prompt-logprobs, metrics consistent with the pre-refactor 002 baseline (scoring path).
- Deploy script: dev×k8s and git×k8s validated end-to-end on the cluster; docker combos share the same in-container setup but the docker transport is not yet smoke-tested.