### PR TITLE
miles backend: multi-LoRA pool mode (M1 — single tenant on pool rails)

### DIFF
--- a/training/backends/miles/backend.py
+++ b/training/backends/miles/backend.py
@@ -33,6 +33,11 @@ class MilesHandle(BackendHandle):
     wandb_config: Optional[Dict[str, Any]] = None
     created_at: str = ""
     training_run_id: str = ""
+    # Multi-LoRA pool mode (TINKERCLOUD_MILES_MULTILORA_SLOTS): this model is
+    # an adapter slot on shared rails rather than a dedicated full model.
+    controller: Any = None            # MultiLoRAController (named Ray actor)
+    adapter_name: Optional[str] = None
+    adapter_slot: Optional[int] = None
     # Serializes GPU-bound ops per model. The task manager runs request
     # handlers as concurrent asyncio tasks; without this, pipelined
     # fb/optim_step broadcasts interleave inconsistently across the DP actors
@@ -119,12 +124,48 @@ class MilesBackend(TrainingBackend):
             # the event loop or /retrieve_future polls stall and clients time out.
             pgs = await asyncio.to_thread(create_placement_groups, args)
 
+            multi_lora = bool(getattr(args, "multi_lora", False))
+            if multi_lora and debug_train_only:
+                raise BackendError(
+                    "Multi-LoRA pool mode requires rollout engines (adapter "
+                    "weight push targets SGLang); debug_train_only unsupported",
+                    backend="miles", operation="create_model",
+                )
+
             rollout_manager = None
             router_ip = None
             router_port = None
             if not debug_train_only:
                 rollout_manager, _ = await asyncio.to_thread(
                     create_rollout_manager, args, pgs["rollout"]
+                )
+
+            controller = None
+            adapter_name = None
+            adapter_slot = None
+            if multi_lora:
+                # Mirror the upstream driver boot: router -> controller
+                # (named actor; reconcile on the actors resolves it by name).
+                from miles.ray.multi_lora.controller import create_multilora_controller
+                from miles.utils.adapter_config import TinkerAdapterConfig
+                import re
+
+                router_ip, router_port = await rollout_manager.get_router_address.remote()
+                args.sglang_router_ip, args.sglang_router_port = router_ip, router_port
+                controller = create_multilora_controller(
+                    args, f"http://{router_ip}:{router_port}"
+                )
+                await controller.start.remote()
+
+                adapter_name = re.sub(r"[^A-Za-z0-9._-]", "-", model_id)
+                registration = await controller.register_adapter.remote(
+                    adapter_name,
+                    TinkerAdapterConfig(rank=args.lora_rank, alpha=args.lora_alpha),
+                )
+                adapter_slot = registration["slot"]
+                logger.info(
+                    "[%s] Multi-LoRA pool: adapter %s -> slot %d",
+                    request_id, adapter_name, adapter_slot,
                 )
 
             train_group = await asyncio.to_thread(lambda: TinkerTrainGroup(
@@ -149,6 +190,11 @@ class MilesBackend(TrainingBackend):
 
             if rollout_manager is not None:
                 await train_group.set_rollout_manager()
+
+                # Pool mode: load the registered adapter into its slot before
+                # the initial push (LoRA B=0 => zero-delta; PENDING->ACTIVE).
+                if multi_lora:
+                    await train_group.reconcile_adapters()
 
                 # Mirror upstream train.py startup: load weights into SGLang
                 # before anything samples, honoring rollout offload state.
@@ -177,6 +223,9 @@ class MilesBackend(TrainingBackend):
                 wandb_config=wandb_config,
                 created_at=datetime.now().isoformat(),
                 training_run_id=model_id,
+                controller=controller,
+                adapter_name=adapter_name,
+                adapter_slot=adapter_slot,
             )
 
             logger.info("[%s] Miles model %s created successfully", request_id, model_id)
@@ -203,7 +252,7 @@ class MilesBackend(TrainingBackend):
             if h.rollout_manager is not None and h.args.offload_rollout:
                 await h.rollout_manager.offload.remote()
 
-            rollout_data = self.converter.forward_to_backend(data, h.args)
+            rollout_data = self.converter.forward_to_backend(data, h.args, adapter_slot=h.adapter_slot)
             # TinkerTrainGroup returns per-sample logprob tensors already
             # merged into the client's submission order.
             logprobs = await h.train_group.forward_logprobs(0, Box(ray.put(rollout_data)))
@@ -260,7 +309,7 @@ class MilesBackend(TrainingBackend):
                 )
 
             rollout_data = self.converter.forward_backward_to_backend(
-                data, loss_fn, h.args,
+                data, loss_fn, h.args, adapter_slot=h.adapter_slot,
             )
 
             results = await h.train_group.forward_backward_only(0, Box(ray.put(rollout_data)))
@@ -326,12 +375,15 @@ class MilesBackend(TrainingBackend):
             offload_train = h.args.offload_train if h.args else True
             offload_rollout = h.args.offload_rollout if h.args else True
 
+            step_kwargs = {"adapter_slot": h.adapter_slot, "adapter_name": h.adapter_name}
             if h.rollout_manager is None:
-                results = await h.train_group.apply_optimizer_step(learning_rate)
+                results = await h.train_group.apply_optimizer_step(learning_rate, **step_kwargs)
             elif not offload_train and not offload_rollout:
-                results = await h.train_group.apply_optimizer_step_and_sync(learning_rate)
+                # Pool mode rides this arm: the sync pushes exactly the stepped
+                # adapter (per-adapter upsert via the pending set).
+                results = await h.train_group.apply_optimizer_step_and_sync(learning_rate, **step_kwargs)
             else:
-                results = await h.train_group.apply_optimizer_step(learning_rate)
+                results = await h.train_group.apply_optimizer_step(learning_rate, **step_kwargs)
 
                 # Mirror upstream train.py's offload dance around weight sync.
                 if offload_train:
@@ -427,6 +479,17 @@ class MilesBackend(TrainingBackend):
         await h.lock.acquire()
         try:
             resources_freed = []
+            # Pool mode: the pool dies with this model (M1: one tenant per
+            # pool). Kill the named controller so the next create_model can
+            # register a fresh one.
+            if h.controller is not None:
+                try:
+                    await h.controller.stop.remote()
+                except Exception:
+                    logger.warning("Multi-LoRA controller stop failed; killing", exc_info=True)
+                ray.kill(h.controller, no_restart=True)
+                resources_freed.append("multi_lora_controller")
+
             for actor in h.train_group._actor_handles:
                 ray.kill(actor, no_restart=True)
                 resources_freed.append("actor")
@@ -497,6 +560,14 @@ class MilesBackend(TrainingBackend):
             )
         client = SGLangClient(base_url=f"http://{h.router_ip}:{h.router_port}")
 
+        # Pool mode: route to this model's adapter by engine-side slot name.
+        # (pinned v0 -> base routing not wired yet; see 003 R6.)
+        lora_path = None
+        if h.adapter_slot is not None:
+            from miles.utils.multi_lora import slot_lora_name
+
+            lora_path = slot_lora_name(h.adapter_slot)
+
         sequences = []
         prompt_logprobs_result = None
         for _ in range(num_samples):
@@ -504,6 +575,7 @@ class MilesBackend(TrainingBackend):
                 input_ids=prompt_tokens,
                 sampling_params=sampling_params or {},
                 prompt_logprobs=prompt_logprobs,
+                lora_path=lora_path,
             )
             sequences.append({
                 "tokens": result["tokens"],

--- a/training/backends/miles/backend.py
+++ b/training/backends/miles/backend.py
@@ -96,6 +96,7 @@ class MilesBackend(TrainingBackend):
                 f"requires a classification backend (automodel / megatron_bridge)",
                 backend="miles", operation="create_model",
             )
+        _cleanup: Dict[str, Any] = {}
         try:
             logger.info("[%s] Creating Miles model %s", request_id, model_id)
 
@@ -123,6 +124,9 @@ class MilesBackend(TrainingBackend):
             # Sync ray calls (pg.ready waits, actor allocation) — keep them off
             # the event loop or /retrieve_future polls stall and clients time out.
             pgs = await asyncio.to_thread(create_placement_groups, args)
+            # Failure past PG creation must not orphan GPU reservations
+            # (orphaned PGs starve every later create_model until a rotation).
+            _cleanup["pgs"] = pgs
 
             multi_lora = bool(getattr(args, "multi_lora", False))
             if multi_lora and debug_train_only:
@@ -139,6 +143,7 @@ class MilesBackend(TrainingBackend):
                 rollout_manager, _ = await asyncio.to_thread(
                     create_rollout_manager, args, pgs["rollout"]
                 )
+                _cleanup["rollout_manager"] = rollout_manager
 
             controller = None
             adapter_name = None
@@ -155,6 +160,7 @@ class MilesBackend(TrainingBackend):
                 controller = create_multilora_controller(
                     args, f"http://{router_ip}:{router_port}"
                 )
+                _cleanup["controller"] = controller
                 await controller.start.remote()
 
                 adapter_name = re.sub(r"[^A-Za-z0-9._-]", "-", model_id)
@@ -178,6 +184,7 @@ class MilesBackend(TrainingBackend):
                 with_ref=False,
                 rollout_manager=rollout_manager,
             ))
+            _cleanup["train_group"] = train_group
 
             try:
                 await asyncio.wait_for(train_group.init(), timeout=1800.0)
@@ -232,11 +239,43 @@ class MilesBackend(TrainingBackend):
             return handle
 
         except BackendError:
+            await asyncio.to_thread(self._teardown_partial, _cleanup)
             raise
         except Exception as e:
+            await asyncio.to_thread(self._teardown_partial, _cleanup)
             raise BackendError(
                 str(e), backend="miles", operation="create_model", original_error=e,
             ) from e
+
+    @staticmethod
+    def _teardown_partial(cleanup: Dict[str, Any]) -> None:
+        """Best-effort release of partially-booted resources (create_model
+        failure path). PG removal also reaps actors placed in them."""
+        train_group = cleanup.get("train_group")
+        if train_group is not None:
+            for actor in getattr(train_group, "_actor_handles", None) or []:
+                try:
+                    ray.kill(actor, no_restart=True)
+                except Exception:
+                    pass
+        for key in ("rollout_manager", "controller"):
+            actor = cleanup.get(key)
+            if actor is not None:
+                try:
+                    ray.kill(actor, no_restart=True)
+                except Exception:
+                    pass
+        seen = set()
+        for pg_tuple in (cleanup.get("pgs") or {}).values():
+            pg_obj = pg_tuple[0] if isinstance(pg_tuple, tuple) else pg_tuple
+            if pg_obj is not None and id(pg_obj) not in seen:
+                seen.add(id(pg_obj))
+                try:
+                    ray.util.remove_placement_group(pg_obj)
+                except Exception:
+                    pass
+        if cleanup:
+            logger.info("create_model failure teardown: released %s", sorted(cleanup))
 
     async def forward(
         self,

--- a/training/backends/miles/converter.py
+++ b/training/backends/miles/converter.py
@@ -21,10 +21,11 @@ class MilesDataConverter(DataConverter):
         self,
         data: List[Dict],
         args: Any,
+        adapter_slot: Any = None,
     ) -> Any:
         """Convert Tinker data to Miles rollout_data for forward pass."""
         rollout_data = self._inner.forward_to_rollout(data)
-        self._add_tinker_seam_keys(rollout_data, len(data))
+        self._add_tinker_seam_keys(rollout_data, len(data), adapter_slot=adapter_slot)
         return rollout_data
 
     def forward_backward_to_backend(
@@ -32,11 +33,12 @@ class MilesDataConverter(DataConverter):
         data: List[Dict],
         loss_fn: str,
         args: Any,
+        adapter_slot: Any = None,
     ) -> Any:
         """Convert Tinker data to Miles rollout_data for training."""
         is_rl = not getattr(args, "debug_train_only", False)
         rollout_data = self._inner.forward_backward_to_rollout(data, is_rl=is_rl)
-        self._add_tinker_seam_keys(rollout_data, len(data))
+        self._add_tinker_seam_keys(rollout_data, len(data), adapter_slot=adapter_slot)
         # Per-request loss selection (upstream dispatches on args.loss_type at
         # startup; the seam overrides per batch). The inner converter already
         # sets sft_loss when it detects SFT-shaped data — don't override that.
@@ -47,16 +49,20 @@ class MilesDataConverter(DataConverter):
         return rollout_data
 
     @staticmethod
-    def _add_tinker_seam_keys(rollout_data: Any, num_samples: int) -> None:
+    def _add_tinker_seam_keys(rollout_data: Any, num_samples: int, adapter_slot: Any = None) -> None:
         """Keys the tinker-seam miles branch consumes.
 
         - dynamic_global_batch_size: actual request size, so upstream
           get_data_iterator schedules correctly for variable batches.
         - _loss_norm_total=1: pure-sum gradients — invariant to how a logical
           batch is split across forward_backward calls (G1 contract).
+        - adapter_slots (pool mode): route every sample of this request to the
+          model's slot; the shard converter injects n_adapters from args.
         """
         rollout_data["dynamic_global_batch_size"] = num_samples
         rollout_data["_loss_norm_total"] = 1
+        if adapter_slot is not None:
+            rollout_data["adapter_slots"] = [adapter_slot] * num_samples
 
     def backend_to_forward_result(
         self,

--- a/training/core/slime_builder.py
+++ b/training/core/slime_builder.py
@@ -82,6 +82,24 @@ class SlimeArgumentBuilder:
         if parallelism_config:
             num_gpus = parallelism_config.get("num_gpus", num_gpus)
 
+        # Multi-LoRA pool mode (explicit opt-in, Constitution P3). Requires a
+        # LoRA model; boots disaggregated (train/rollout GPUs split — upstream
+        # bans colocate+offload with multi-LoRA).
+        multi_lora_slots = int(os.environ.get("TINKERCLOUD_MILES_MULTILORA_SLOTS", "0") or 0)
+        if multi_lora_slots > 0 and not (lora_config and lora_config.get("rank", 0) > 0):
+            logger.info("Multi-LoRA pool disabled for this model: no LoRA rank in lora_config")
+            multi_lora_slots = 0
+        if multi_lora_slots > 0 and rlve_enabled:
+            raise ValueError("Multi-LoRA pool mode does not support RLVE")
+        rollout_gpus = 0
+        if multi_lora_slots > 0:
+            train_gpus = int(os.environ.get("TINKERCLOUD_MILES_TRAIN_GPUS", "0") or 0) or max(num_gpus // 2, 1)
+            rollout_gpus = num_gpus - train_gpus
+            assert rollout_gpus > 0, (
+                f"Multi-LoRA needs disaggregated rollout GPUs: total={num_gpus}, train={train_gpus}"
+            )
+            num_gpus = train_gpus  # parallelism + actor sizing below see train GPUs only
+
         # Get max sequence length for CP decision
         # Use parameter value (from tinker-cookbook), but allow rlve_config to override for RLVE mode
         if rlve_config and rlve_config.get('rollout_max_response_len'):
@@ -113,7 +131,9 @@ class SlimeArgumentBuilder:
         minimal_args = self._build_minimal_args(
             hf_model_path, model_config, tp_size, pp_size, cp_size, megatron_checkpoint_path, max_batch_size,
             num_gpus=num_gpus,
-            rlve_config=rlve_config
+            rlve_config=rlve_config,
+            multi_lora_slots=multi_lora_slots,
+            lora_config=lora_config,
         )
 
         # Parse args to get Slime defaults
@@ -130,7 +150,9 @@ class SlimeArgumentBuilder:
             model_config,
             parallel_config,
             rlve_config=rlve_config,
-            wandb_config=wandb_config
+            wandb_config=wandb_config,
+            multi_lora_slots=multi_lora_slots,
+            rollout_gpus=rollout_gpus,
         )
 
         return args, hf_model_path
@@ -145,7 +167,9 @@ class SlimeArgumentBuilder:
         megatron_checkpoint_path: str,
         max_batch_size: int = 4096,
         num_gpus: int = 4,
-        rlve_config: Optional[Dict[str, Any]] = None
+        rlve_config: Optional[Dict[str, Any]] = None,
+        multi_lora_slots: int = 0,
+        lora_config: Optional[Dict[str, Any]] = None,
     ) -> list:
         """Build minimal CLI arguments for Slime's parse_args."""
         # Check if RLVE mode is enabled
@@ -212,11 +236,29 @@ class SlimeArgumentBuilder:
             '--ref-load', megatron_checkpoint_path,
             '--save', self.default_save_dir,
             '--save-interval', '20000',  # ~100 batches (each batch ~200 microbatches)
+        ]
+
+        if multi_lora_slots > 0:
+            # Multi-LoRA pool: validate_multi_lora_args runs inside parse_args
+            # and needs the LoRA surface at parse time; it also bans
+            # colocate/offload (disaggregated boot) and forces the multi-LoRA
+            # rollout fn / data source / dynamic GBS.
+            rank = lora_config.get("rank", 32) if lora_config else 32
+            alpha = (lora_config.get("alpha") or rank) if lora_config else rank
+            minimal_args.extend([
+                '--multi-lora-n-adapters', str(multi_lora_slots),
+                '--lora-rank', str(rank),
+                '--lora-alpha', str(alpha),
+                '--target-modules', 'all-linear',
+                '--qkv-format', 'thd',
+            ])
+        else:
             # Memory management: colocate SGLang with Megatron, enable offload
             # These MUST be set here because parse_args() sets defaults based on them
-            '--colocate',
-            '--offload',  # Equivalent to --offload-train + --offload-rollout
-        ]
+            minimal_args.extend([
+                '--colocate',
+                '--offload',  # Equivalent to --offload-train + --offload-rollout
+            ])
 
         # Add kv-channels if model has explicit head_dim (e.g., Qwen3)
         if model_config.get('kv_channels'):
@@ -303,7 +345,9 @@ class SlimeArgumentBuilder:
         model_config: Dict[str, Any],
         parallel_config: Dict[str, int],
         rlve_config: Optional[Dict[str, Any]] = None,
-        wandb_config: Optional[Dict[str, Any]] = None
+        wandb_config: Optional[Dict[str, Any]] = None,
+        multi_lora_slots: int = 0,
+        rollout_gpus: int = 0,
     ) -> Namespace:
         """Configure model-specific argument overrides."""
         # Check if RLVE mode is enabled
@@ -410,11 +454,11 @@ class SlimeArgumentBuilder:
         args.max_tokens_per_gpu = 4096
 
         # Features
-        args.colocate = True
+        args.colocate = multi_lora_slots == 0
         args.move_rl_fields_to_gpu = True
 
         # Rollout/SGLang configuration
-        args.rollout_num_gpus = 4
+        args.rollout_num_gpus = rollout_gpus if multi_lora_slots > 0 else 4
         args.rollout_num_gpus_per_engine = 1
         args.sglang_router_ip = None
         args.sglang_router_port = None
@@ -431,14 +475,20 @@ class SlimeArgumentBuilder:
         args.debug_train_only = debug_train_only
         args.sglang_mem_fraction_static = compute_sglang_mem_fraction(model_config, base_model)
 
-        # Rollout function paths
-        args.rollout_function_path = "miles.rollout.sglang_rollout.generate_rollout"
-        args.eval_function_path = "miles.rollout.sglang_rollout.generate_rollout"
+        # Rollout function paths. Pool mode keeps the multi-LoRA pair that
+        # validate_multi_lora_args swapped in during parse (never driven by
+        # TinkerCloud, but reset here would break reconcile-time wiring).
+        if multi_lora_slots == 0:
+            args.rollout_function_path = "miles.rollout.sglang_rollout.generate_rollout"
+            args.eval_function_path = "miles.rollout.sglang_rollout.generate_rollout"
 
         # No server-side prompt dataset: Tinker clients drive all training and
         # sampling data, so RolloutManager must not load one (its data source
-        # raises if the file is missing).
-        args.rollout_global_dataset = False
+        # raises if the file is missing). (Pool mode: validate forces True —
+        # the per-adapter data source is controller-global; it loads nothing
+        # for Tinker adapters.)
+        if multi_lora_slots == 0:
+            args.rollout_global_dataset = False
         args.prompt_data = "/data/datasets/gsm8k_rl.jsonl"
         args.rollout_shuffle = False
         args.rollout_max_prompt_len = 2048

--- a/training/utils/sglang_client.py
+++ b/training/utils/sglang_client.py
@@ -38,7 +38,8 @@ class SGLangClient:
         self,
         input_ids: List[int],
         sampling_params: Optional[Dict[str, Any]] = None,
-        prompt_logprobs: bool = False
+        prompt_logprobs: bool = False,
+        lora_path: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         Generate text completion from SGLang.
@@ -75,10 +76,14 @@ class SGLangClient:
             "return_logprob": True,
         }
 
+        # Multi-LoRA pool: route to the model's adapter (engine-side slot name).
+        if lora_path is not None:
+            payload["lora_path"] = lora_path
+
         # Request prompt logprobs if needed
         if prompt_logprobs:
             payload["logprob_start_len"] = 0
-            logger.debug(f"Requesting prompt logprobs from SGLang")
+            logger.debug("Requesting prompt logprobs from SGLang")
 
         # Make async HTTP request
         async with httpx.AsyncClient() as client:


### PR DESCRIPTION
## What

Opt-in multi-LoRA pool mode for the miles backend: a Tinker model becomes an adapter slot on shared rails instead of a dedicated full model. Explicit config per Constitution P3 — `TINKERCLOUD_MILES_MULTILORA_SLOTS=<K>` (off by default), `TINKERCLOUD_MILES_TRAIN_GPUS` for the train/rollout split (default half).

- **Builder**: pool mode passes the LoRA surface at parse time (validate_multi_lora_args runs inside parse_args and configures the multi-LoRA rollout fn / data source / dynamic GBS), boots disaggregated (no colocate/offload — upstream bans both with multi-LoRA), and keeps the parse-time multi-LoRA function paths.
- **create_model**: mirrors the upstream driver boot — router → controller (named actor) → `register_adapter` (duck-typed `TinkerAdapterConfig`) → `reconcile_adapters` → initial push (LoRA B=0 ⇒ zero-delta, PENDING→ACTIVE). Failure past PG creation now tears down partially-booted resources (orphaned PGs starved every later create_model until a server rotation).
- **fb/forward**: converter stamps per-request `adapter_slots`; the shard converter injects `n_adapters`.
- **optim_step**: steps exactly the model's slot (`apply_optimizer_step(adapter_slot, adapter_name)`) and syncs that adapter only — per-adapter delta upsert replaces full-weight refit.
- **sample**: routes `lora_path=slot_lora_name(slot)` per request (pinned-v0→base routing is a follow-up).
- **delete_model**: kills the pool controller (frees the actor name), actors, and PGs; verified a second pool boots cleanly after.

## Validation (tinkercloud-miles pod, 2 train GPUs DP2 + 2 lora-enabled SGLang engines)

- G1: grad_norm 252.10936676867047 bit-identical across 1xfb(8)+step ≡ 2xfb(4)+accum+step ≡ rerun.
- G3: sl_basic 30-step SFT, NLL 2.80→2.26 (single-LoRA seam baseline 2.80→2.28), per-adapter weight push after every optim step, final checkpoint saved.
- Both gate pools deleted via API; GPUs and placement groups fully released.

Depends on miles `tinker-multilora-m1` (GavinZhu-GMI/miles#5) and, for pod recreates until the next image bake, a Megatron-Bridge `hide_adapters` guard (site-packages patch documented in the deploy notes).
