### PR TITLE
scripts: miles image default -> :20260730a (Bridge hide_adapters fix baked)

### DIFF
--- a/scripts/deploy_tinkercloud.sh
+++ b/scripts/deploy_tinkercloud.sh
@@ -95,7 +95,7 @@ case "$PROFILE" in
     # in the GMI base image (built from github.com/GavinZhu-GMI/miles); we overlay
     # only the tinker-cloud server code. The image is a PRIVATE GAR repo, so the
     # pod needs an imagePullSecret (IMAGE_PULL_SECRET, default gcp-secret).
-    IMAGE="${IMAGE:-us-west1-docker.pkg.dev/devv-404803/gmi-test-repo/miles_tinker_seam:20260730}"
+    IMAGE="${IMAGE:-us-west1-docker.pkg.dev/devv-404803/gmi-test-repo/miles_tinker_seam:20260730a}"
     BACKEND="${BACKEND:-miles}"
     GPUS="${GPUS:-4}"
     NODE="${NODE:-master-02}"


### PR DESCRIPTION
Bumps the miles profile default image to miles_tinker_seam:20260730a, which
bakes Megatron-Bridge from GavinZhu-GMI/Megatron-Bridge@abeec217 (upstream
bridge tip 7f0fb345 + getattr guards in MultiLoRALinear state dicts, so
hide_adapters() survives torch_dist base loads). Removes the need for the
manual site-packages patch after every pod recreate.

Image pushed to GAR; contents otherwise identical to :20260730 (layer-cache
rebuild from the Bridge layer only), miles tree at 24b98bd32.