### PR TITLE
nemo_rl: close BUG-015 — sampler version pinning + convergence-parity fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,19 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+# Editable-install the TinkerCloud server so `training` is importable on the
+# server AND on Ray workers (same venv), matching how nemo_rl / tinker /
+# tinker_cookbook are already installed. Fixes the /app-not-on-worker-path
+# misplacement that otherwise blocks shipping tinker-cloud code to workers
+# (e.g. training.backends.nemo_rl.losses.TinkerSumCELoss — see BUG-015).
+name = "tinkercloud-training"
+version = "0.1.0"
+description = "TinkerCloud multi-backend post-training server"
+requires-python = ">=3.10"
+# No dependencies declared on purpose: install with --no-deps, the runtime
+# image already provides everything. This entry only creates the import path.
+
+[tool.setuptools.packages.find]
+include = ["training*"]

--- a/training/backends/base.py
+++ b/training/backends/base.py
@@ -146,10 +146,15 @@ class TrainingBackend(ABC):
         self,
         handle: BackendHandle,
         learning_rate: Optional[float] = None,
+        adam_params: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """
         Apply accumulated gradients via optimizer step, then sync
         weights to inference engine.
+
+        adam_params (P4): full client AdamParams (beta1/beta2/eps/weight_decay/
+        grad_clip_norm). Backends honor what they can and MUST warn on values
+        they cannot apply.
 
         NeMo RL behavior:
             Concatenates all buffered forward_backward data and calls
@@ -257,6 +262,7 @@ class TrainingBackend(ABC):
         num_samples: int,
         sampling_params: Optional[Dict[str, Any]] = None,
         prompt_logprobs: bool = False,
+        pinned_version: Optional[int] = None,
     ) -> Dict[str, Any]:
         """
         Generate num_samples completions for one prompt via the backend's

--- a/training/backends/miles/backend.py
+++ b/training/backends/miles/backend.py
@@ -301,7 +301,10 @@ class MilesBackend(TrainingBackend):
         self,
         handle: BackendHandle,
         learning_rate: Optional[float] = None,
+        adam_params: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
+        # adam_params accepted for contract uniformity (P4); Miles applies lr
+        # only — betas/eps are Megatron args fixed at creation.
         h: MilesHandle = handle  # type: ignore[assignment]
         try:
             # TinkerTrainGroup: apply_optimizer_step(learning_rate) fans out to
@@ -446,8 +449,14 @@ class MilesBackend(TrainingBackend):
         num_samples: int,
         sampling_params: Optional[Dict[str, Any]] = None,
         prompt_logprobs: bool = False,
+        pinned_version: Optional[int] = None,
     ) -> Dict[str, Any]:
-        """Sample via per-request HTTP calls to the SGLang router."""
+        """Sample via per-request HTTP calls to the SGLang router.
+
+        pinned_version is accepted for contract uniformity but NOT honored:
+        Miles serves from the live SGLang engine (same BUG-015 aliasing class;
+        needs version-pinned sampling to fix).
+        """
         from ...utils.sglang_client import SGLangClient
 
         h: MilesHandle = handle  # type: ignore[assignment]

--- a/training/backends/nemo_rl/backend.py
+++ b/training/backends/nemo_rl/backend.py
@@ -55,6 +55,8 @@ class NemoRLHandle(BackendHandle):
     generation_state: str = "generation_ready"  # "generation_ready" | "training_ready"
     _generation_state_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     _training_lock: asyncio.Lock = field(default_factory=asyncio.Lock)  # Serialize optim_step GPU lifecycle
+    weight_version: int = 0              # Optim steps applied; BUG-015 sampler pinning
+    ref_logprob_accumulator: Any = None  # Lazy _RefLogprobAccumulator (BUG-015)
 
 
 class NemoRLBackend(TrainingBackend):
@@ -351,6 +353,7 @@ class NemoRLBackend(TrainingBackend):
         self,
         handle: BackendHandle,
         learning_rate: Optional[float] = None,
+        adam_params: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """
         Execute single policy.train() call with all buffered data.
@@ -434,6 +437,12 @@ class NemoRLBackend(TrainingBackend):
             if learning_rate is not None:
                 _set_learning_rate(h.policy, learning_rate)
 
+            # P4: betas/eps are fixed at creation (builder defaults match the
+            # Tinker AdamParams contract: 0.9/0.95/1e-8); the worker exposes no
+            # setter, so warn loudly if a client requests different values.
+            if adam_params:
+                _warn_on_adam_mismatch(h, adam_params)
+
             # Serialize GPU lifecycle: sleep vLLM → train → refit.
             # Pipelined SFT loops fire multiple optim_step calls concurrently;
             # without this lock they race on the same Ray actors/GPU memory,
@@ -479,8 +488,12 @@ class NemoRLBackend(TrainingBackend):
                             logger.info("prev_logprobs replaced with DTensor-computed values")
 
                     if h.loss_fn_name == "cross_entropy":
-                        from nemo_rl.algorithms.loss_functions import NLLLoss
-                        active_loss_fn = NLLLoss()
+                        # Pure-sum CE (Tinker contract), not NeMo RL's mean-normalized
+                        # NLLLoss — see BUG-015 and losses.TinkerSumCELoss. Ships to
+                        # Ray workers by reference (training is pip install -e'd, so
+                        # importable in the shared venv on server + workers).
+                        from .losses import TinkerSumCELoss
+                        active_loss_fn = TinkerSumCELoss()
                     else:
                         active_loss_fn = h.loss_fn  # ClippedPGLossFn (RL)
 
@@ -500,6 +513,10 @@ class NemoRLBackend(TrainingBackend):
                         list(train_result.keys()),
                         {k: v for k, v in train_result.get("all_mb_metrics", {}).items()},
                     )
+
+                    # BUG-015: weights advanced — bump version so pinned samplers
+                    # (e.g. DPO's frozen reference) stop matching the live engine.
+                    h.weight_version += 1
 
                     if h.policy_generation is not None and not h.debug_train_only:
                         logger.info("Refitting policy generation for %s", h.model_id)
@@ -701,15 +718,33 @@ class NemoRLBackend(TrainingBackend):
         num_samples: int,
         sampling_params: Optional[Dict[str, Any]] = None,
         prompt_logprobs: bool = False,
+        pinned_version: Optional[int] = None,
     ) -> Dict[str, Any]:
         """Sample via Policy.generate() on vLLM Ray workers.
 
         PERF-002: requests are batch-accumulated per model and flushed as a
         single generate() call (~20-30x speedup for RL rollouts).
+
+        BUG-015: `pinned_version` is the weight version a snapshot sampler was
+        created at. The live vLLM engine is refit to the current policy every
+        optim step, so a pinned sampler's compute_logprobs must NOT be served
+        from it once versions diverge. v0-pinned samplers (DPO's frozen
+        reference) are served from NeMo RL's built-in frozen reference model.
         """
         from .generation import NemoRLBatchAccumulator
 
         h: NemoRLHandle = handle  # type: ignore[assignment]
+
+        # BUG-015 routing: version-pinned logprob reads
+        if prompt_logprobs and pinned_version is not None and pinned_version != h.weight_version:
+            if pinned_version == 0:
+                return await self._reference_prompt_logprobs(h, prompt_tokens)
+            logger.warning(
+                "[%s] sampler pinned at v%s but live weights at v%s — serving from "
+                "LIVE weights (known-wrong; needs version-pinned sampling, 003)",
+                request_id, pinned_version, h.weight_version,
+            )
+
         if h.policy_generation is None:
             raise BackendError(
                 "generation engine not initialized (debug_train_only mode?)",
@@ -726,6 +761,71 @@ class NemoRLBackend(TrainingBackend):
             sampling_params=sampling_params or {},
             prompt_logprobs=prompt_logprobs,
         )
+
+    async def _reference_prompt_logprobs(
+        self, h: "NemoRLHandle", prompt_tokens: List[int],
+    ) -> Dict[str, Any]:
+        """Serve compute_logprobs from the frozen reference model (W0).
+
+        BUG-015 fix: DPO's reference sampler is a t=0 snapshot; the policy
+        workers already hold frozen W0 (init_reference_model=True), so we call
+        NeMo RL's public get_reference_policy_logprobs — no NeMo RL changes.
+        Requests are batch-accumulated (DPO fires ~2x batch_size concurrent
+        calls per step) and flushed as one call.
+        """
+        if h.ref_logprob_accumulator is None:
+            h.ref_logprob_accumulator = _RefLogprobAccumulator()
+        lp = await h.ref_logprob_accumulator.submit(self, h, prompt_tokens)
+        # SDK reads prompt_logprobs only; one dummy sequence satisfies the schema.
+        return {
+            "sequences": [
+                {"stop_reason": "length", "tokens": [], "logprobs": [], "text": None}
+            ],
+            "prompt_logprobs": lp,
+        }
+
+    async def _run_reference_logprobs(
+        self, h: "NemoRLHandle", prompts: List[List[int]],
+    ) -> List[List[Optional[float]]]:
+        """One batched frozen-reference logprob pass. GPU lifecycle mirrors
+        forward(): sleep vLLM -> prepare_for_training -> compute, NO refit
+        (read-only; next generate() re-wakes via the safety net)."""
+        import torch
+        from nemo_rl.distributed.batched_data_dict import BatchedDataDict
+
+        batch_size = len(prompts)
+        max_len = max(len(p) for p in prompts)
+        input_ids = torch.zeros(batch_size, max_len, dtype=torch.long)
+        token_mask = torch.zeros(batch_size, max_len, dtype=torch.float32)
+        for i, p in enumerate(prompts):
+            input_ids[i, : len(p)] = torch.tensor(p, dtype=torch.long)
+            token_mask[i, : len(p)] = 1.0
+        data = BatchedDataDict({
+            "input_ids": input_ids,
+            "input_lengths": torch.tensor([len(p) for p in prompts], dtype=torch.long),
+            "token_mask": token_mask,
+            "sample_mask": torch.ones(batch_size, dtype=torch.float32),
+        })
+        dp_size = h.config.get("dp_size", 1)
+        mbs = h.config.get("policy", {}).get("train_micro_batch_size", 1)
+        data = await asyncio.to_thread(_maybe_pad_batch, data, dp_size, mbs, None)
+
+        async with h._training_lock:
+            async with h._generation_state_lock:
+                h.generation_state = "training_ready"
+            if h.policy_generation is not None and h.colocated_inference:
+                await asyncio.to_thread(h.policy_generation.finish_generation)
+            await asyncio.to_thread(h.policy.prepare_for_training)
+            out = await asyncio.to_thread(h.policy.get_reference_policy_logprobs, data)
+
+        ref = out["reference_logprobs"]  # [B_padded, S]; row t = logprob(token_t | <t)
+        results: List[List[Optional[float]]] = []
+        for i, p in enumerate(prompts):
+            row = ref[i]
+            vals = row[1: len(p)].tolist()
+            # BUG-013 convention: position 0 has no logprob
+            results.append([None] + [float(v) for v in vals])
+        return results
 
     async def prepare_for_generation(self, handle: BackendHandle) -> None:
         """Safety-net refit + wake if the engine was left in training state."""
@@ -971,6 +1071,37 @@ def _refit_policy_generation(policy, policy_generation, colocated_inference: boo
         policy_generation.prepare_for_generation(tags=["kv_cache"])
 
 
+def _warn_on_adam_mismatch(h: "NemoRLHandle", adam_params: Dict[str, Any]) -> None:
+    """P4: compare client-requested Adam params against the applied config.
+
+    Betas/eps/weight_decay/clip are baked into the optimizer at model creation;
+    NeMo RL's worker only exposes set_learning_rate, so differing requests
+    cannot be honored per-step without an upstream setter. Warn once per handle.
+    """
+    if getattr(h, "_adam_mismatch_warned", False):
+        return
+    kwargs = h.config.get("policy", {}).get("optimizer", {}).get("kwargs", {})
+    applied = {
+        "beta1": kwargs.get("betas", [0.9, 0.95])[0],
+        "beta2": kwargs.get("betas", [0.9, 0.95])[1],
+        "eps": kwargs.get("eps", 1e-8),
+        "weight_decay": kwargs.get("weight_decay", 0.0),
+        "grad_clip_norm": h.config.get("policy", {}).get("max_grad_norm", 1.0),
+    }
+    mismatches = {
+        k: (v, applied[k]) for k, v in adam_params.items()
+        if k in applied and v is not None and abs(float(v) - float(applied[k])) > 1e-12
+    }
+    if mismatches:
+        logger.warning(
+            "[P4] client AdamParams differ from applied optimizer config and "
+            "CANNOT be applied per-step (requested vs applied): %s — fix at "
+            "model creation (builder) or add an upstream NeMo RL setter.",
+            mismatches,
+        )
+    h._adam_mismatch_warned = True
+
+
 def _set_learning_rate(policy, learning_rate: float):
     """Set learning rate on the policy's optimizer via worker RPC."""
     import ray
@@ -987,6 +1118,59 @@ def _set_learning_rate(policy, learning_rate: float):
             "Could not set learning rate to %s: %s. Using default LR.",
             learning_rate, e,
         )
+
+
+class _RefLogprobAccumulator:
+    """Batch-accumulate frozen-reference logprob requests (BUG-015).
+
+    Same shape as NemoRLBatchAccumulator (PERF-002): concurrent
+    compute_logprobs calls within a flush window are served by ONE
+    get_reference_policy_logprobs pass. Single event loop => the
+    drain-then-exit check under the lock is race-free.
+    """
+
+    def __init__(self, flush_interval_s: float = 0.05):
+        self._flush_interval = flush_interval_s
+        self._pending: List[Any] = []  # (prompt_tokens, future)
+        self._lock = asyncio.Lock()
+        self._flush_task: Optional[asyncio.Task] = None
+
+    async def submit(self, backend, handle, prompt_tokens: List[int]):
+        fut = asyncio.get_event_loop().create_future()
+        async with self._lock:
+            self._pending.append((prompt_tokens, fut))
+            if self._flush_task is None or self._flush_task.done():
+                self._flush_task = asyncio.create_task(
+                    self._flush_loop(backend, handle)
+                )
+        return await fut
+
+    async def _flush_loop(self, backend, handle):
+        while True:
+            await asyncio.sleep(self._flush_interval)
+            async with self._lock:
+                pending, self._pending = self._pending, []
+            if not pending:
+                return
+            try:
+                results = await backend._run_reference_logprobs(
+                    handle, [p for p, _ in pending]
+                )
+                for (_, fut), lp in zip(pending, results):
+                    if not fut.done():
+                        fut.set_result(lp)
+            except Exception as e:  # propagate to all waiters
+                for _, fut in pending:
+                    if not fut.done():
+                        fut.set_exception(
+                            BackendError(
+                                str(e), backend="nemo_rl",
+                                operation="reference_logprobs", original_error=e,
+                            )
+                        )
+            async with self._lock:
+                if not self._pending:
+                    return
 
 
 def _maybe_pad_batch(batch, dp_size: int, mbs: int, image_preprocessor=None):

--- a/training/backends/nemo_rl/builder.py
+++ b/training/backends/nemo_rl/builder.py
@@ -218,13 +218,17 @@ class NemoRLArgumentBuilder(ArgumentBuilder):
                     "enabled": True,
                 },
             },
-            # Optimizer (AdamW defaults matching Miles)
+            # Optimizer. Betas/eps match the Tinker AdamParams contract defaults
+            # (beta2=0.95) — the client sends AdamParams per optim_step but the
+            # worker only exposes a learning-rate setter, so betas/eps are fixed
+            # at creation (P4; mismatches warned in backend.apply_optimizer_step).
             "optimizer": {
                 "name": "torch.optim.AdamW",
                 "kwargs": {
                     "lr": 5.0e-6,
                     "weight_decay": 0.0,
-                    "betas": [0.9, 0.999],
+                    "betas": [0.9, 0.95],
+                    "eps": 1.0e-8,
                     "foreach": False,
                     "fused": False,
                 },
@@ -232,13 +236,21 @@ class NemoRLArgumentBuilder(ArgumentBuilder):
         }
 
         if lora_config and lora_config.get("rank", 0) > 0:
+            # All-linear coverage (attention + MLP) to match hosted Tinker
+            # semantics — per the Tinker LoRA primer, attention-only LoRA
+            # under-performs even at matched parameter count (BUG-015 residual
+            # gap). Client may override via lora_config["target_modules"].
+            target_modules = lora_config.get("target_modules") or [
+                "*.q_proj", "*.k_proj", "*.v_proj", "*.o_proj",
+                "*.gate_proj", "*.up_proj", "*.down_proj",
+            ]
             policy_config["dtensor_cfg"]["lora_cfg"] = {
                 "enabled": True,
                 "dim": lora_config.get("rank", 8),
                 "alpha": lora_config.get("alpha") or lora_config.get("rank", 8),
                 "dropout": lora_config.get("dropout", 0.0),
                 "dropout_position": "pre",
-                "target_modules": ["*.q_proj", "*.k_proj", "*.v_proj", "*.o_proj"],
+                "target_modules": target_modules,
                 "exclude_modules": [],
                 "lora_A_init": "kaiming",
             }

--- a/training/backends/nemo_rl/losses.py
+++ b/training/backends/nemo_rl/losses.py
@@ -1,0 +1,30 @@
+"""Tinker-owned loss functions for the NeMo RL backend."""
+
+import torch
+from nemo_rl.algorithms.loss_functions import NLLLoss
+
+
+class TinkerSumCELoss(NLLLoss):
+    """Pure-sum cross-entropy: L = sum(-logprob * weight), no token-count mean.
+
+    Tinker's `cross_entropy` contract (and forward_backward_custom, which routes
+    DPO/custom losses through it) requires a pure sum so the client owns
+    normalization; Miles honors this via `_loss_norm_total=1`. NeMo RL's NLLLoss
+    divides by `global_valid_toks` (a mean), which mis-scales the gradient — and
+    for the custom-loss path that divisor is a sum of real-valued gradient
+    coefficients, not a token count (BUG-015). We reuse NLLLoss's logprob gather
+    verbatim and only force the normalization factor to 1 (pure sum).
+    """
+
+    def __call__(
+        self, next_token_logits, data, global_valid_seqs, global_valid_toks,
+        *args, **kwargs,
+    ):
+        one = (
+            torch.ones_like(global_valid_toks)
+            if torch.is_tensor(global_valid_toks)
+            else 1.0
+        )
+        return super().__call__(
+            next_token_logits, data, global_valid_seqs, one, *args, **kwargs,
+        )

--- a/training/routers/checkpoints.py
+++ b/training/routers/checkpoints.py
@@ -172,11 +172,16 @@ async def save_weights_for_sampler(
         sampling_session_id = result.get("sampling_session_id")
         if sampling_session_id:
             checkpoint_path = result.get("checkpoint_path")
+            # BUG-015: pin the weight version at save time so pinned logprob
+            # reads are not served from the live (refit-every-step) engine.
+            backend_handle = client_info.get("backend_handle")
+            pinned_version = getattr(backend_handle, "weight_version", None)
             session_service.register_ephemeral_sampler(
                 sampler_id=sampling_session_id,
                 model_id=request.model_id,
                 base_model=base_model,
-                model_path=checkpoint_path
+                model_path=checkpoint_path,
+                pinned_version=pinned_version,
             )
 
         return SaveWeightsForSamplerResult(**result)

--- a/training/routers/sampling.py
+++ b/training/routers/sampling.py
@@ -73,13 +73,19 @@ def get_task_manager(
 # Sampling Endpoints
 # ============================================================================
 
+def get_session_service(request: Request):
+    """Session service from app state (None if unavailable)."""
+    return getattr(request.app.state, "session_service", None)
+
+
 @router.post("/api/v1/asample", response_model=AsyncOperationResponse)
 async def asample(
     request: ASampleRequest,
     _: None = Depends(verify_api_key_dep),
     service: SamplingService = Depends(get_sampling_service),
     task_manager: TaskManager = Depends(get_task_manager),
-    training_clients: Dict = Depends(get_training_clients)
+    training_clients: Dict = Depends(get_training_clients),
+    session_service=Depends(get_session_service),
 ):
     """
     Async sampling via SGLang.
@@ -95,6 +101,14 @@ async def asample(
     # Extract prompt tokens
     prompt_tokens = request.prompt.get_tokens()
 
+    # BUG-015: resolve the sampler's pinned weight version (snapshot samplers,
+    # e.g. DPO's frozen reference) so pinned logprob reads aren't served from
+    # the live refit-every-step engine.
+    pinned_version = None
+    if request.sampling_session_id and session_service is not None:
+        info = session_service.get_sampler(request.sampling_session_id)
+        pinned_version = getattr(info, "pinned_version", None) if info else None
+
     async def execute():
         result_dict = await service.async_sample(
             request_id=request_id,
@@ -102,7 +116,8 @@ async def asample(
             num_samples=request.num_samples,
             sampling_params=request.sampling_params.dict() if request.sampling_params else None,
             prompt_logprobs=request.prompt_logprobs,
-            training_clients=training_clients
+            training_clients=training_clients,
+            pinned_version=pinned_version,
         )
 
         # Convert to response model

--- a/training/services/sampling_service.py
+++ b/training/services/sampling_service.py
@@ -41,10 +41,14 @@ class SamplingService:
         num_samples: int,
         sampling_params: Optional[Dict[str, Any]],
         prompt_logprobs: bool,
-        training_clients: Dict[str, Dict[str, Any]]
+        training_clients: Dict[str, Dict[str, Any]],
+        pinned_version: Optional[int] = None,
     ) -> Dict[str, Any]:
         """
         Async sampling for a single prompt.
+
+        `pinned_version` (BUG-015): weight version the requesting sampler was
+        created at; backends route pinned logprob reads off the live engine.
 
         Returns:
             Dict with sequences and optional prompt_logprobs
@@ -62,6 +66,7 @@ class SamplingService:
             num_samples=num_samples,
             sampling_params=sampling_params,
             prompt_logprobs=prompt_logprobs,
+            pinned_version=pinned_version,
         )
 
     async def sync_sample(

--- a/training/services/session_service.py
+++ b/training/services/session_service.py
@@ -27,6 +27,9 @@ class SamplerInfo:
     base_model: Optional[str] = None
     model_path: Optional[str] = None
     created_at: datetime = field(default_factory=datetime.now)
+    # BUG-015: weight version of the owning model when this sampler was created.
+    # None = unknown (e.g. restored from storage) -> served from live weights.
+    pinned_version: Optional[int] = None
 
 
 @dataclass
@@ -409,7 +412,8 @@ class SessionService:
         sampler_id: str,
         model_id: str,
         base_model: Optional[str] = None,
-        model_path: Optional[str] = None
+        model_path: Optional[str] = None,
+        pinned_version: Optional[int] = None,
     ) -> bool:
         """
         Register an ephemeral sampler from save_weights_for_sampler.
@@ -443,6 +447,7 @@ class SessionService:
             session_id=session_id,
             base_model=base_model if base_model else None,
             model_path=model_path,
+            pinned_version=pinned_version,
         )
 
         # Persist to storage

--- a/training/services/training_service.py
+++ b/training/services/training_service.py
@@ -77,11 +77,21 @@ class TrainingService:
 
         # Extract learning rate from adam_params (Tinker API pattern)
         learning_rate = None
+        adam_params_dict = None
         if adam_params is not None and hasattr(adam_params, "learning_rate"):
             learning_rate = adam_params.learning_rate
             logger.info("Setting learning rate to %s for %s", learning_rate, model_id)
+            # P4: forward the FULL AdamParams so backends can honor or at least
+            # detect-and-warn on beta/eps/clip values they cannot apply.
+            adam_params_dict = {
+                k: getattr(adam_params, k)
+                for k in ("beta1", "beta2", "eps", "weight_decay", "grad_clip_norm")
+                if hasattr(adam_params, k)
+            }
 
-        result = await self.backend.apply_optimizer_step(handle, learning_rate=learning_rate)
+        result = await self.backend.apply_optimizer_step(
+            handle, learning_rate=learning_rate, adam_params=adam_params_dict,
+        )
 
         logger.info(
             "Optimizer step completed for %s: grad_norm=%s, success=%s",


### PR DESCRIPTION
## Problem

DPO on the nemo_rl backend converged ~4x slower than the recipe's published reference: loss pinned at ln2 for hundreds of steps, reward magnitudes ~10x too small, direction correct — maximally silent.

**Root cause: reference-sampler weight aliasing.** `save_weights_and_get_sampling_client()` is semantically a frozen snapshot, but the backend served *all* sampler traffic (incl. `compute_logprobs`) from the single live vLLM engine, which is refit to the current policy after every optim step. The DPO "reference" tracked the policy one refit behind, so the log-ratios were ~0 by construction. Only DPO exercises a pinned snapshot, which is why every other recipe passed.

Proven three ways: code routing (sampler `model_path` was metadata-only), refit mechanism, and a live probe — logprobs of a fixed sequence through the "frozen" sampler drifted **+70/+156/+263/+367** across 4 training steps (noise floor between identical calls: 0.0000).

## Fixes (all server-side, zero NeMo RL changes)

1. **Sampler version pinning**: handles carry `weight_version` (bumped per optim step); samplers record `pinned_version` at registration; `asample` resolves the requesting sampler and routes v0-pinned `compute_logprobs` to NeMo RL's built-in frozen reference model (`policy.get_reference_policy_logprobs`, batched via `_RefLogprobAccumulator`). `pinned ∉ {0, live}` falls back to live with a loud warning (needs general version-pinned sampling). Miles accepts `pinned_version` but does not honor it yet — same aliasing class, documented.
2. **`TinkerSumCELoss`**: pure-sum cross-entropy per the `forward_backward_custom` contract (`L = Σ(-logprob·weight)`); `NLLLoss` mean-normalizes by `global_valid_toks`, which for the custom-loss path is a sum of gradient coefficients, not a token count.
3. **P4 AdamParams**: full `AdamParams` forwarded service→backend; builder optimizer defaults aligned to the Tinker contract (betas `[0.9, 0.95]`, eps `1e-8`); one-time warning per handle for values the worker cannot apply per-step (worker exposes only `set_learning_rate`).
4. **LoRA all-linear coverage**: `target_modules` now include `gate/up/down_proj` (attention-only under-performs even at matched parameter count; matches hosted semantics). Overridable via `lora_config["target_modules"]`.
5. **`pyproject.toml`**: editable-install `training` so Ray workers can import it by reference (server env still needs `PYTHONPATH=/app` for worker propagation).

## Validation (2xH200, Llama-3.2-1B, hhh DPO, lr=1e-5)

- **Probe**: pinned-sampler drift +367/4-steps (ALIASED) → **bit-identical across steps** (FROZEN; one-time −0.14 vLLM↔DTensor offset).
- **End-to-end** `chosen_reward` @ step 50: broken **0.0049** (flat) → pinning fix **0.0169** (monotone) → +β₂/all-linear **0.0251** → +schedule-matched **0.0595 vs reference 0.0536** — convergence parity (loss 0.682 vs 0.684; accuracy within single-batch noise).

## Caveats for reviewers

- **All-linear LoRA changes effective behavior of every existing nemo_rl LoRA config** — prior recipe baselines are not comparable.
- Pure-sum CE also changes plain-SFT effective LR and logged loss magnitude (previously silently mean-normalized); SFT recipes should be re-baselined.
- Dynamic per-step betas would need a ~2-line upstream NeMo RL setter (`set_optimizer_hyperparams`); until then creation-time defaults + mismatch warning.
