### PR TITLE
backends: trim comment bloat across all backends

### DIFF
--- a/training/backends/automodel/backend.py
+++ b/training/backends/automodel/backend.py
@@ -25,9 +25,6 @@ from ..objectives import Objective, is_classification
 
 logger = logging.getLogger(__name__)
 
-_PLAN = "specs/004-bionemo-classification/plan.md"
-
-# P0-proven LoRA targets for ESM/BERT-style encoders (plan.md P0 findings).
 _DEFAULT_LORA_TARGETS = ["query", "key", "value", "dense"]
 _DEFAULT_LR = 1e-4
 
@@ -171,7 +168,7 @@ class AutomodelBackend(TrainingBackend):
         model = _apply_lora(model, objective, lora_config, hc)
         if hc.get("freeze_base"):
             # Linear-probe / head-only baseline: train only the classification
-            # head, freeze the encoder. (plan.md CS2 head-only ablation.)
+            # head, freeze the encoder.
             for name, p in model.named_parameters():
                 p.requires_grad = "classifier" in name or "score" in name
         model.to(device)
@@ -281,7 +278,7 @@ class AutomodelBackend(TrainingBackend):
             "metrics": {"grad_norm": grad_norm},
         }
 
-    # --- generation plane: N/A for classification (plan.md Non-Goals) ---
+    # --- generation plane: N/A for classification ---
 
     async def update_inference_weights(self, handle: BackendHandle) -> None:
         raise _no_generation("update_inference_weights")

--- a/training/backends/megatron_bridge/worker.py
+++ b/training/backends/megatron_bridge/worker.py
@@ -1,14 +1,9 @@
 """Ray GPU worker for the megatron_bridge backend.
 
-Holds the Evo2 classifier + megatron distributed context INSIDE a Ray actor, so
-the tinker-cloud server stays a plain process (like automodel in-process / nemo_rl
-+ miles Ray-actor delegation) — NOT run under torchrun. Each model gets its own
-actor, so megatron's global state (parallel_state, microbatch calculator) is
-isolated per model: multi-model works and restarts are clean.
-
-Imports megatron.bridge + the bionemo-recipes evo2_classifier, which exist only in
-the cu13 recipe venv (deploy_tinkercloud.sh --profile megatron_bridge). Ray actors
-inherit the driver (server) venv, so those are available in the actor.
+Holds the Evo2 classifier + megatron distributed context in a per-model Ray actor
+(isolated parallel_state), so the server stays a plain process. Needs the cu13
+recipe venv (deploy_tinkercloud.sh --profile megatron_bridge), inherited by the
+actor from the driver. See specs/004-bionemo-classification/P5-TINKER-BACKEND.md.
 """
 import os
 

--- a/training/backends/miles/backend.py
+++ b/training/backends/miles/backend.py
@@ -1,10 +1,5 @@
-"""
-Miles backend implementation.
-
-Wraps existing RayTrainGroup/RolloutManager/SlimeArgumentBuilder code
-behind the TrainingBackend interface. This is a refactoring — no
-behavior change from the existing Miles-based TinkerCloud.
-"""
+"""Miles backend — wraps RayTrainGroup/RolloutManager/SlimeArgumentBuilder
+behind the TrainingBackend interface (refactor only, no behavior change)."""
 import asyncio
 import logging
 from dataclasses import dataclass, field
@@ -36,12 +31,7 @@ class MilesHandle(BackendHandle):
 
 
 class MilesBackend(TrainingBackend):
-    """
-    Miles backend — wraps existing RayTrainGroup + RolloutManager.
-
-    This is a thin adapter over the existing Miles integration code
-    from model_service.py and training_service.py.
-    """
+    """Thin adapter over existing Miles integration code (model_service.py / training_service.py)."""
 
     def __init__(self, overrides: Optional[Dict[str, Any]] = None):
         self.overrides = overrides or {}
@@ -107,10 +97,8 @@ class MilesBackend(TrainingBackend):
             )
             logger.info("[%s] Miles args built, hf_path=%s", request_id, hf_path)
 
-            # Import Miles actors
             from miles.ray.actor_group import RayTrainGroup
 
-            # Create placement group
             num_nodes = 1
             num_gpus_per_node = num_gpus
             bundles = [{"GPU": 1, "CPU": 1} for _ in range(num_nodes * num_gpus_per_node)]
@@ -123,7 +111,6 @@ class MilesBackend(TrainingBackend):
 
             reordered_indices = list(range(len(bundles)))
 
-            # Create RayTrainGroup
             train_group = RayTrainGroup(
                 args=args,
                 num_nodes=num_nodes,
@@ -133,7 +120,6 @@ class MilesBackend(TrainingBackend):
                 role="actor",
             )
 
-            # Initialize actors
             init_refs = train_group.async_init(args, role="actor", with_ref=False)
             try:
                 await asyncio.wait_for(
@@ -186,7 +172,6 @@ class MilesBackend(TrainingBackend):
                         rollout_manager.onload.remote(tags=[GPU_MEMORY_TYPE_KV_CACHE])
                     ))
 
-                # Get router address
                 try:
                     router_address_ref = rollout_manager.get_router_address.remote()
                     router_ip, router_port = await asyncio.wrap_future(router_address_ref.future())
@@ -229,7 +214,6 @@ class MilesBackend(TrainingBackend):
         try:
             from miles.utils.ray_utils import Box
 
-            # Offload SGLang if needed
             if h.rollout_manager is not None and h.args.offload_rollout:
                 await asyncio.to_thread(lambda: ray.get(h.rollout_manager.offload.remote()))
 
@@ -258,11 +242,9 @@ class MilesBackend(TrainingBackend):
         try:
             from miles.utils.ray_utils import Box
 
-            # Offload SGLang if needed
             if h.rollout_manager is not None and h.args.offload_rollout:
                 await asyncio.to_thread(lambda: ray.get(h.rollout_manager.offload.remote()))
 
-            # Determine training mode (RL vs SFT)
             is_rl = not h.args.debug_train_only
 
             # Check if data needs fake generation (legacy test compat)
@@ -280,7 +262,6 @@ class MilesBackend(TrainingBackend):
                 )
                 rollout_data = self._generate_fake_rollout_data(h.args)
             else:
-                # Validate data against Megatron args
                 from ...core.validators import RequestValidator
                 from ...config import get_config
 
@@ -296,7 +277,6 @@ class MilesBackend(TrainingBackend):
                         f"{validator.get_config_summary()}"
                     )
 
-                # Convert data
                 rollout_data = self.converter.forward_backward_to_backend(
                     data, loss_fn, h.args,
                 )
@@ -381,7 +361,6 @@ class MilesBackend(TrainingBackend):
     ) -> Dict[str, Any]:
         h: MilesHandle = handle  # type: ignore[assignment]
         try:
-            # Set learning rate if provided
             if learning_rate is not None:
                 await asyncio.to_thread(h.train_group.set_learning_rate, learning_rate)
 
@@ -477,7 +456,6 @@ class MilesBackend(TrainingBackend):
     ) -> None:
         h: MilesHandle = handle  # type: ignore[assignment]
         try:
-            # Load weights on all actors via Megatron's load_checkpoint
             object_refs = [
                 actor.load_checkpoint.remote(checkpoint_path)
                 for actor in h.train_group._actor_handlers

--- a/training/backends/nemo_rl/backend.py
+++ b/training/backends/nemo_rl/backend.py
@@ -115,7 +115,6 @@ class NemoRLBackend(TrainingBackend):
         try:
             logger.info("[%s] Creating NeMo RL model %s", request_id, model_id)
 
-            # Build NeMo RL config
             config_dict, hf_path = await asyncio.to_thread(
                 self.builder.build_args,
                 base_model=base_model,
@@ -133,7 +132,6 @@ class NemoRLBackend(TrainingBackend):
             )
             logger.info("[%s] NeMo RL config built, hf_path=%s", request_id, hf_path)
 
-            # Initialize NeMo RL components (blocking — run in thread pool)
             policy, policy_generation, cluster, tokenizer, loss_fn = await asyncio.to_thread(
                 _init_nemo_rl_components,
                 config_dict=config_dict,
@@ -199,7 +197,6 @@ class NemoRLBackend(TrainingBackend):
         """
         h: NemoRLHandle = handle  # type: ignore[assignment]
         try:
-            # Convert data to NeMo RL format
             batched_data = self.converter.forward_to_backend(data, h.config)
 
             # Pad for dp_size alignment (get_logprobs uses shard_by_batch_size)
@@ -213,26 +210,16 @@ class NemoRLBackend(TrainingBackend):
             if h.policy_generation is not None and h.colocated_inference:
                 await asyncio.to_thread(h.policy_generation.finish_generation)
 
-            # Move model CPU→CUDA for logprob computation.
-            # NOTE: NeMo RL's native algorithms use prepare_for_lp_inference()
-            # (eval mode + optimizer offload) before get_logprobs(). We use
-            # prepare_for_training() instead because in pipelined SFT, forward()
-            # may be called concurrently with apply_optimizer_step — calling
-            # prepare_for_lp_inference() would offload the optimizer while
-            # policy.train() is using it, causing a deadlock. The difference
-            # is minimal: model.train() vs model.eval() produces identical
-            # logprobs for LLMs without dropout.
+            # Use prepare_for_training(), not prepare_for_lp_inference(): the latter
+            # offloads the optimizer, deadlocking a concurrent apply_optimizer_step
+            # in pipelined SFT. train vs eval mode gives identical logprobs (no dropout).
             await asyncio.to_thread(h.policy.prepare_for_training)
 
-            # Compute logprobs via policy.get_logprobs()
             result = await asyncio.to_thread(h.policy.get_logprobs, batched_data)
 
-            # Skip refit after forward(): this is a read-only eval pass (no weight
-            # updates), so inference weights are already in sync. Refitting here
-            # crashes because DTensor sharding metadata becomes stale after the
-            # CPU→CUDA transition in prepare_for_training (NCCL error in
-            # tensor.full_tensor() → redistribute). Refit only happens after
-            # apply_optimizer_step() which actually modifies weights.
+            # No refit after forward(): read-only pass, inference weights already in
+            # sync. Refitting here crashes (stale DTensor sharding after CPU→CUDA →
+            # NCCL error in full_tensor()); refit only follows apply_optimizer_step().
 
             return self.converter.backend_to_forward_result(
                 result, data, loss_fn=loss_fn,
@@ -314,7 +301,6 @@ class NemoRLBackend(TrainingBackend):
                             operation="forward_backward",
                         )
 
-                # Buffer the data — training deferred to apply_optimizer_step()
                 h.data_buffer.append(batched_data)
                 buffer_len = len(h.data_buffer)
                 # Store loss_fn name for apply_optimizer_step() response
@@ -325,20 +311,15 @@ class NemoRLBackend(TrainingBackend):
                 buffer_len, h.model_id, len(data),
             )
 
-            # Return deferred result — no training metrics available yet.
-            # CHK010: Deferred contract: empty metrics, deferred=True.
-            # Real metrics available at optim_step.
-            # Populate loss_fn_outputs with zero-logprobs per datum so the
-            # SFT train loop's finish_batch can zip(logprobs, weights) without
-            # crashing. The actual NLL is computed by the NLL evaluator via
-            # the forward() path; these zeros are placeholders only.
+            # CHK010: deferred contract — empty metrics, real metrics at optim_step.
+            # Zero-logprob placeholders let SFT finish_batch zip(logprobs, weights);
+            # actual NLL comes from the forward() path.
             placeholder_outputs = []
             for datum in data:
                 # Handle both Pydantic ForwardBackwardDatum and plain dict
                 lfi = getattr(datum, "loss_fn_inputs", None) or (
                     datum.get("loss_fn_inputs") if isinstance(datum, dict) else None
                 ) or {}
-                # Navigate weights → data to find length
                 weights = getattr(lfi, "weights", None) or (
                     lfi.get("weights") if isinstance(lfi, dict) else None
                 )
@@ -450,7 +431,6 @@ class NemoRLBackend(TrainingBackend):
                 num_buffered, h.model_id,
             )
 
-            # Set learning rate if provided
             if learning_rate is not None:
                 _set_learning_rate(h.policy, learning_rate)
 
@@ -498,17 +478,14 @@ class NemoRLBackend(TrainingBackend):
                             all_data["prev_logprobs"] = logprob_result["logprobs"]
                             logger.info("prev_logprobs replaced with DTensor-computed values")
 
-                    # Select loss function based on loss_fn_name from forward_backward()
                     if h.loss_fn_name == "cross_entropy":
                         from nemo_rl.algorithms.loss_functions import NLLLoss
                         active_loss_fn = NLLLoss()
                     else:
                         active_loss_fn = h.loss_fn  # ClippedPGLossFn (RL)
 
-                    # Execute training — policy.train() does forward + backward + optimizer.step()
-                    # Pass gbs=actual batch size so NeMo RL shards correctly.
-                    # Without this, it defaults to train_global_batch_size from config
-                    # which may not match the recipe's batch size.
+                    # Pass gbs=actual size so NeMo RL shards correctly instead of
+                    # defaulting to config train_global_batch_size.
                     train_result = await asyncio.to_thread(
                         h.policy.train,
                         data=all_data,
@@ -524,7 +501,6 @@ class NemoRLBackend(TrainingBackend):
                         {k: v for k, v in train_result.get("all_mb_metrics", {}).items()},
                     )
 
-                    # Sync weights to inference engine
                     if h.policy_generation is not None and not h.debug_train_only:
                         logger.info("Refitting policy generation for %s", h.model_id)
                         await asyncio.to_thread(
@@ -550,7 +526,6 @@ class NemoRLBackend(TrainingBackend):
                             )
                             h.generation_state = "generation_ready"
 
-            # Normalize metrics to common schema
             result = self.converter.backend_to_forward_backward_result(
                 train_result, [], loss_fn=h.loss_fn_name,
             )
@@ -562,7 +537,6 @@ class NemoRLBackend(TrainingBackend):
                 train_result.get("curr_logprobs"), all_data, original_size,
             )
 
-            # Override with optimizer step format
             return {
                 "success": True,
                 "grad_norm": result.get("grad_norm", 0.0),
@@ -607,9 +581,6 @@ class NemoRLBackend(TrainingBackend):
         """Save model checkpoint via policy.save_checkpoint()."""
         h: NemoRLHandle = handle  # type: ignore[assignment]
         try:
-            # Translate tinker:// URI to local filesystem path.
-            # The checkpoint_service generates tinker://<run_id>/weights/<name>
-            # but NeMo RL expects a real filesystem path.
             local_path = _resolve_checkpoint_path(checkpoint_path)
 
             weights_path = f"{local_path}/weights"
@@ -656,7 +627,6 @@ class NemoRLBackend(TrainingBackend):
                 optimizer_path=optimizer_path,
             )
 
-            # Sync loaded weights to inference engine
             if h.policy_generation is not None and not h.debug_train_only:
                 logger.info("Refitting policy generation after checkpoint load for %s", h.model_id)
                 await asyncio.to_thread(
@@ -768,11 +738,6 @@ class NemoRLBackend(TrainingBackend):
         await _ensure_generation_ready(h)
 
 
-# ---------------------------------------------------------------------------
-# Async helpers (called directly from async code)
-# ---------------------------------------------------------------------------
-
-
 async def _ensure_generation_ready(handle) -> None:
     """Ensure the handle is ready for generation.
 
@@ -836,7 +801,6 @@ def _resolve_checkpoint_path(path: str) -> str:
     Plain filesystem paths are returned as-is.
     """
     if path.startswith("tinker://"):
-        # tinker://model_xxx/weights/checkpoint_name → /data/checkpoints/model_xxx/checkpoint_name
         parts = path[len("tinker://"):].split("/")
         # parts: [model_id, "weights", checkpoint_name]
         run_id = parts[0]
@@ -870,11 +834,9 @@ def _init_nemo_rl_components(
     loss_fn_config = config_dict["loss_fn"]
     cluster_config = config_dict["cluster"]
 
-    # Ensure Ray is initialized
     if not ray.is_initialized():
         ray.init(ignore_reinit_error=True)
 
-    # Create virtual cluster
     cluster = RayVirtualCluster(
         bundle_ct_per_node_list=cluster_config["bundle_ct_per_node_list"],
         num_gpus_per_node=cluster_config.get("num_gpus_per_node", 8),
@@ -886,10 +848,8 @@ def _init_nemo_rl_components(
     tokenizer_config = {"name": model_name}
     tokenizer = get_tokenizer(tokenizer_config)
 
-    # Create loss function
     loss_fn = ClippedPGLossFn(loss_fn_config)
 
-    # Initialize generation engine (vLLM) if not debug_train_only
     policy_generation = None
     if not debug_train_only:
         generation_config = policy_config.get("generation")
@@ -897,18 +857,12 @@ def _init_nemo_rl_components(
             from nemo_rl.models.generation import configure_generation_config
             from nemo_rl.models.generation.vllm import VllmGeneration
 
-            # Set model_name on generation config
             generation_config["model_name"] = model_name
 
-            # Set stop_strings BEFORE configure_generation_config() so it sees
-            # them and sets skip_tokenizer_init=False (vLLM needs the tokenizer
-            # to match text-based stop strings).
-            # Use stop_strings (not stop_token_ids) because NeMo RL vLLM sets
-            # include_stop_str_in_output=True for strings, so the stop token
-            # appears in the output. Renderers (e.g. Qwen3, Llama3) expect the
-            # stop token in the response for parse_response() to succeed.
-            # stop_token_ids would also stop generation but vLLM strips those
-            # from output, causing parse_success=False and format=0.
+            # Set stop_strings BEFORE configure_generation_config() so it sets
+            # skip_tokenizer_init=False (vLLM needs the tokenizer for text matching).
+            # Use stop_strings, not stop_token_ids: vLLM keeps stop strings in the
+            # output (renderers need them for parse_response) but strips stop ids.
             stop_strs = set()
             for token_str in ["<|im_end|>", "<|eot_id|>", "<|end▁of▁sentence|>"]:
                 try:
@@ -921,9 +875,8 @@ def _init_nemo_rl_components(
                 generation_config["stop_strings"] = list(stop_strs)
                 logger.info("Set stop_strings from tokenizer: %s", list(stop_strs))
 
-            # configure_generation_config sets skip_tokenizer_init based on
-            # whether stop_strings is set: False if set (needed for text matching),
-            # True if not. Do NOT override skip_tokenizer_init manually.
+            # configure_generation_config derives skip_tokenizer_init from
+            # stop_strings — do NOT override it manually.
             generation_config = configure_generation_config(generation_config, tokenizer)
 
             logger.info("Initializing VllmGeneration (colocated mode)...")

--- a/training/backends/nemo_rl/builder.py
+++ b/training/backends/nemo_rl/builder.py
@@ -116,7 +116,6 @@ class NemoRLArgumentBuilder(ArgumentBuilder):
         except Exception as e:
             logger.debug("model config read skipped (VLM/seq-len detection): %s", e)
 
-        # Warn about Miles-only RLVE server-side features
         if rlve_config and rlve_config.get("enabled", False):
             miles_only_keys = [
                 "custom_prompt_preprocessor", "answer_marker_type",
@@ -132,7 +131,6 @@ class NemoRLArgumentBuilder(ArgumentBuilder):
                     unsupported,
                 )
 
-        # Parallelism config
         tp_size = 1
         pp_size = 1
         cp_size = 1
@@ -151,11 +149,8 @@ class NemoRLArgumentBuilder(ArgumentBuilder):
             model_parallel = tp_size * pp_size * cp_size
             dp_size = max(1, num_gpus // model_parallel)
 
-        # Micro-batch size calculation
-        # NeMo RL train_global_batch_size = total samples per train() call
-        # train_micro_batch_size = samples per GPU per forward/backward pass
-        # MBS=1 minimizes activation memory (NeMo RL convention: 78/91 configs use 1)
-        # Gradient accumulation steps = GBS / (MBS * DP) bridges the gap
+        # GBS = samples per train() call; MBS=1 minimizes activation memory
+        # (NeMo RL convention); grad-accum steps = GBS / (MBS * DP) bridge the gap.
         train_global_batch_size = max_batch_size
         train_micro_batch_size = 1
 
@@ -236,7 +231,6 @@ class NemoRLArgumentBuilder(ArgumentBuilder):
             },
         }
 
-        # LoRA config
         if lora_config and lora_config.get("rank", 0) > 0:
             policy_config["dtensor_cfg"]["lora_cfg"] = {
                 "enabled": True,
@@ -269,7 +263,6 @@ class NemoRLArgumentBuilder(ArgumentBuilder):
             "force_on_policy_ratio": False,
         }
 
-        # Override loss config from rl_config or rlve_config
         if rl_config:
             if "kl_penalty_coef" in rl_config:
                 loss_fn_config["reference_policy_kl_penalty"] = rl_config["kl_penalty_coef"]
@@ -277,7 +270,6 @@ class NemoRLArgumentBuilder(ArgumentBuilder):
                 loss_fn_config["ratio_clip_min"] = rl_config["eps_clip"]
                 loss_fn_config["ratio_clip_max"] = rl_config["eps_clip"]
 
-        # Cluster config
         cluster_config = {
             "bundle_ct_per_node_list": [num_gpus],
             "num_gpus_per_node": num_gpus,
@@ -292,7 +284,6 @@ class NemoRLArgumentBuilder(ArgumentBuilder):
         if checkpoint_config:
             checkpointing_config.update(checkpoint_config)
 
-        # Apply overrides
         config_dict = {
             "policy": policy_config,
             "loss_fn": loss_fn_config,
@@ -304,7 +295,6 @@ class NemoRLArgumentBuilder(ArgumentBuilder):
             "rlve_config": rlve_config,
         }
 
-        # Deep merge user overrides
         if self.overrides:
             _deep_merge(config_dict, self.overrides)
 

--- a/training/backends/nemo_rl/converter.py
+++ b/training/backends/nemo_rl/converter.py
@@ -96,7 +96,6 @@ class NemoRLDataConverter(DataConverter):
         if not data:
             return self._empty_batched_data_dict()
 
-        # SFT path — reconstruct full sequence for NLLLoss
         if loss_fn == "cross_entropy":
             return self._forward_backward_sft(data, image_preprocessor)
 
@@ -105,7 +104,6 @@ class NemoRLDataConverter(DataConverter):
         max_seq_len = max((len(t) for t in full_tokens_B), default=0)
         batch_size = len(data)
 
-        # Initialize tensors with padding (zeros)
         input_ids = torch.zeros(batch_size, max_seq_len, dtype=torch.long)
         input_lengths = torch.zeros(batch_size, dtype=torch.long)
         token_mask = torch.zeros(batch_size, max_seq_len, dtype=torch.float32)
@@ -178,10 +176,7 @@ class NemoRLDataConverter(DataConverter):
             image_preprocessor.image_token_id if image_preprocessor is not None else None
         )
 
-        # Compute max reconstructed sequence length.
-        # For VLM, expand chunks to include image placeholder tokens
-        # (<|image_pad|>=151655 for Qwen3-VL) at each image position.
-        # For text-only, fall back to the text-chunk concatenation.
+        # VLM: expand image chunks to placeholder tokens; text-only: concat text chunks.
         def _full_input_tokens(datum):
             if image_token_id is not None:
                 expanded = _expand_chunks_to_full_sequence(datum, image_token_id)
@@ -199,13 +194,10 @@ class NemoRLDataConverter(DataConverter):
         sample_mask = torch.ones(batch_size, dtype=torch.float32)
 
         for i, datum in enumerate(data):
-            # Get full input sequence (with image_pad tokens inserted for VLM)
             input_tokens = _full_input_tokens(datum)
 
-            # Extract target_tokens — same length as input_tokens shifted by 1
             target_tokens = _extract_target_tokens(datum)
 
-            # Reconstruct full sequence: concat(input_tokens, [target_tokens[-1]])
             if target_tokens is not None and len(target_tokens) > 0:
                 last_token = target_tokens[-1].unsqueeze(0)
                 full_tokens = torch.cat([input_tokens, last_token])
@@ -220,14 +212,11 @@ class NemoRLDataConverter(DataConverter):
             input_ids[i, :seq_len] = full_tokens
             input_lengths[i] = seq_len
 
-            # Extract weights (length N-1)
             weights = _extract_sft_weights(datum)
 
-            # Reconstruct full mask: concat([0.0], weights) → length N
             if weights is not None:
                 full_mask = torch.cat([torch.zeros(1, dtype=torch.float32), weights])
             else:
-                # Fallback: mask entire response (all ones except first position)
                 full_mask = torch.ones(seq_len, dtype=torch.float32)
                 full_mask[0] = 0.0
                 logger.warning(
@@ -359,7 +348,6 @@ class NemoRLDataConverter(DataConverter):
         loss = _to_python_scalar(result.get("loss", 0.0))
         grad_norm = _to_python_scalar(result.get("grad_norm", 0.0))
 
-        # Extract per-microbatch metrics
         all_mb_metrics = result.get("all_mb_metrics", {})
         metrics = {
             "total_loss": loss,
@@ -462,14 +450,12 @@ def _extract_tokens(datum) -> torch.Tensor:
                 if all_tokens:
                     return torch.cat(all_tokens)
 
-        # Try direct tokens: model_input.tokens
         tokens = _get_attr_or_key(model_input, "tokens")
         if tokens is not None:
             if isinstance(tokens, torch.Tensor):
                 return tokens.detach().cpu().long()
             return torch.tensor(tokens, dtype=torch.long)
 
-        # Try input_ids: model_input.input_ids
         input_ids = _get_attr_or_key(model_input, "input_ids")
         if input_ids is not None:
             if isinstance(input_ids, torch.Tensor):

--- a/training/backends/nemo_rl/generation.py
+++ b/training/backends/nemo_rl/generation.py
@@ -3,7 +3,7 @@ NeMo RL generation batching.
 
 Accumulates per-sample generation requests and flushes them as a single
 batched Policy.generate() call (PERF-002). Lifted from SamplingService
-so all NeMo RL specifics live behind the backend abstraction (001 review P2).
+so all NeMo RL specifics live behind the backend abstraction.
 """
 import asyncio
 import logging
@@ -78,8 +78,6 @@ class NemoRLBatchAccumulator:
         except asyncio.TimeoutError:
             pass
 
-        # Keep flushing until the queue is empty — new requests may arrive
-        # while generate() is running (which takes seconds to minutes).
         while True:
             had_work = await self._flush(handle, request_id)
             if not had_work:
@@ -192,7 +190,6 @@ async def _batched_nemo_rl_generate(
         for i in range(actual_size)
     ] + [top_p] * (padded_size - actual_size)
 
-    # Stop strings
     raw_stop = first_params.get("stop")
     stop_strings: List[str] = []
     if raw_stop is not None:
@@ -203,7 +200,6 @@ async def _batched_nemo_rl_generate(
     if stop_strings:
         data["stop_strings"] = [stop_strings] * padded_size
 
-    # Prompt logprobs
     any_prompt_logprobs = any(req.prompt_logprobs for req in batch)
     if any_prompt_logprobs:
         data["_tinker_prompt_logprobs"] = [True] * padded_size
@@ -213,11 +209,9 @@ async def _batched_nemo_rl_generate(
         request_id, len(batch), actual_size, padded_size,
     )
 
-    # Generate — single call for entire batch
     await _ensure_generation_ready(handle)
     result = await asyncio.to_thread(handle.policy_generation.generate, data, greedy)
 
-    # Split results back to per-request responses
     output_ids = result["output_ids"]
     gen_lengths = result["generation_lengths"]
     logprobs_tensor = result["logprobs"]

--- a/training/backends/objectives.py
+++ b/training/backends/objectives.py
@@ -14,7 +14,7 @@ class Objective(str, Enum):
     TOKEN_CLASSIFICATION = "token_classification"
 
 
-# Loss-registry name for classification cross-entropy (plan.md:113).
+# Loss-registry name for classification cross-entropy.
 CLASSIFICATION_CE = "classification_ce"
 
 CLASSIFICATION_OBJECTIVES = frozenset({


### PR DESCRIPTION
Remove comments that restate the code, dead plan.md pointer tags, and the unused _PLAN const; condense verbose narrative comments to one terse line. Load-bearing rationale (deadlock/NCCL/DTensor notes, CHK/BUG/PERF refs, data-shape notes, gotchas) preserved. Comments/docstrings only — no logic change; all files parse.