### PR TITLE
miles: remove dead fake-rollout-data path + add miles deploy profile

### DIFF
--- a/scripts/deploy_tinkercloud.sh
+++ b/scripts/deploy_tinkercloud.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # One-key deploy of a TinkerCloud dev environment (k8s pod or docker container).
 #
-#   deploy_tinkercloud.sh [--profile nemo_rl|bionemo|megatron_bridge] \
+#   deploy_tinkercloud.sh [--profile nemo_rl|bionemo|megatron_bridge|miles] \
 #                         [--source dev|git] [--target k8s|docker] [--code-only]
 #
 # Profiles (cased by BASE IMAGE — the images ship incompatible stacks)
@@ -16,6 +16,12 @@
 #            evo2_megatron recipe (megatron-bridge v0.4.1) so the megatron_bridge
 #            backend can import megatron.bridge + evo2_classifier. Env only until
 #            that backend lands (stubs today). GPUS=2, master-03.
+#   miles    Miles/Slime backend. Image is the private GMI GAR build of
+#            github.com/GavinZhu-GMI/miles (miles + Megatron/SGLang/TE pre-installed);
+#            overlays only the server code, starts Ray head + `python3 -m training`
+#            (TINKERCLOUD_BACKEND=miles), health-checks :8000. GPUS=4, master-02.
+#            Needs a pull secret for the private image: IMAGE_PULL_SECRET (default
+#            gcp-secret) must exist in namespace $NS.
 #   Per-profile defaults (IMAGE, GPUS, NODE, BACKEND) are overridable by env vars.
 #   See specs/004-bionemo-classification/P5-TINKER-BACKEND.md.
 #
@@ -84,10 +90,24 @@ case "$PROFILE" in
     POD="${POD:-evo2-recipe}"
     CONTAINER="${CONTAINER:-evo2-recipe}"
     RUN_SERVER=0 ;;   # env only until the megatron_bridge backend lands (stubs today)
-  *) echo "unknown --profile $PROFILE (want: nemo_rl | bionemo | megatron_bridge)"; exit 1 ;;
+  miles)
+    # Miles/Slime backend. Miles + its Megatron/SGLang/TE stack are pre-installed
+    # in the GMI base image (built from github.com/GavinZhu-GMI/miles); we overlay
+    # only the tinker-cloud server code. The image is a PRIVATE GAR repo, so the
+    # pod needs an imagePullSecret (IMAGE_PULL_SECRET, default gcp-secret).
+    IMAGE="${IMAGE:-us-west1-docker.pkg.dev/devv-404803/gmi-test-repo/miles_dev-202511120a-dev:latest}"
+    BACKEND="${BACKEND:-miles}"
+    GPUS="${GPUS:-4}"
+    NODE="${NODE:-master-02}"
+    POD="${POD:-tinkercloud-miles}"
+    CONTAINER="${CONTAINER:-tinkercloud-miles}"
+    IMAGE_PULL_SECRET="${IMAGE_PULL_SECRET:-gcp-secret}"
+    RUN_SERVER=1 ;;   # Ray head + `python3 -m training` (TINKERCLOUD_BACKEND=miles)
+  *) echo "unknown --profile $PROFILE (want: nemo_rl | bionemo | megatron_bridge | miles)"; exit 1 ;;
 esac
 
 # --- shared config (IMAGE/GPUS/NODE/POD/CONTAINER/BACKEND set per-profile) --
+IMAGE_PULL_SECRET="${IMAGE_PULL_SECRET:-}"   # non-empty only for private-registry profiles (miles)
 SERVER_LOG="${SERVER_LOG:-/data/server1.log}"
 HF_TOKEN_FILE="${HF_TOKEN_FILE:-}"
 # k8s
@@ -127,6 +147,9 @@ fi
 if [ "$CODE_ONLY" = 0 ]; then
   if [ "$TARGET" = k8s ]; then
     echo "==> [1/6] creating pod $POD on $NODE"
+    # private-registry profiles (miles GAR image) need a pull secret; blank otherwise
+    PULL_SECRET_YAML=""
+    [ -n "$IMAGE_PULL_SECRET" ] && PULL_SECRET_YAML="imagePullSecrets: [{name: $IMAGE_PULL_SECRET}]"
     cat > "$TMP/pod.yaml" <<EOF
 apiVersion: v1
 kind: Pod
@@ -138,6 +161,7 @@ spec:
   nodeName: $NODE          # bypasses scheduler; NoSchedule taints don't block
   restartPolicy: Never
   runtimeClassName: nvidia # MANDATORY: without it vLLM dies (no NVML)
+  $PULL_SECRET_YAML
   tolerations:
   - {key: node.kubernetes.io/unschedulable, operator: Exists, effect: NoSchedule}
   containers:
@@ -280,7 +304,7 @@ echo "==> [6/6] starting API server (log: $SERVER_LOG)"
 EX_TIMEOUT "
 export PYTHONPATH=/app NUM_GPUS=$GPUS RAY_ADDRESS=ray://localhost:10001
 export HF_TOKEN=\$(cat /tmp/hf_token.txt) HF_HOME=/data/.cache/huggingface \
-       TINKER_API_KEY=tml-dev-key TINKERCLOUD_BACKEND=nemo_rl ALLOW_PARTIAL_BATCHES=true
+       TINKER_API_KEY=tml-dev-key TINKERCLOUD_BACKEND=$BACKEND ALLOW_PARTIAL_BATCHES=true
 cd /app && setsid nohup python3 -m training > $SERVER_LOG 2>&1 < /dev/null &
 sleep 2; echo LAUNCHED"
 

--- a/scripts/lib/setup_container.sh
+++ b/scripts/lib/setup_container.sh
@@ -5,6 +5,7 @@
 #
 # PROFILE (env, default nemo_rl) cases the base-image-specific steps:
 #   nemo_rl  overlay RL/nemo_rl, editable-install SDK+cookbook + extra deps.
+#   miles    miles pre-installed in the image; editable-install SDK+cookbook + deps.
 #   bionemo  deploy code + scripts/evo2 only; NO nemo_rl overlay, NO SDK/cookbook
 #            installs (the bionemo image's deps are tightly pinned — don't perturb).
 #   megatron_bridge  build the bionemo-recipes evo2_megatron recipe env
@@ -54,9 +55,14 @@ if [ "$PROFILE" = megatron_bridge ]; then
   exit 0
 fi
 
-# NeMo RL worker overlay onto the image's install (picked up at next create_model)
-PKG=$(python3 -c 'import nemo_rl, os; print(os.path.dirname(nemo_rl.__file__))')
-cp -r /tmp/RL/nemo_rl/. "$PKG/"
+# nemo_rl overlays its worker onto the image's install (picked up at next
+# create_model); miles + its stack are already baked into the miles image.
+if [ "$PROFILE" = nemo_rl ]; then
+  PKG=$(python3 -c 'import nemo_rl, os; print(os.path.dirname(nemo_rl.__file__))')
+  cp -r /tmp/RL/nemo_rl/. "$PKG/"
+elif [ "$PROFILE" = miles ]; then
+  python3 -c 'import miles; print("miles pre-installed OK")'
+fi
 
 # SDK + cookbook editable installs
 mv /tmp/tinker_gmi /work/tinker_gmi
@@ -66,12 +72,13 @@ pip install -e /work/tinker_gmi --no-deps -q
 SETUPTOOLS_SCM_PRETEND_VERSION=${SETUPTOOLS_SCM_PRETEND_VERSION:-0.1.0} \
   pip install -e /work/tinker-cookbook --no-deps -q
 
-# deps missing from the nemo-rl image that --no-deps skips
+# deps missing from the base image that --no-deps skips
 # (distro: SDK; chz/termcolor/blobfile/tiktoken: cookbook;
 #  sympy/pylatexenc/math-verify: math_rl recipe extras)
 pip install -q distro chz termcolor blobfile tiktoken cloudpickle rich anyio \
   'httpx[http2]' sympy pylatexenc math-verify
 
-python3 -c 'import tinker, tinker_cookbook, nemo_rl; print("imports OK")'
+RUNTIME=$([ "$PROFILE" = miles ] && echo miles || echo nemo_rl)
+python3 -c "import tinker, tinker_cookbook, $RUNTIME; print('imports OK')"
 PYTHONPATH=/app python3 -c 'import training; print("training OK")'
 echo SETUP_DONE

--- a/training/backends/miles/backend.py
+++ b/training/backends/miles/backend.py
@@ -247,39 +247,24 @@ class MilesBackend(TrainingBackend):
 
             is_rl = not h.args.debug_train_only
 
-            # Check if data needs fake generation (legacy test compat)
-            needs_fake_data = (
-                not data
-                or len(data) == 0
-                or len(data) < h.args.data_parallel_size
+            from ...core.validators import RequestValidator
+            from ...config import get_config
+
+            config = get_config()
+            allow_partial = getattr(config, "allow_partial_batches", False)
+            validator = RequestValidator(h.args, allow_partial_batches=allow_partial)
+            validation_error = validator.validate_forward_backward_request(
+                data, is_rl=is_rl,
             )
-
-            if needs_fake_data:
-                logger.info(
-                    "Insufficient data (%d samples, need %d) — generating fake test data",
-                    len(data) if data else 0,
-                    h.args.data_parallel_size,
+            if validation_error:
+                raise ValueError(
+                    f"Request validation failed:\n{validation_error}\n\n"
+                    f"{validator.get_config_summary()}"
                 )
-                rollout_data = self._generate_fake_rollout_data(h.args)
-            else:
-                from ...core.validators import RequestValidator
-                from ...config import get_config
 
-                config = get_config()
-                allow_partial = getattr(config, "allow_partial_batches", False)
-                validator = RequestValidator(h.args, allow_partial_batches=allow_partial)
-                validation_error = validator.validate_forward_backward_request(
-                    data, is_rl=is_rl,
-                )
-                if validation_error:
-                    raise ValueError(
-                        f"Request validation failed:\n{validation_error}\n\n"
-                        f"{validator.get_config_summary()}"
-                    )
-
-                rollout_data = self.converter.forward_backward_to_backend(
-                    data, loss_fn, h.args,
-                )
+            rollout_data = self.converter.forward_backward_to_backend(
+                data, loss_fn, h.args,
+            )
 
             results = await asyncio.to_thread(
                 h.train_group.forward_backward_only,
@@ -298,61 +283,6 @@ class MilesBackend(TrainingBackend):
             raise BackendError(
                 str(e), backend="miles", operation="forward_backward", original_error=e,
             ) from e
-
-    @staticmethod
-    def _generate_fake_rollout_data(args) -> Dict[str, Any]:
-        """Generate fake rollout data for legacy test compatibility."""
-        import torch
-
-        seq_length = args.seq_length
-        vocab_size = args.vocab_size
-        batch_size = args.global_batch_size
-        response_length = seq_length - (seq_length // 2)
-        device = torch.device("cpu")
-
-        tokens_list = []
-        loss_masks_list = []
-        response_lengths_list = []
-        advantages_list = []
-        log_probs_list = []
-        ref_log_probs_list = []
-        returns_list = []
-        values_list = []
-
-        for _ in range(batch_size):
-            tokens_list.append(
-                torch.randint(0, vocab_size, (seq_length,), dtype=torch.long, device=device)
-            )
-            loss_masks_list.append(
-                torch.ones(response_length, dtype=torch.float32, device=device)
-            )
-            response_lengths_list.append(response_length)
-            advantages_list.append(
-                torch.randn(response_length, dtype=torch.float32, device=device) * 0.1
-            )
-            log_probs_list.append(
-                torch.randn(response_length, dtype=torch.float32, device=device) * 0.5 - 5.0
-            )
-            ref_log_probs_list.append(
-                torch.randn(response_length, dtype=torch.float32, device=device) * 0.5 - 5.0
-            )
-            returns_list.append(
-                torch.randn(response_length, dtype=torch.float32, device=device) * 0.5
-            )
-            values_list.append(
-                torch.randn(response_length, dtype=torch.float32, device=device) * 0.5
-            )
-
-        return {
-            "tokens": tokens_list,
-            "loss_masks": loss_masks_list,
-            "response_lengths": response_lengths_list,
-            "advantages": advantages_list,
-            "log_probs": log_probs_list,
-            "ref_log_probs": ref_log_probs_list,
-            "values": values_list,
-            "returns": returns_list,
-        }
 
     async def apply_optimizer_step(
         self,


### PR DESCRIPTION
## Summary
- **Remove miles backend bloat**: delete `_generate_fake_rollout_data` (54 lines) and its `needs_fake_data` trigger in `forward_backward`. This was legacy scaffolding for `test_4_multi_step_training.py` (no longer in the repo); it silently fabricated random advantages/logprobs/returns/values when a batch was smaller than `data_parallel_size`, so a mis-sized request would train on garbage instead of failing. `forward_backward` now always validates + converts real data — empty/insufficient data correctly errors. **-70 lines.**
- **Add a `miles` deploy profile** to `deploy_tinkercloud.sh` + `setup_container.sh` (prebuilt private GMI GAR image with miles pre-installed; parameterized `IMAGE_PULL_SECRET`), so the Miles backend can be deployed/tested on the cluster (previously only nemo_rl/bionemo/megatron_bridge profiles existed).
- **Bug fix**: the server launch hardcoded `TINKERCLOUD_BACKEND=nemo_rl` for every profile → now `$BACKEND`. Without this the miles (and megatron_bridge) server would come up on the wrong backend.

## Testing
Deployed on ns.config (master-03, 4×H200) via the new `--profile miles`: image pulled, `import miles` + `import training` OK, Ray head up, server healthy (`Backend initialized: miles`, `ray_initialized:true`, proc env `TINKERCLOUD_BACKEND=miles`). Bloat removal is comments/logic-safe: no test references the removed path; the normal (real-data) `forward_backward` path is unchanged.