### PR TITLE
miles: drive the upstream-based tinker-seam interface

### DIFF
--- a/scripts/deploy_tinkercloud.sh
+++ b/scripts/deploy_tinkercloud.sh
@@ -276,7 +276,7 @@ fi
 
 # --- 4. in-container setup ---------------------------------------------------
 echo "==> [4/6] running in-container setup (profile=$PROFILE)"
-EX "PROFILE=$PROFILE bash /tmp/setup_container.sh"
+EX "PROFILE=$PROFILE MILES_REPO='${MILES_REPO:-}' MILES_REF='${MILES_REF:-}' bash /tmp/setup_container.sh"
 
 if [ "$RUN_SERVER" = 0 ]; then
   # bionemo profile: env only — no Ray, no server (no working evo2 server yet).

--- a/scripts/lib/setup_container.sh
+++ b/scripts/lib/setup_container.sh
@@ -61,7 +61,17 @@ if [ "$PROFILE" = nemo_rl ]; then
   PKG=$(python3 -c 'import nemo_rl, os; print(os.path.dirname(nemo_rl.__file__))')
   cp -r /tmp/RL/nemo_rl/. "$PKG/"
 elif [ "$PROFILE" = miles ]; then
-  python3 -c 'import miles; print("miles pre-installed OK")'
+  # Overlay the GMI miles fork onto the image's editable install: the base image's
+  # baked miles predates the Tinker Ray-orchestration interface (forward_backward_only,
+  # apply_optimizer_step(learning_rate=), apply_optimizer_step_and_sync). Fork main is
+  # the maintained branch (PR merges fix_hackathon_rebased -> main).
+  MILES_REPO="${MILES_REPO:-https://github.com/GavinZhu-GMI/miles.git}"
+  MILES_REF="${MILES_REF:-main}"
+  MPKG=$(python3 -c 'import miles, os; print(os.path.dirname(miles.__file__))')
+  rm -rf /tmp/miles_src
+  git clone -q --depth 1 --branch "$MILES_REF" "$MILES_REPO" /tmp/miles_src
+  cp -r /tmp/miles_src/miles/. "$MPKG/"
+  python3 -c 'import miles; print("miles fork overlaid OK ('"$MILES_REF"')")'
 fi
 
 # SDK + cookbook editable installs

--- a/scripts/lib/setup_container.sh
+++ b/scripts/lib/setup_container.sh
@@ -68,9 +68,19 @@ elif [ "$PROFILE" = miles ]; then
   MILES_REPO="${MILES_REPO:-https://github.com/GavinZhu-GMI/miles.git}"
   MILES_REF="${MILES_REF:-main}"
   MPKG=$(python3 -c 'import miles, os; print(os.path.dirname(miles.__file__))')
-  rm -rf /tmp/miles_src
-  git clone -q --depth 1 --branch "$MILES_REF" "$MILES_REPO" /tmp/miles_src
-  cp -r /tmp/miles_src/miles/. "$MPKG/"
+  MROOT=$(dirname "$MPKG")
+  if git -C "$MROOT" rev-parse --git-dir >/dev/null 2>&1; then
+    # miles is an editable checkout (miles image): update it via git so the
+    # worktree IS the pinned ref — a bare cp leaves stale files and a dirty
+    # git status that masquerades as unsaved work.
+    git -C "$MROOT" fetch -q --depth 1 "$MILES_REPO" "$MILES_REF"
+    git -C "$MROOT" checkout -qf FETCH_HEAD
+    git -C "$MROOT" clean -qfd -- miles/
+  else
+    rm -rf /tmp/miles_src "$MPKG"
+    git clone -q --depth 1 --branch "$MILES_REF" "$MILES_REPO" /tmp/miles_src
+    cp -r /tmp/miles_src/miles "$MPKG"
+  fi
   python3 -c 'import miles; print("miles fork overlaid OK ('"$MILES_REF"')")'
 fi
 

--- a/training/backends/miles/backend.py
+++ b/training/backends/miles/backend.py
@@ -1,8 +1,8 @@
 """Miles backend — wraps TinkerTrainGroup/RolloutManager/SlimeArgumentBuilder
 behind the TrainingBackend interface.
 
-Targets the miles `tinker-seam` branch (upstream-based; specs/005 in
-tinker-nemorl): async TinkerTrainGroup fanout, decoupled
+Targets the miles `tinker-seam` branch (upstream-based): async
+TinkerTrainGroup fanout, decoupled
 forward_backward_only / apply_optimizer_step, pure-sum loss via rollout keys
 set in the converter."""
 import asyncio
@@ -256,7 +256,7 @@ class MilesBackend(TrainingBackend):
 
             # Only pipeline-last-stage actors return metrics; average across
             # the DP ranks that did. Per-sample logprobs are not emitted by the
-            # seam's fb pass (specs/005 HANDOFF, open item).
+            # seam's fb pass itself (they ride a separate forward).
             summed: Dict[str, float] = {}
             reporting = 0
             for r in results or []:

--- a/training/backends/miles/backend.py
+++ b/training/backends/miles/backend.py
@@ -265,13 +265,26 @@ class MilesBackend(TrainingBackend):
                     reporting += 1
                     for k, v in loss_dict.items():
                         summed[k] = summed.get(k, 0.0) + float(v)
-            metrics = {k: v / reporting for k, v in summed.items()} if reporting else {}
+            averaged = {k: v / reporting for k, v in summed.items()} if reporting else {}
+            # SDK metric keys carry their cross-chunk reduction as ":<type>"
+            # (chunked_fwdbwd_helpers._metrics_reduction splits on ":").
+            metrics = {f"{k}:mean": v for k, v in averaged.items()}
+
+            # Per-datum response logprobs in client order (the SDK weights its
+            # metric reduction by len(loss_fn_outputs), and the cookbook
+            # computes NLL from these).
+            from miles.ray.tinker_group import merge_dp_sample_outputs
+            logprobs_list = merge_dp_sample_outputs(results or [], key="log_probs")
+            loss_fn_outputs = [
+                {"logprobs": {"data": lp.tolist(), "shape": [len(lp)], "dtype": "float32"}}
+                for lp in logprobs_list
+            ]
 
             return {
                 "loss_fn_output_type": loss_fn,
-                "loss": metrics.get("loss"),
+                "loss": averaged.get("loss"),
                 "metrics": metrics,
-                "loss_fn_outputs": [],
+                "loss_fn_outputs": loss_fn_outputs,
                 "deferred": False,
             }
 

--- a/training/backends/miles/backend.py
+++ b/training/backends/miles/backend.py
@@ -108,7 +108,9 @@ class MilesBackend(TrainingBackend):
             from miles.ray.placement_group import create_placement_groups, create_rollout_manager
             from miles.ray.tinker_group import TinkerTrainGroup
 
-            pgs = create_placement_groups(args)
+            # Sync ray calls (pg.ready waits, actor allocation) — keep them off
+            # the event loop or /retrieve_future polls stall and clients time out.
+            pgs = await asyncio.to_thread(create_placement_groups, args)
 
             rollout_manager = None
             router_ip = None
@@ -118,7 +120,7 @@ class MilesBackend(TrainingBackend):
                     create_rollout_manager, args, pgs["rollout"]
                 )
 
-            train_group = TinkerTrainGroup(
+            train_group = await asyncio.to_thread(lambda: TinkerTrainGroup(
                 args=args,
                 num_nodes=args.actor_num_nodes,
                 num_gpus_per_node=args.actor_num_gpus_per_node,
@@ -127,7 +129,7 @@ class MilesBackend(TrainingBackend):
                 role="actor",
                 with_ref=False,
                 rollout_manager=rollout_manager,
-            )
+            ))
 
             try:
                 await asyncio.wait_for(train_group.init(), timeout=1800.0)
@@ -396,7 +398,8 @@ class MilesBackend(TrainingBackend):
                 seen = set()
                 for pg_tuple in h.placement_group.values():
                     pg_obj = pg_tuple[0] if isinstance(pg_tuple, tuple) else pg_tuple
-                    if id(pg_obj) not in seen:
+                    # debug_train_only leaves the rollout entry as None
+                    if pg_obj is not None and id(pg_obj) not in seen:
                         seen.add(id(pg_obj))
                         ray.util.remove_placement_group(pg_obj)
                         resources_freed.append("placement_group")

--- a/training/backends/miles/backend.py
+++ b/training/backends/miles/backend.py
@@ -291,16 +291,17 @@ class MilesBackend(TrainingBackend):
     ) -> Dict[str, Any]:
         h: MilesHandle = handle  # type: ignore[assignment]
         try:
-            if learning_rate is not None:
-                await asyncio.to_thread(h.train_group.set_learning_rate, learning_rate)
-
+            # Miles' RayTrainGroup takes the LR as a parameter (no set_learning_rate);
+            # apply_optimizer_step_and_sync = apply_optimizer_step + update_weights.
             offload_train = h.args.offload_train if h.args else True
             offload_rollout = h.args.offload_rollout if h.args else True
 
             if not offload_train and not offload_rollout:
-                results = await asyncio.to_thread(h.train_group.apply_optimizer_step_and_sync)
+                results = await asyncio.to_thread(
+                    h.train_group.apply_optimizer_step_and_sync, learning_rate)
             else:
-                results = await asyncio.to_thread(h.train_group.apply_optimizer_step)
+                results = await asyncio.to_thread(
+                    h.train_group.apply_optimizer_step, learning_rate)
 
                 if h.rollout_manager is not None:
                     from sglang.srt.constants import GPU_MEMORY_TYPE_KV_CACHE, GPU_MEMORY_TYPE_WEIGHTS

--- a/training/backends/miles/backend.py
+++ b/training/backends/miles/backend.py
@@ -1,8 +1,13 @@
-"""Miles backend — wraps RayTrainGroup/RolloutManager/SlimeArgumentBuilder
-behind the TrainingBackend interface (refactor only, no behavior change)."""
+"""Miles backend — wraps TinkerTrainGroup/RolloutManager/SlimeArgumentBuilder
+behind the TrainingBackend interface.
+
+Targets the miles `tinker-seam` branch (upstream-based; specs/005 in
+tinker-nemorl): async TinkerTrainGroup fanout, decoupled
+forward_backward_only / apply_optimizer_step, pure-sum loss via rollout keys
+set in the converter."""
 import asyncio
 import logging
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
@@ -97,93 +102,64 @@ class MilesBackend(TrainingBackend):
             )
             logger.info("[%s] Miles args built, hf_path=%s", request_id, hf_path)
 
-            from miles.ray.actor_group import RayTrainGroup
+            # Reuse upstream's own wiring (miles tinker-seam branch): placement
+            # groups + RolloutManager from the factories train.py uses, and the
+            # TinkerTrainGroup fanout for the decoupled train-step seam.
+            from miles.ray.placement_group import create_placement_groups, create_rollout_manager
+            from miles.ray.tinker_group import TinkerTrainGroup
 
-            num_nodes = 1
-            num_gpus_per_node = num_gpus
-            bundles = [{"GPU": 1, "CPU": 1} for _ in range(num_nodes * num_gpus_per_node)]
-            pg = ray.util.placement_group(bundles, strategy="PACK")
+            pgs = create_placement_groups(args)
 
-            await asyncio.wait_for(
-                asyncio.wrap_future(pg.ready().future()),
-                timeout=120.0,
-            )
-
-            reordered_indices = list(range(len(bundles)))
-
-            train_group = RayTrainGroup(
-                args=args,
-                num_nodes=num_nodes,
-                num_gpus_per_node=num_gpus_per_node,
-                pg=(pg, reordered_indices),
-                num_gpus_per_actor=0.8,
-                role="actor",
-            )
-
-            init_refs = train_group.async_init(args, role="actor", with_ref=False)
-            try:
-                await asyncio.wait_for(
-                    asyncio.gather(*[asyncio.wrap_future(ref.future()) for ref in init_refs]),
-                    timeout=1800.0,
+            rollout_manager = None
+            router_ip = None
+            router_port = None
+            if not debug_train_only:
+                rollout_manager, _ = await asyncio.to_thread(
+                    create_rollout_manager, args, pgs["rollout"]
                 )
+
+            train_group = TinkerTrainGroup(
+                args=args,
+                num_nodes=args.actor_num_nodes,
+                num_gpus_per_node=args.actor_num_gpus_per_node,
+                pg=pgs["actor"],
+                num_gpus_per_actor=0.4,
+                role="actor",
+                with_ref=False,
+                rollout_manager=rollout_manager,
+            )
+
+            try:
+                await asyncio.wait_for(train_group.init(), timeout=1800.0)
             except asyncio.TimeoutError:
-                ray.util.remove_placement_group(pg)
                 raise BackendError(
                     "Actor initialization timeout after 1800s",
                     backend="miles",
                     operation="create_model",
                 )
 
-            # Create RolloutManager for SGLang (RL mode only)
-            rollout_manager = None
-            router_ip = None
-            router_port = None
+            if rollout_manager is not None:
+                await train_group.set_rollout_manager()
 
-            if not debug_train_only:
-                from miles.ray.rollout import RolloutManager
-
-                rollout_manager = RolloutManager.options(
-                    num_cpus=1, num_gpus=0,
-                ).remote(args, (pg, reordered_indices))
-
-                await asyncio.to_thread(train_group.set_rollout_manager, rollout_manager)
-
-                # Initialize SGLang memory state
-                from sglang.srt.constants import GPU_MEMORY_TYPE_WEIGHTS, GPU_MEMORY_TYPE_KV_CACHE
-                try:
-                    from sglang.srt.constants import GPU_MEMORY_TYPE_CUDA_GRAPH
-                except ImportError:
-                    GPU_MEMORY_TYPE_CUDA_GRAPH = None
-
+                # Mirror upstream train.py startup: load weights into SGLang
+                # before anything samples, honoring rollout offload state.
                 if args.offload_rollout:
-                    await asyncio.to_thread(lambda: ray.get(rollout_manager.offload.remote()))
-                    await asyncio.to_thread(lambda: ray.get(
-                        rollout_manager.onload.remote(tags=[GPU_MEMORY_TYPE_WEIGHTS])
-                    ))
-
-                await asyncio.to_thread(train_group.update_weights)
-
+                    await rollout_manager.onload_weights.remote()
+                await train_group.update_weights()
                 if args.offload_rollout:
-                    if GPU_MEMORY_TYPE_CUDA_GRAPH is not None:
-                        await asyncio.to_thread(lambda: ray.get(
-                            rollout_manager.onload.remote(tags=[GPU_MEMORY_TYPE_CUDA_GRAPH])
-                        ))
-                    await asyncio.to_thread(lambda: ray.get(
-                        rollout_manager.onload.remote(tags=[GPU_MEMORY_TYPE_KV_CACHE])
-                    ))
+                    await rollout_manager.onload_kv.remote()
 
-                try:
-                    router_address_ref = rollout_manager.get_router_address.remote()
-                    router_ip, router_port = await asyncio.wrap_future(router_address_ref.future())
-                except Exception as e:
-                    logger.error("[%s] Failed to get router address: %s", request_id, e)
+                router_ip = getattr(args, "sglang_router_ip", None)
+                router_port = getattr(args, "sglang_router_port", None)
+                if not router_ip:
+                    logger.error("[%s] SGLang router address missing from args", request_id)
 
             handle = MilesHandle(
                 model_id=model_id,
                 backend_type="miles",
                 train_group=train_group,
                 rollout_manager=rollout_manager,
-                placement_group=pg,
+                placement_group=pgs,
                 args=args,
                 hf_path=hf_path,
                 router_ip=router_ip,
@@ -215,15 +191,23 @@ class MilesBackend(TrainingBackend):
             from miles.utils.ray_utils import Box
 
             if h.rollout_manager is not None and h.args.offload_rollout:
-                await asyncio.to_thread(lambda: ray.get(h.rollout_manager.offload.remote()))
+                await h.rollout_manager.offload.remote()
 
             rollout_data = self.converter.forward_to_backend(data, h.args)
-            results = await asyncio.to_thread(
-                h.train_group.forward_only,
-                rollout_id=0,
-                rollout_data_ref=Box(ray.put(rollout_data)),
-            )
-            return self.converter.backend_to_forward_result(results, data)
+            # TinkerTrainGroup returns per-sample logprob tensors already
+            # merged into the client's submission order.
+            logprobs = await h.train_group.forward_logprobs(0, Box(ray.put(rollout_data)))
+
+            loss_fn_outputs = [
+                {"logprobs": {"data": lp.tolist(), "shape": [len(lp)], "dtype": "float32"}}
+                for lp in logprobs
+            ]
+            return {
+                "type": "forward",
+                "loss_fn_output_type": loss_fn,
+                "loss_fn_outputs": loss_fn_outputs,
+                "metrics": {},
+            }
 
         except BackendError:
             raise
@@ -243,7 +227,7 @@ class MilesBackend(TrainingBackend):
             from miles.utils.ray_utils import Box
 
             if h.rollout_manager is not None and h.args.offload_rollout:
-                await asyncio.to_thread(lambda: ray.get(h.rollout_manager.offload.remote()))
+                await h.rollout_manager.offload.remote()
 
             is_rl = not h.args.debug_train_only
 
@@ -266,14 +250,28 @@ class MilesBackend(TrainingBackend):
                 data, loss_fn, h.args,
             )
 
-            results = await asyncio.to_thread(
-                h.train_group.forward_backward_only,
-                rollout_id=0,
-                rollout_data_ref=Box(ray.put(rollout_data)),
-            )
-            result = self.converter.backend_to_forward_backward_result(results, data)
-            result["deferred"] = False
-            return result
+            results = await h.train_group.forward_backward_only(0, Box(ray.put(rollout_data)))
+
+            # Only pipeline-last-stage actors return metrics; average across
+            # the DP ranks that did. Per-sample logprobs are not emitted by the
+            # seam's fb pass (specs/005 HANDOFF, open item).
+            summed: Dict[str, float] = {}
+            reporting = 0
+            for r in results or []:
+                loss_dict = (r or {}).get("loss") or {}
+                if loss_dict:
+                    reporting += 1
+                    for k, v in loss_dict.items():
+                        summed[k] = summed.get(k, 0.0) + float(v)
+            metrics = {k: v / reporting for k, v in summed.items()} if reporting else {}
+
+            return {
+                "loss_fn_output_type": loss_fn,
+                "loss": metrics.get("loss"),
+                "metrics": metrics,
+                "loss_fn_outputs": [],
+                "deferred": False,
+            }
 
         except BackendError:
             raise
@@ -291,43 +289,26 @@ class MilesBackend(TrainingBackend):
     ) -> Dict[str, Any]:
         h: MilesHandle = handle  # type: ignore[assignment]
         try:
-            # Miles' RayTrainGroup takes the LR as a parameter (no set_learning_rate);
-            # apply_optimizer_step_and_sync = apply_optimizer_step + update_weights.
+            # TinkerTrainGroup: apply_optimizer_step(learning_rate) fans out to
+            # the actors; _and_sync additionally pushes weights to SGLang.
             offload_train = h.args.offload_train if h.args else True
             offload_rollout = h.args.offload_rollout if h.args else True
 
-            if not offload_train and not offload_rollout:
-                results = await asyncio.to_thread(
-                    h.train_group.apply_optimizer_step_and_sync, learning_rate)
+            if h.rollout_manager is None:
+                results = await h.train_group.apply_optimizer_step(learning_rate)
+            elif not offload_train and not offload_rollout:
+                results = await h.train_group.apply_optimizer_step_and_sync(learning_rate)
             else:
-                results = await asyncio.to_thread(
-                    h.train_group.apply_optimizer_step, learning_rate)
+                results = await h.train_group.apply_optimizer_step(learning_rate)
 
-                if h.rollout_manager is not None:
-                    from sglang.srt.constants import GPU_MEMORY_TYPE_KV_CACHE, GPU_MEMORY_TYPE_WEIGHTS
-                    try:
-                        from sglang.srt.constants import GPU_MEMORY_TYPE_CUDA_GRAPH
-                    except ImportError:
-                        GPU_MEMORY_TYPE_CUDA_GRAPH = None
-
-                    if offload_train:
-                        await asyncio.to_thread(h.train_group.offload)
-
-                    if offload_rollout:
-                        await asyncio.to_thread(lambda: ray.get(
-                            h.rollout_manager.onload.remote(tags=[GPU_MEMORY_TYPE_WEIGHTS])
-                        ))
-
-                    await asyncio.to_thread(h.train_group.update_weights)
-
-                    if offload_rollout:
-                        if GPU_MEMORY_TYPE_CUDA_GRAPH is not None:
-                            await asyncio.to_thread(lambda: ray.get(
-                                h.rollout_manager.onload.remote(tags=[GPU_MEMORY_TYPE_CUDA_GRAPH])
-                            ))
-                        await asyncio.to_thread(lambda: ray.get(
-                            h.rollout_manager.onload.remote(tags=[GPU_MEMORY_TYPE_KV_CACHE])
-                        ))
+                # Mirror upstream train.py's offload dance around weight sync.
+                if offload_train:
+                    await h.train_group.offload()
+                if offload_rollout:
+                    await h.rollout_manager.onload_weights.remote()
+                await h.train_group.update_weights()
+                if offload_rollout:
+                    await h.rollout_manager.onload_kv.remote()
 
             return {
                 "success": results[0]["success"],
@@ -346,7 +327,7 @@ class MilesBackend(TrainingBackend):
     async def update_inference_weights(self, handle: BackendHandle) -> None:
         h: MilesHandle = handle  # type: ignore[assignment]
         try:
-            await asyncio.to_thread(h.train_group.update_weights)
+            await h.train_group.update_weights()
         except Exception as e:
             raise BackendError(
                 str(e), backend="miles", operation="update_inference_weights", original_error=e,
@@ -368,11 +349,7 @@ class MilesBackend(TrainingBackend):
             if step_id is None:
                 step_id = 0
 
-            object_refs = [
-                actor.save_model.remote(step_id)
-                for actor in h.train_group._actor_handlers
-            ]
-            await asyncio.gather(*[asyncio.wrap_future(ref.future()) for ref in object_refs])
+            await h.train_group.save_model(step_id)
             return checkpoint_path
 
         except Exception as e:
@@ -387,15 +364,11 @@ class MilesBackend(TrainingBackend):
     ) -> None:
         h: MilesHandle = handle  # type: ignore[assignment]
         try:
-            object_refs = [
-                actor.load_checkpoint.remote(checkpoint_path)
-                for actor in h.train_group._actor_handlers
-            ]
-            await asyncio.gather(*[asyncio.wrap_future(ref.future()) for ref in object_refs])
+            await h.train_group.load_checkpoint(checkpoint_path)
 
             # Sync loaded weights to inference engine
             if h.rollout_manager is not None:
-                await asyncio.to_thread(h.train_group.update_weights)
+                await h.train_group.update_weights()
 
             logger.info("Miles checkpoint loaded from %s", checkpoint_path)
 
@@ -408,7 +381,7 @@ class MilesBackend(TrainingBackend):
         h: MilesHandle = handle  # type: ignore[assignment]
         try:
             resources_freed = []
-            for actor in h.train_group._actor_handlers:
+            for actor in h.train_group._actor_handles:
                 ray.kill(actor, no_restart=True)
                 resources_freed.append("actor")
 
@@ -416,9 +389,17 @@ class MilesBackend(TrainingBackend):
                 ray.kill(h.rollout_manager, no_restart=True)
                 resources_freed.append("rollout_manager")
 
-            if h.placement_group is not None:
-                ray.util.remove_placement_group(h.placement_group)
-                resources_freed.append("placement_group")
+            # placement_group holds the create_placement_groups() dict of
+            # (pg, bundle_indices, gpu_ids) tuples; pgs may be shared between
+            # roles (colocate), so dedupe before removal.
+            if h.placement_group:
+                seen = set()
+                for pg_tuple in h.placement_group.values():
+                    pg_obj = pg_tuple[0] if isinstance(pg_tuple, tuple) else pg_tuple
+                    if id(pg_obj) not in seen:
+                        seen.add(id(pg_obj))
+                        ray.util.remove_placement_group(pg_obj)
+                        resources_freed.append("placement_group")
 
             logger.info("Miles model %s deleted, freed %d resources", h.model_id, len(resources_freed))
 

--- a/training/backends/miles/converter.py
+++ b/training/backends/miles/converter.py
@@ -48,7 +48,7 @@ class MilesDataConverter(DataConverter):
 
     @staticmethod
     def _add_tinker_seam_keys(rollout_data: Any, num_samples: int) -> None:
-        """Keys the tinker-seam miles branch consumes (specs/005 design.md).
+        """Keys the tinker-seam miles branch consumes.
 
         - dynamic_global_batch_size: actual request size, so upstream
           get_data_iterator schedules correctly for variable batches.

--- a/training/backends/miles/converter.py
+++ b/training/backends/miles/converter.py
@@ -23,7 +23,9 @@ class MilesDataConverter(DataConverter):
         args: Any,
     ) -> Any:
         """Convert Tinker data to Miles rollout_data for forward pass."""
-        return self._inner.forward_to_rollout(data)
+        rollout_data = self._inner.forward_to_rollout(data)
+        self._add_tinker_seam_keys(rollout_data, len(data))
+        return rollout_data
 
     def forward_backward_to_backend(
         self,
@@ -33,7 +35,28 @@ class MilesDataConverter(DataConverter):
     ) -> Any:
         """Convert Tinker data to Miles rollout_data for training."""
         is_rl = not getattr(args, "debug_train_only", False)
-        return self._inner.forward_backward_to_rollout(data, is_rl=is_rl)
+        rollout_data = self._inner.forward_backward_to_rollout(data, is_rl=is_rl)
+        self._add_tinker_seam_keys(rollout_data, len(data))
+        # Per-request loss selection (upstream dispatches on args.loss_type at
+        # startup; the seam overrides per batch). The inner converter already
+        # sets sft_loss when it detects SFT-shaped data — don't override that.
+        rollout_data.setdefault(
+            "_loss_type_override",
+            "sft_loss" if loss_fn == "cross_entropy" else "policy_loss",
+        )
+        return rollout_data
+
+    @staticmethod
+    def _add_tinker_seam_keys(rollout_data: Any, num_samples: int) -> None:
+        """Keys the tinker-seam miles branch consumes (specs/005 design.md).
+
+        - dynamic_global_batch_size: actual request size, so upstream
+          get_data_iterator schedules correctly for variable batches.
+        - _loss_norm_total=1: pure-sum gradients — invariant to how a logical
+          batch is split across forward_backward calls (G1 contract).
+        """
+        rollout_data["dynamic_global_batch_size"] = num_samples
+        rollout_data["_loss_norm_total"] = 1
 
     def backend_to_forward_result(
         self,

--- a/training/core/data_converter.py
+++ b/training/core/data_converter.py
@@ -42,8 +42,8 @@ class TinkerDataConverter:
         """
         # Try chunks first. A ModelInput may carry MULTIPLE chunks (the SDK
         # splits inputs); concatenate them all — taking only chunks[0]
-        # silently truncates the sample (specs/005: 4-token tokens vs
-        # 438-token weights crash in the miles loss).
+        # silently truncates the sample (e.g. 4-token tokens vs 438-token
+        # weights, crashing the miles loss on shape mismatch).
         chunks = TinkerDataConverter._get_field(model_input, "chunks")
         if chunks:
             tokens: List[int] = []

--- a/training/core/data_converter.py
+++ b/training/core/data_converter.py
@@ -40,13 +40,22 @@ class TinkerDataConverter:
 
         Works with both dict and Pydantic model inputs.
         """
-        # Try chunks first
+        # Try chunks first. A ModelInput may carry MULTIPLE chunks (the SDK
+        # splits inputs); concatenate them all — taking only chunks[0]
+        # silently truncates the sample (specs/005: 4-token tokens vs
+        # 438-token weights crash in the miles loss).
         chunks = TinkerDataConverter._get_field(model_input, "chunks")
         if chunks:
-            if not chunks:
-                raise ValueError("Empty chunks in model_input")
-            first_chunk = chunks[0]
-            return TinkerDataConverter._get_field(first_chunk, "tokens")
+            tokens: List[int] = []
+            for chunk in chunks:
+                chunk_tokens = TinkerDataConverter._get_field(chunk, "tokens")
+                if chunk_tokens is None:
+                    raise ValueError(
+                        "model_input chunk without tokens (non-text chunks are "
+                        "not supported by the miles backend)"
+                    )
+                tokens.extend(chunk_tokens)
+            return tokens
 
         # Try tokens
         tokens = TinkerDataConverter._get_field(model_input, "tokens")

--- a/training/core/data_converter.py
+++ b/training/core/data_converter.py
@@ -112,11 +112,15 @@ class TinkerDataConverter:
                 # Default: all ones (no masking)
                 loss_mask = torch.ones(len(tokens), dtype=torch.float32)
 
+            # Miles convention: the mask covers the response REGION, so
+            # response_length is the mask's length (zeros inside are allowed);
+            # counting nonzeros breaks prompt/response alignment in get_batch.
+            # Causal N-1 trim: response == total yields an empty logit slice
+            # (same handling as the forward_backward RL path).
+            if len(loss_mask) == len(tokens) and len(tokens) > 1:
+                loss_mask = loss_mask[1:]
             loss_masks_list.append(loss_mask)
-
-            # Response length is number of non-zero mask elements
-            response_length = int(loss_mask.sum().item())
-            response_lengths_list.append(response_length)
+            response_lengths_list.append(len(loss_mask))
             # print(f"[CONVERTER DEBUG SFT] Sample {len(loss_masks_list)-1}: loss_mask sum={response_length}, len={len(loss_mask)}", flush=True)
 
         # Build rollout_data with dummy RL fields (not used for forward-only)

--- a/training/core/slime_builder.py
+++ b/training/core/slime_builder.py
@@ -328,9 +328,11 @@ class SlimeArgumentBuilder:
         if checkpoint_path:
             args.load = parse_checkpoint_uri(checkpoint_path, args.save)
 
-        # LoRA configuration
+        # LoRA configuration. alpha defaults to rank per the API schema
+        # (requests.py LoraConfig); alpha=0 zeroes LoRA scaling and gradients
+        # entirely — see specs/005-miles-ray-interface/design.md (grad_norm=0).
         args.lora_rank = lora_config.get("rank", 0) if lora_config else 0
-        args.lora_alpha = lora_config.get("alpha", 0) if lora_config else 0
+        args.lora_alpha = (lora_config.get("alpha") or args.lora_rank) if lora_config else 0
         args.lora_dropout = lora_config.get("dropout", 0.0) if lora_config else 0.0
 
         # Parallelism settings - use values from parallel_config (already auto-detected in build_args)

--- a/training/core/slime_builder.py
+++ b/training/core/slime_builder.py
@@ -473,10 +473,15 @@ class SlimeArgumentBuilder:
             }
 
         # Disable offload_train for simpler GPU memory management
-        # When offload_train=False, must also set train_memory_margin_bytes=0 to avoid assert
+        # When offload_train=False, must also set train_memory_margin_bytes=0 to avoid assert.
+        # Also reset flags parse_args DERIVED from the minimal-args --offload flag,
+        # or actors allocate grad buffers in a torch_memory_saver region without
+        # LD_PRELOAD (only set for offload actors) and crash at init.
         args.offload_train = False
         args.offload_rollout = False
         args.train_memory_margin_bytes = 0
+        args.disable_grad_buffers_cpu_backup = False
+        args.disable_param_buffers_cpu_backup = False
 
         # Tinker seam (miles tinker-seam branch, specs/005 design.md):
         # per-request batch sizes ride the dynamic_global_batch_size rollout key

--- a/training/core/slime_builder.py
+++ b/training/core/slime_builder.py
@@ -329,7 +329,7 @@ class SlimeArgumentBuilder:
 
         # LoRA configuration. alpha defaults to rank per the API schema
         # (requests.py LoraConfig); alpha=0 zeroes LoRA scaling and gradients
-        # entirely — see specs/005-miles-ray-interface/design.md (grad_norm=0).
+        # entirely (the historical grad_norm=0 constant-loss bug).
         args.lora_rank = lora_config.get("rank", 0) if lora_config else 0
         args.lora_alpha = (lora_config.get("alpha") or args.lora_rank) if lora_config else 0
         args.lora_dropout = lora_config.get("dropout", 0.0) if lora_config else 0.0
@@ -500,7 +500,7 @@ class SlimeArgumentBuilder:
         args.disable_grad_buffers_cpu_backup = False
         args.disable_param_buffers_cpu_backup = False
 
-        # Tinker seam (miles tinker-seam branch, specs/005 design.md):
+        # Tinker seam (miles tinker-seam branch):
         # per-request batch sizes ride the dynamic_global_batch_size rollout key
         # (its assert couples this arg to the key's presence), and each actor
         # splits the fanned-out batch by DP rank locally.

--- a/training/core/slime_builder.py
+++ b/training/core/slime_builder.py
@@ -12,7 +12,6 @@ from typing import Any, Dict, Optional, Tuple
 
 from ..utils.model_config import (
     load_model_config,
-    get_parallelism_config,
     auto_detect_all_parallelism,
     detect_torch_dist_path,
     parse_checkpoint_uri,
@@ -478,5 +477,12 @@ class SlimeArgumentBuilder:
         args.offload_train = False
         args.offload_rollout = False
         args.train_memory_margin_bytes = 0
+
+        # Tinker seam (miles tinker-seam branch, specs/005 design.md):
+        # per-request batch sizes ride the dynamic_global_batch_size rollout key
+        # (its assert couples this arg to the key's presence), and each actor
+        # splits the fanned-out batch by DP rank locally.
+        args.use_dynamic_global_batch_size = True
+        args.delay_split_train_data_by_dp = True
 
         return args

--- a/training/core/slime_builder.py
+++ b/training/core/slime_builder.py
@@ -333,6 +333,21 @@ class SlimeArgumentBuilder:
         args.lora_rank = lora_config.get("rank", 0) if lora_config else 0
         args.lora_alpha = (lora_config.get("alpha") or args.lora_rank) if lora_config else 0
         args.lora_dropout = lora_config.get("dropout", 0.0) if lora_config else 0.0
+        # Megatron module targets from Tinker's train_attn/train_mlp flags
+        # (upstream requires target_modules when LoRA is enabled; unembed LoRA
+        # is not supported by miles' injector).
+        target_modules = []
+        if not lora_config or lora_config.get("train_attn", True):
+            target_modules += ["linear_qkv", "linear_proj"]
+        if not lora_config or lora_config.get("train_mlp", True):
+            target_modules += ["linear_fc1", "linear_fc2"]
+        args.target_modules = target_modules
+        # Upstream only injects megatron-side LoRA adapters on the bridge path
+        # (model.py: is_lora_enabled and megatron_to_hf_mode == "bridge");
+        # without this the model silently builds as full-finetune and LoRA
+        # weight sync to SGLang fails (no lora_A/lora_B params).
+        if args.lora_rank > 0:
+            args.megatron_to_hf_mode = "bridge"
 
         # Parallelism settings - use values from parallel_config (already auto-detected in build_args)
         tp_size = parallel_config.get('tensor_parallel_size', 2)
@@ -420,8 +435,10 @@ class SlimeArgumentBuilder:
         args.rollout_function_path = "miles.rollout.sglang_rollout.generate_rollout"
         args.eval_function_path = "miles.rollout.sglang_rollout.generate_rollout"
 
-        # Dataset configuration (fallback for testing)
-        args.rollout_global_dataset = True
+        # No server-side prompt dataset: Tinker clients drive all training and
+        # sampling data, so RolloutManager must not load one (its data source
+        # raises if the file is missing).
+        args.rollout_global_dataset = False
         args.prompt_data = "/data/datasets/gsm8k_rl.jsonl"
         args.rollout_shuffle = False
         args.rollout_max_prompt_len = 2048

--- a/training/utils/model_config.py
+++ b/training/utils/model_config.py
@@ -107,7 +107,12 @@ def load_model_config(base_model: str) -> Dict[str, Any]:
                 config, 'rms_norm_eps',
                 getattr(config, 'layer_norm_eps', 1e-6)
             ),
-            'rotary_base': getattr(config, 'rope_theta', 10000),
+            # transformers 5.x moved rope_theta into the rope_parameters dict
+            'rotary_base': (
+                getattr(config, 'rope_theta', None)
+                or (getattr(config, 'rope_parameters', None) or {}).get('rope_theta')
+                or 10000
+            ),
             'tie_word_embeddings': getattr(config, 'tie_word_embeddings', False),
             'max_position_embeddings': getattr(config, 'max_position_embeddings', 2048),
         }


### PR DESCRIPTION
Adapts `MilesBackend` to the re-ported Tinker seam on upstream-based miles ([GavinZhu-GMI/miles `tinker-seam`](https://github.com/GavinZhu-GMI/miles/tree/tinker-seam), based on radixark/miles `fecd5d9`), replacing the old fork's Ray-orchestration interface. Design + validation record: monorepo `specs/005-miles-ray-interface/`.

## What changed
- **Backend** drives the new `TinkerTrainGroup` async fanout (`await`, no more sync + `to_thread`); upstream factories for placement groups / RolloutManager.
- **Converter** sends `dynamic_global_batch_size=len(batch)`, `_loss_norm_total=1` (pure-sum loss semantics — split-invariant gradient accumulation across pipelined `forward_backward` calls), and `_loss_type_override` for per-request loss selection.
- **Builder**: `use_dynamic_global_batch_size=True`, `delay_split_train_data_by_dp=True`; LoRA alpha now defaults to rank per the API schema (was 0 → zero gradients by construction).
- **Deploy**: miles profile overlays via git checkout (not `cp -r`), forwards `MILES_REPO`/`MILES_REF` into the container.
- First-boot and G3 fixes: rope_theta/transformers-5.x, forward-result converter (response_length + causal trim), chunk concat in datum conversion, fb per-datum logprobs, event-loop blocking in create.

## Validation (ns.config 4×H200, DP=4, Qwen2.5-0.5B bridge-LoRA, 2026-07-13/14)
- **G1 (grad accumulation parity)**: grad_norm bit-identical (314.3438105800717) for 1×fb(8) vs 2×fb(4) + one step — ratio exactly 1.0.
- **G2 (client-order outputs)**: per-sample logprobs return in submission order through DP shard + packing.
- **G3 (real recipe)**: sl_basic NoRobots SFT, 30 steps end-to-end through the full stack (session → megatron actors → SGLang sync → checkpoint); NLL 2.74 → 2.34.
- Weights move; 5-step loss 11.77 → 9.06 at lr=1e-5.

Note the semantics shift: pure-sum grad_norm scales with total weighted tokens (~100× the old mean-normalized value); clients own normalization via weights/LR, per the Tinker contract.
