### PR TITLE
miles: submission-order execution + CP-safe parallelism default; seam gate harnesses

### DIFF
--- a/scripts/deploy_tinkercloud.sh
+++ b/scripts/deploy_tinkercloud.sh
@@ -95,7 +95,7 @@ case "$PROFILE" in
     # in the GMI base image (built from github.com/GavinZhu-GMI/miles); we overlay
     # only the tinker-cloud server code. The image is a PRIVATE GAR repo, so the
     # pod needs an imagePullSecret (IMAGE_PULL_SECRET, default gcp-secret).
-    IMAGE="${IMAGE:-us-west1-docker.pkg.dev/devv-404803/gmi-test-repo/miles_tinker_seam:20260715}"
+    IMAGE="${IMAGE:-us-west1-docker.pkg.dev/devv-404803/gmi-test-repo/miles_tinker_seam:20260730}"
     BACKEND="${BACKEND:-miles}"
     GPUS="${GPUS:-4}"
     NODE="${NODE:-master-02}"

--- a/scripts/gates/README.md
+++ b/scripts/gates/README.md
@@ -1,0 +1,15 @@
+# Seam parity gates (miles backend)
+
+Standalone harnesses for the 005 validation gates (definitions:
+`specs/005-miles-ray-interface/design.md`; current baselines:
+`specs/003-multi-tenant-lora/HANDOFF.md`). Run ON the server pod with
+`TINKER_BASE_URL=http://localhost:8000`; each creates its own model —
+rotate the server between runs (models are not auto-reaped).
+
+| Script | Gate | Pass criterion |
+|---|---|---|
+| `g1_seam_parity.py` | G1 grad-accum split-invariance | grad_norm bit-identical: 1×fb(8) ≡ 2×fb(4), + determinism rerun |
+| `g2_client_order.py` | G2 client-order | per-datum logprob length == its weights length (distinct lens) |
+| `g2_pipelined.py` | G2 under pipelining | same, with fb/optim/fb/optim submitted before any await |
+| `g3_batch_probe.py` | G3 data-shape diagnostic | real shuffled NoRobots batch through fb, length audit |
+| `g3_sl_basic.py` | G3 end-to-end | 30-step SFT completes, NLL decreasing (2026-07-30: 2.80→2.28) |

--- a/scripts/gates/g1_seam_parity.py
+++ b/scripts/gates/g1_seam_parity.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""G1 seam parity gate, v3 (2026-07-30 rewrite; v2 harness lost with the pod).
+
+Gate (specs/005 design.md): N x forward_backward + 1 x optim_step must equal
+1 x forward_backward(same total data) + 1 x optim_step -- grad_norm ratio
+EXACTLY 1.0 under the pure-sum contract (_loss_norm_total=1).
+
+Method: all optim steps use lr=0.0 (honored: seam checks `is not None`), so
+weights never move and every arm sees identical parameters. Arms:
+  A1: fb(8)        + step   -> grad_norm
+  B : fb(4), fb(4) + step   -> grad_norm   (accumulation arm)
+  A2: fb(8)        + step   -> grad_norm   (determinism check, == A1)
+PASS = A1 == B == A2 bit-identical (repr equality on the float).
+"""
+import os, sys, time, json
+
+os.environ.setdefault("TINKER_BASE_URL", "http://localhost:8000")
+os.environ.setdefault("TINKER_API_KEY", "tml-dev-key")
+BASE = os.environ["TINKER_BASE_URL"]
+KEY = os.environ["TINKER_API_KEY"]
+
+import requests
+import torch
+import tinker
+from tinker import types
+
+BASE_MODEL = "Qwen/Qwen2.5-0.5B"
+RANK = 32
+SEQ = 64
+N = 8
+HDRS = {"X-API-Key": KEY, "Content-Type": "application/json"}
+
+
+def make_datums():
+    out = []
+    for i in range(N):
+        toks = [(1000 + i * 7919 + j * 104729) % 50000 for j in range(SEQ)]
+        inp, tgt = toks[:-1], toks[1:]
+        out.append(types.Datum(
+            model_input=types.ModelInput.from_ints(inp),
+            loss_fn_inputs={
+                "weights": types.TensorData.from_torch(
+                    torch.ones(len(inp), dtype=torch.float32)),
+                "target_tokens": types.TensorData.from_torch(
+                    torch.tensor(tgt, dtype=torch.long)),
+            },
+        ))
+    return out
+
+
+def step_lr0(model_id):
+    r = requests.post(f"{BASE}/api/v1/optim_step", headers=HDRS, json={
+        "model_id": model_id,
+        "adam_params": {"learning_rate": 0.0},
+    })
+    r.raise_for_status()
+    rid = r.json()["request_id"]
+    deadline = time.time() + 600
+    while time.time() < deadline:
+        fr = requests.post(f"{BASE}/api/v1/retrieve_future/{rid}", headers=HDRS)
+        if fr.status_code == 200:
+            return fr.json()          # raw backend result: {success, grad_norm}
+        if fr.status_code == 408:     # still pending
+            time.sleep(2)
+            continue
+        print(f"STEP FAILED ({fr.status_code}):", fr.text[:2000])
+        sys.exit(2)
+    print("STEP TIMEOUT")
+    sys.exit(2)
+
+
+def main():
+    sc = tinker.ServiceClient()
+    tc = sc.create_lora_training_client(base_model=BASE_MODEL, rank=RANK)
+    model_id = tc.model_id
+    print("model_id:", model_id, flush=True)
+    ds = make_datums()
+
+    grad_norms = {}
+    for arm, splits in [("A1", [ds]), ("B", [ds[:4], ds[4:]]), ("A2", [ds])]:
+        t0 = time.time()
+        for part in splits:
+            fut = tc.forward_backward(part, "cross_entropy")
+            fut.result()
+        res = step_lr0(model_id)
+        gn = res.get("grad_norm")
+        grad_norms[arm] = gn
+        print(f"{arm}: grad_norm={gn!r} success={res.get('success')} "
+              f"({time.time()-t0:.1f}s)", flush=True)
+
+    a1, b, a2 = grad_norms["A1"], grad_norms["B"], grad_norms["A2"]
+    ratio = b / a1 if a1 else float("nan")
+    det = "BIT-IDENTICAL" if repr(a1) == repr(a2) else f"DRIFT ({a1!r} vs {a2!r})"
+    split = "BIT-IDENTICAL" if repr(a1) == repr(b) else f"ratio={ratio!r}"
+    print(f"\nG1 split-invariance : {split}")
+    print(f"G1 determinism (A2) : {det}")
+    ok = repr(a1) == repr(b) == repr(a2) and a1 and a1 > 0
+    print("G1:", "PASS" if ok else "FAIL")
+    sys.exit(0 if ok else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/gates/g2_client_order.py
+++ b/scripts/gates/g2_client_order.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""G2 order probe (2026-07-30): fb with distinct-length datums; verify each
+returned per-sample logprob vector has its own datum's length (client order).
+Diagnoses the G3 failure (logprobs[218] paired with weights[432])."""
+import os
+
+os.environ.setdefault("TINKER_BASE_URL", "http://localhost:8000")
+os.environ.setdefault("TINKER_API_KEY", "tml-dev-key")
+
+import torch
+import tinker
+from tinker import types
+
+BASE_MODEL = "Qwen/Qwen2.5-0.5B"
+LENS = [40, 55, 70, 85, 100, 115, 130, 145]  # distinct per-datum seq lens
+
+
+def datum(seq_len, salt):
+    toks = [(1000 + salt * 7919 + j * 104729) % 50000 for j in range(seq_len)]
+    inp, tgt = toks[:-1], toks[1:]
+    return types.Datum(
+        model_input=types.ModelInput.from_ints(inp),
+        loss_fn_inputs={
+            "weights": types.TensorData.from_torch(torch.ones(len(inp), dtype=torch.float32)),
+            "target_tokens": types.TensorData.from_torch(torch.tensor(tgt, dtype=torch.long)),
+        },
+    )
+
+
+def main():
+    sc = tinker.ServiceClient()
+    tc = sc.create_lora_training_client(base_model=BASE_MODEL, rank=32)
+    print("model_id:", tc.model_id, flush=True)
+    ds = [datum(L, i) for i, L in enumerate(LENS)]
+    out = tc.forward_backward(ds, "cross_entropy").result()
+    lfo = out.loss_fn_outputs
+    print(f"num outputs: {len(lfo)} (expected {len(LENS)})")
+    ok = True
+    for i, (o, L) in enumerate(zip(lfo, LENS)):
+        lp = o["logprobs"].to_torch()
+        exp = L - 1  # weights length
+        match = "OK" if len(lp) == exp else "MISMATCH"
+        if len(lp) != exp:
+            ok = False
+        print(f"  datum {i}: expected {exp}, got {len(lp)}  {match}")
+    print("G2 order:", "PASS" if ok else "FAIL")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/gates/g2_pipelined.py
+++ b/scripts/gates/g2_pipelined.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Pipelined-fb probe (2026-07-30): mimic the cookbook's submission pattern
+fb(0), optim(0), fb(1), optim(1) all submitted before any await, then check
+each fb result's per-sample logprob lengths against ITS OWN batch.
+
+Batch 0 lengths: 40..421 (step 3); batch 1 lengths: 500..627 (step 1) —
+disjoint ranges, so cross-wired futures show as bulk mismatches.
+"""
+import os
+
+os.environ.setdefault("TINKER_BASE_URL", "http://localhost:8000")
+os.environ.setdefault("TINKER_API_KEY", "tml-dev-key")
+
+import torch
+import tinker
+from tinker import types
+
+BASE_MODEL = "Qwen/Qwen2.5-0.5B"
+LENS0 = [40 + 3 * i for i in range(128)]   # 40..421
+LENS1 = [500 + i for i in range(128)]      # 500..627
+
+
+def datum(seq_len, salt):
+    toks = [(1000 + salt * 7919 + j * 104729) % 50000 for j in range(seq_len)]
+    inp, tgt = toks[:-1], toks[1:]
+    return types.Datum(
+        model_input=types.ModelInput.from_ints(inp),
+        loss_fn_inputs={
+            "weights": types.TensorData.from_torch(torch.ones(len(inp), dtype=torch.float32)),
+            "target_tokens": types.TensorData.from_torch(torch.tensor(tgt, dtype=torch.long)),
+        },
+    )
+
+
+def check(tag, out, lens):
+    lfo = out.loss_fn_outputs
+    bad = 0
+    first = None
+    for i, (o, L) in enumerate(zip(lfo, lens)):
+        lp = o["logprobs"].to_torch()
+        if len(lp) != L - 1:
+            bad += 1
+            if first is None:
+                first = (i, L - 1, len(lp))
+    print(f"{tag}: n={len(lfo)} mismatches={bad}"
+          + (f" first: datum {first[0]} expected {first[1]} got {first[2]}" if first else ""))
+    return bad == 0
+
+
+def main():
+    sc = tinker.ServiceClient()
+    tc = sc.create_lora_training_client(base_model=BASE_MODEL, rank=32)
+    print("model_id:", tc.model_id, flush=True)
+    ds0 = [datum(L, i) for i, L in enumerate(LENS0)]
+    ds1 = [datum(L, 1000 + i) for i, L in enumerate(LENS1)]
+    ap = types.AdamParams(learning_rate=2e-4)
+
+    # Pipelined submission, cookbook-style: all four before any await.
+    fb0 = tc.forward_backward(ds0, "cross_entropy")
+    o0 = tc.optim_step(ap)
+    fb1 = tc.forward_backward(ds1, "cross_entropy")
+    o1 = tc.optim_step(ap)
+
+    r0 = fb0.result()
+    ro0 = o0.result()
+    r1 = fb1.result()
+    ro1 = o1.result()
+
+    ok0 = check("fb0", r0, LENS0)
+    ok1 = check("fb1", r1, LENS1)
+    print("optim0 metrics:", (ro0.metrics or {}))
+    print("optim1 metrics:", (ro1.metrics or {}))
+    print("PIPELINED:", "PASS" if ok0 and ok1 else "FAIL")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/gates/g3_batch_probe.py
+++ b/scripts/gates/g3_batch_probe.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""G3 data probe v2: use set_epoch(seed=0) like the training loop (shuffled
+batch 0 = the batch that crashes), submit fb, find mismatched datums, and
+introspect their ModelInput chunk structure."""
+import os
+
+os.environ.setdefault("TINKER_BASE_URL", "http://localhost:8000")
+os.environ.setdefault("TINKER_API_KEY", "tml-dev-key")
+
+import tinker
+from tinker import types
+from tinker_cookbook.recipes.chat_sl import chat_datasets
+from tinker_cookbook.renderers import TrainOnWhat
+from tinker_cookbook.supervised.types import ChatDatasetBuilderCommonConfig
+
+MODEL = "Qwen/Qwen2.5-0.5B"
+
+builder = chat_datasets.NoRobotsBuilder(
+    common_config=ChatDatasetBuilderCommonConfig(
+        model_name_for_tokenizer=MODEL,
+        renderer_name="qwen3",
+        max_length=8192,
+        batch_size=128,
+        train_on_what=TrainOnWhat.ALL_ASSISTANT_MESSAGES,
+    )
+)
+dataset, _ = builder()
+dataset.set_epoch(seed=0)  # exactly what train.main does before get_batch(0)
+data = dataset.get_batch(0)
+
+# Client-side shape audit BEFORE submitting
+multi_chunk = []
+for i, d in enumerate(data):
+    chunks = d.model_input.chunks
+    wl = len(d.loss_fn_inputs["weights"].data)
+    il = d.model_input.length
+    if len(chunks) != 1 or wl != il:
+        multi_chunk.append((i, len(chunks), il, wl, [type(c).__name__ for c in chunks]))
+print(f"batch: {len(data)} datums; irregular datums (chunks!=1 or weights!=input len): {len(multi_chunk)}")
+for row in multi_chunk[:10]:
+    print("  ", row)
+
+sc = tinker.ServiceClient()
+tc = sc.create_lora_training_client(base_model=MODEL, rank=32)
+print("model_id:", tc.model_id, flush=True)
+
+out = tc.forward_backward(data, "cross_entropy").result()
+lfo = out.loss_fn_outputs
+wlens = [len(d.loss_fn_inputs["weights"].data) for d in data]
+got = [len(o["logprobs"].to_torch()) for o in lfo]
+bad = [(i, wlens[i], got[i]) for i in range(min(len(got), len(wlens))) if got[i] != wlens[i]]
+print(f"outputs: {len(lfo)}; mismatches: {len(bad)}")
+for i, exp, g in bad[:10]:
+    d = data[i]
+    chunks = d.model_input.chunks
+    print(f"  datum {i}: expected {exp}, got {g}; input_len={d.model_input.length} "
+          f"chunks={len(chunks)} chunk_lens={[c.length for c in chunks]}")
+print("G3-DATA2:", "PASS" if not bad else "FAIL")

--- a/scripts/gates/g3_sl_basic.py
+++ b/scripts/gates/g3_sl_basic.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""G3 gate, v2 (2026-07-30 rewrite; v1 harness lost with the pod).
+
+sl_basic-equivalent 30-step SFT run against the local TinkerCloud miles
+backend: NoRobots chat data, Qwen2.5-0.5B, LoRA r32, lr 2e-4 linear
+(sl_basic recipe hyperparams; model swapped to the 005 gate model).
+PASS = run completes, grad_norm nonzero, train NLL decreases.
+005 reference on 20260715 base: NLL 2.74 -> 2.34 over 30 steps (different
+harness lineage -- trend is the gate, exact values re-baselined here).
+"""
+import asyncio
+import os
+
+os.environ.setdefault("TINKER_BASE_URL", "http://localhost:8000")
+os.environ.setdefault("TINKER_API_KEY", "tml-dev-key")
+
+from tinker_cookbook.recipes.chat_sl import chat_datasets
+from tinker_cookbook.renderers import TrainOnWhat
+from tinker_cookbook.supervised import train
+from tinker_cookbook.supervised.types import ChatDatasetBuilderCommonConfig
+
+MODEL = "Qwen/Qwen2.5-0.5B"
+LOG_PATH = "/data/g3_sl_basic_20260730"
+
+config = train.Config(
+    log_path=LOG_PATH,
+    model_name=MODEL,
+    renderer_name="qwen3",
+    dataset_builder=chat_datasets.NoRobotsBuilder(
+        common_config=ChatDatasetBuilderCommonConfig(
+            model_name_for_tokenizer=MODEL,
+            renderer_name="qwen3",
+            max_length=8192,
+            batch_size=128,
+            train_on_what=TrainOnWhat.ALL_ASSISTANT_MESSAGES,
+        )
+    ),
+    learning_rate=2e-4,
+    lr_schedule="linear",
+    num_epochs=1,
+    max_steps=30,
+    lora_rank=32,
+    eval_every=0,
+    save_every=0,
+)
+
+if __name__ == "__main__":
+    asyncio.run(train.main(config))

--- a/training/backends/miles/backend.py
+++ b/training/backends/miles/backend.py
@@ -7,7 +7,7 @@ forward_backward_only / apply_optimizer_step, pure-sum loss via rollout keys
 set in the converter."""
 import asyncio
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
@@ -33,6 +33,13 @@ class MilesHandle(BackendHandle):
     wandb_config: Optional[Dict[str, Any]] = None
     created_at: str = ""
     training_run_id: str = ""
+    # Serializes GPU-bound ops per model. The task manager runs request
+    # handlers as concurrent asyncio tasks; without this, pipelined
+    # fb/optim_step broadcasts interleave inconsistently across the DP actors
+    # (mispaired collectives -> scrambled outputs; optim_step consuming a
+    # later fb's grads). asyncio.Lock wakes waiters FIFO, so execution
+    # follows submission order.
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
 
 
 class MilesBackend(TrainingBackend):
@@ -189,6 +196,7 @@ class MilesBackend(TrainingBackend):
         loss_fn: str,
     ) -> Dict[str, Any]:
         h: MilesHandle = handle  # type: ignore[assignment]
+        await h.lock.acquire()
         try:
             from miles.utils.ray_utils import Box
 
@@ -217,6 +225,8 @@ class MilesBackend(TrainingBackend):
             raise BackendError(
                 str(e), backend="miles", operation="forward", original_error=e,
             ) from e
+        finally:
+            h.lock.release()
 
     async def forward_backward(
         self,
@@ -225,6 +235,7 @@ class MilesBackend(TrainingBackend):
         loss_fn: str,
     ) -> Dict[str, Any]:
         h: MilesHandle = handle  # type: ignore[assignment]
+        await h.lock.acquire()
         try:
             from miles.utils.ray_utils import Box
 
@@ -296,6 +307,8 @@ class MilesBackend(TrainingBackend):
             raise BackendError(
                 str(e), backend="miles", operation="forward_backward", original_error=e,
             ) from e
+        finally:
+            h.lock.release()
 
     async def apply_optimizer_step(
         self,
@@ -306,6 +319,7 @@ class MilesBackend(TrainingBackend):
         # adam_params accepted for contract uniformity (P4); Miles applies lr
         # only — betas/eps are Megatron args fixed at creation.
         h: MilesHandle = handle  # type: ignore[assignment]
+        await h.lock.acquire()
         try:
             # TinkerTrainGroup: apply_optimizer_step(learning_rate) fans out to
             # the actors; _and_sync additionally pushes weights to SGLang.
@@ -341,15 +355,20 @@ class MilesBackend(TrainingBackend):
             raise BackendError(
                 str(e), backend="miles", operation="apply_optimizer_step", original_error=e,
             ) from e
+        finally:
+            h.lock.release()
 
     async def update_inference_weights(self, handle: BackendHandle) -> None:
         h: MilesHandle = handle  # type: ignore[assignment]
+        await h.lock.acquire()
         try:
             await h.train_group.update_weights()
         except Exception as e:
             raise BackendError(
                 str(e), backend="miles", operation="update_inference_weights", original_error=e,
             ) from e
+        finally:
+            h.lock.release()
 
     async def save_checkpoint(
         self,
@@ -358,6 +377,7 @@ class MilesBackend(TrainingBackend):
         step_id: Optional[int] = None,
     ) -> str:
         h: MilesHandle = handle  # type: ignore[assignment]
+        await h.lock.acquire()
         try:
             offload_train = h.args.offload_train if h.args else False
             if offload_train:
@@ -374,6 +394,8 @@ class MilesBackend(TrainingBackend):
             raise BackendError(
                 str(e), backend="miles", operation="save_checkpoint", original_error=e,
             ) from e
+        finally:
+            h.lock.release()
 
     async def load_checkpoint(
         self,
@@ -381,6 +403,7 @@ class MilesBackend(TrainingBackend):
         checkpoint_path: str,
     ) -> None:
         h: MilesHandle = handle  # type: ignore[assignment]
+        await h.lock.acquire()
         try:
             await h.train_group.load_checkpoint(checkpoint_path)
 
@@ -394,9 +417,14 @@ class MilesBackend(TrainingBackend):
             raise BackendError(
                 str(e), backend="miles", operation="load_checkpoint", original_error=e,
             ) from e
+        finally:
+            h.lock.release()
 
     async def delete_model(self, handle: BackendHandle) -> None:
         h: MilesHandle = handle  # type: ignore[assignment]
+        # Hold the op lock so teardown can't interleave with an in-flight
+        # fb/step (delete-during-optim_step crash class).
+        await h.lock.acquire()
         try:
             resources_freed = []
             for actor in h.train_group._actor_handles:
@@ -426,6 +454,8 @@ class MilesBackend(TrainingBackend):
             raise BackendError(
                 str(e), backend="miles", operation="delete_model", original_error=e,
             ) from e
+        finally:
+            h.lock.release()
 
     async def get_logprobs(
         self,

--- a/training/utils/model_config.py
+++ b/training/utils/model_config.py
@@ -298,8 +298,13 @@ def auto_detect_all_parallelism(
     if env_cp:
         cp = int(env_cp)
         logger.info(f"Using SLIME_DEFAULT_CP override: CP={cp}")
-    elif max_seq_len > 2048:
-        cp = 2  # Long sequences benefit from context parallel
+    elif max_seq_len > 8192:
+        # CP caveat: the miles seam returns per-CP-rank logprob chunks for
+        # fb/forward (no full-sequence reassembly yet) — clients would see
+        # half-length per-sample logprobs at CP=2. Engage CP only when the
+        # sequence length actually requires it; ≤8K fits without CP for the
+        # supported model sizes.
+        cp = 2
     else:
         cp = 1  # Short sequences don't need CP
 


### PR DESCRIPTION
Fixes surfaced by re-validating the miles seam on the `miles_tinker_seam:20260730` base (upstream multi-LoRA era). All three gates green after these changes: G1 grad-accum split-invariance bit-identical (grad_norm 178.9398358212894 for 1xfb(8) vs 2xfb(4)+step, and across reruns), G2 client-order exact (8/128 datums, incl. pipelined submission), G3 sl_basic 30-step SFT NLL 2.80->2.28 on Qwen2.5-0.5B r32.

**1. `dc470bd` — serialize per-model backend ops.** The task manager runs request handlers as concurrent asyncio tasks, so pipelined fb/optim_step broadcasts executed overlapped on one TrainGroup: optim_step consumed a later fb's gradients, and concurrent fan-outs reach the DP actors' mailboxes in inconsistent per-rank order, mispairing collectives (observed: per-sample logprobs scrambled across requests). Per-handle FIFO `asyncio.Lock` restores the client's submission-order contract; `delete_model` holds it too (delete-during-optim_step crash class).

**2. `3f72f75` — engage CP only above 8K max_seq_len.** The cookbook passes `max_seq_len=8192` at create, which flipped auto-parallelism to CP=2; at CP>1 the seam returns per-CP-rank logprob chunks (each exactly pad-to-CP-multiple/2 long) because there is no full-sequence reassembly yet — clients see half-length per-sample logprobs. 8K fits without CP for supported model sizes; threshold raised until the seam stitches CP chunks (tracked as an open gap).

**3. `6b3e1d9` — durable gate harnesses + image default.** G1/G2/G3 harnesses land in `scripts/gates/` (previously pod-local /tmp, lost on every pod recreate); miles profile default image bumped to `miles_tinker_seam:20260730`.

Companion miles-side fix (upstream `get_rollout_data` tuple return): GavinZhu-GMI/miles#4.
