### PR TITLE
miles backend: multi-LoRA pool reuse (M2 — N tenants, serialized train calls)

### DIFF
--- a/scripts/gates/README.md
+++ b/scripts/gates/README.md
@@ -13,3 +13,8 @@ rotate the server between runs (models are not auto-reaped).
 | `g2_pipelined.py` | G2 under pipelining | same, with fb/optim/fb/optim submitted before any await |
 | `g3_batch_probe.py` | G3 data-shape diagnostic | real shuffled NoRobots batch through fb, length audit |
 | `g3_sl_basic.py` | G3 end-to-end | 30-step SFT completes, NLL decreasing (2026-07-30: 2.80→2.28) |
+| `g4_pool_isolation.py` | G4 pool isolation (M2) | 2 tenants, 1 pool: join fast; B's pinned probe bit-stable across A's steps; interleaved ≡ serialized; A bit-equal after B's delete |
+
+G4 needs a pool-mode server (`TINKERCLOUD_MILES_MULTILORA_SLOTS>0`). The
+per-tenant E₂ gate is two `g3_sl_basic.py` runs launched concurrently
+against the same pool-mode server (each creates its own tenant).

--- a/scripts/gates/g3_sl_basic.py
+++ b/scripts/gates/g3_sl_basic.py
@@ -20,7 +20,9 @@ from tinker_cookbook.supervised import train
 from tinker_cookbook.supervised.types import ChatDatasetBuilderCommonConfig
 
 MODEL = "Qwen/Qwen2.5-0.5B"
-LOG_PATH = "/data/g3_sl_basic_20260730"
+# Env-overridable so two instances can run concurrently against a pool-mode
+# server (the M2 per-tenant E2 gate).
+LOG_PATH = os.environ.get("G3_LOG_PATH", "/data/g3_sl_basic_20260730")
 
 config = train.Config(
     log_path=LOG_PATH,

--- a/scripts/gates/g4_pool_isolation.py
+++ b/scripts/gates/g4_pool_isolation.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""G4 pool isolation gate (M2): two tenants on ONE multi-LoRA pool; tenant A
+training must not disturb tenant B's observables.
+
+Server must be booted in pool mode (TINKERCLOUD_MILES_MULTILORA_SLOTS>0).
+Phases, all through the public API:
+  P1 join      : create A then B — B's create must JOIN A's pool (no boot)
+  P2 isolation : B's probe logprobs + grad_norm bit-stable across A's REAL
+                 steps (the BUG-015 pinned-probe monitor, cross-tenant)
+  P3 interleave: fb(A),fb(B),step(A),fb(B),step(B) pipelined == serialized
+                 per-tenant grad_norms (R2(ii) through the API; lr=0)
+  P4 survive   : delete B; A's probe grad_norm still bit-equal (slot cleanup
+                 does not disturb the co-tenant)
+PASS = every comparison bit-identical (repr equality on floats/lists).
+"""
+import os, sys, time
+
+os.environ.setdefault("TINKER_BASE_URL", "http://localhost:8000")
+os.environ.setdefault("TINKER_API_KEY", "tml-dev-key")
+BASE = os.environ["TINKER_BASE_URL"]
+KEY = os.environ["TINKER_API_KEY"]
+
+import requests
+import torch
+import tinker
+from tinker import types
+
+BASE_MODEL = "Qwen/Qwen2.5-0.5B"
+RANK = 32
+SEQ = 64
+HDRS = {"X-API-Key": KEY, "Content-Type": "application/json"}
+FAILS = []
+
+
+def check(name, ok, detail=""):
+    print(f"  {name}: {'PASS' if ok else 'FAIL'}{' ' + detail if detail else ''}", flush=True)
+    if not ok:
+        FAILS.append(name)
+
+
+def make_datums(n, salt):
+    out = []
+    for i in range(n):
+        toks = [(1000 + (salt * 31 + i) * 7919 + j * 104729) % 50000 for j in range(SEQ)]
+        inp, tgt = toks[:-1], toks[1:]
+        out.append(types.Datum(
+            model_input=types.ModelInput.from_ints(inp),
+            loss_fn_inputs={
+                "weights": types.TensorData.from_torch(
+                    torch.ones(len(inp), dtype=torch.float32)),
+                "target_tokens": types.TensorData.from_torch(
+                    torch.tensor(tgt, dtype=torch.long)),
+            },
+        ))
+    return out
+
+
+def submit_step(model_id, lr):
+    r = requests.post(f"{BASE}/api/v1/optim_step", headers=HDRS, json={
+        "model_id": model_id,
+        "adam_params": {"learning_rate": lr},
+    })
+    r.raise_for_status()
+    return r.json()["request_id"]
+
+
+def await_future(rid, timeout=600):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        fr = requests.post(f"{BASE}/api/v1/retrieve_future/{rid}", headers=HDRS)
+        if fr.status_code == 200:
+            return fr.json()
+        if fr.status_code == 408:
+            time.sleep(2)
+            continue
+        print(f"FUTURE FAILED ({fr.status_code}):", fr.text[:2000])
+        sys.exit(2)
+    print("FUTURE TIMEOUT")
+    sys.exit(2)
+
+
+def step(model_id, lr):
+    return await_future(submit_step(model_id, lr))
+
+
+def probe(tc, model_id, ds):
+    """fb(probe) + step(lr=0): returns (logprobs repr, grad_norm). lr=0 moves
+    nothing and clears the slot's accumulated probe grads."""
+    out = tc.forward_backward(ds, "cross_entropy").result()
+    lps = [o["logprobs"].to_torch().tolist() for o in out.loss_fn_outputs]
+    gn = step(model_id, 0.0).get("grad_norm")
+    return repr(lps), gn
+
+
+def main():
+    sc = tinker.ServiceClient()
+
+    print("P1 join: creating tenant A (pool boot)...", flush=True)
+    t0 = time.time()
+    tc_a = sc.create_lora_training_client(base_model=BASE_MODEL, rank=RANK)
+    boot_s = time.time() - t0
+    print(f"  A={tc_a.model_id} ({boot_s:.0f}s)", flush=True)
+    t0 = time.time()
+    tc_b = sc.create_lora_training_client(base_model=BASE_MODEL, rank=RANK)
+    join_s = time.time() - t0
+    print(f"  B={tc_b.model_id} ({join_s:.0f}s)", flush=True)
+    # A join must not reboot the rails: order-of-magnitude faster than boot.
+    check("P1 B joined (no second boot)", join_s < max(60.0, boot_s / 3),
+          f"boot={boot_s:.0f}s join={join_s:.0f}s")
+
+    probe_b = make_datums(4, salt=2)
+    probe_a = make_datums(4, salt=1)
+    train_a = make_datums(8, salt=3)
+
+    print("P2 isolation: B pinned probe across A's real steps", flush=True)
+    lp_b0, gn_b0 = probe(tc_b, tc_b.model_id, probe_b)
+    print(f"  B baseline grad_norm={gn_b0!r}", flush=True)
+    for i in range(3):
+        tc_a.forward_backward(train_a, "cross_entropy").result()
+        res = step(tc_a.model_id, 2e-4)
+        print(f"  A real step {i}: grad_norm={res.get('grad_norm')!r}", flush=True)
+    lp_b1, gn_b1 = probe(tc_b, tc_b.model_id, probe_b)
+    check("P2 B logprobs bit-stable", lp_b0 == lp_b1)
+    check("P2 B grad_norm bit-stable", repr(gn_b0) == repr(gn_b1),
+          f"{gn_b0!r} vs {gn_b1!r}")
+
+    print("P3 interleave: pipelined cross-tenant == serialized (lr=0)", flush=True)
+    # Interleaved: submit before awaiting; the pool FIFO lock executes in
+    # submission order with A/B ops crossing.
+    fut_a = tc_a.forward_backward(probe_a, "cross_entropy")
+    fut_b1 = tc_b.forward_backward(probe_b, "cross_entropy")
+    rid_sa = submit_step(tc_a.model_id, 0.0)
+    fut_b2 = tc_b.forward_backward(probe_b, "cross_entropy")
+    rid_sb = submit_step(tc_b.model_id, 0.0)
+    fut_a.result(); fut_b1.result(); fut_b2.result()
+    gn_a_i = await_future(rid_sa).get("grad_norm")
+    gn_b_i = await_future(rid_sb).get("grad_norm")
+    # Serialized per-tenant, same data (weights static under lr=0).
+    tc_a.forward_backward(probe_a, "cross_entropy").result()
+    gn_a_s = step(tc_a.model_id, 0.0).get("grad_norm")
+    tc_b.forward_backward(probe_b, "cross_entropy").result()
+    tc_b.forward_backward(probe_b, "cross_entropy").result()
+    gn_b_s = step(tc_b.model_id, 0.0).get("grad_norm")
+    check("P3 A interleaved == serialized", repr(gn_a_i) == repr(gn_a_s),
+          f"{gn_a_i!r} vs {gn_a_s!r}")
+    check("P3 B interleaved == serialized", repr(gn_b_i) == repr(gn_b_s),
+          f"{gn_b_i!r} vs {gn_b_s!r}")
+
+    print("P4 survive: delete B, A unchanged", flush=True)
+    r = requests.post(f"{BASE}/api/v1/delete_model", headers=HDRS,
+                      json={"model_id": tc_b.model_id})
+    check("P4 delete B", r.status_code == 200, f"status={r.status_code}")
+    tc_a.forward_backward(probe_a, "cross_entropy").result()
+    gn_a_post = step(tc_a.model_id, 0.0).get("grad_norm")
+    check("P4 A grad_norm after B's exit", repr(gn_a_post) == repr(gn_a_s),
+          f"{gn_a_post!r} vs {gn_a_s!r}")
+
+    requests.post(f"{BASE}/api/v1/delete_model", headers=HDRS,
+                  json={"model_id": tc_a.model_id})
+    print("\nG4:", "PASS" if not FAILS else f"FAIL ({', '.join(FAILS)})")
+    sys.exit(0 if not FAILS else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/gates/g4_pool_isolation.py
+++ b/scripts/gates/g4_pool_isolation.py
@@ -125,22 +125,30 @@ def main():
           f"{gn_b0!r} vs {gn_b1!r}")
 
     print("P3 interleave: pipelined cross-tenant == serialized (lr=0)", flush=True)
-    # Interleaved: submit before awaiting; the pool FIFO lock executes in
-    # submission order with A/B ops crossing.
+    # Interleaved: ALL ops via the SDK — its per-client _take_turn preserves
+    # submission order; mixing raw-HTTP steps with SDK fb races (the raw
+    # step can reach the server first and consume an empty slot; observed
+    # 2026-07-30: grad_norm 0.0 + exact 2x/4x leftover-grad multiples).
+    # Verdict comes from post-round state probes: an out-of-order step
+    # leaves unconsumed grads and the next probe's grad_norm doubles.
+    lr0 = types.AdamParams(learning_rate=0.0)
     fut_a = tc_a.forward_backward(probe_a, "cross_entropy")
     fut_b1 = tc_b.forward_backward(probe_b, "cross_entropy")
-    rid_sa = submit_step(tc_a.model_id, 0.0)
+    fut_sa = tc_a.optim_step(lr0)
     fut_b2 = tc_b.forward_backward(probe_b, "cross_entropy")
-    rid_sb = submit_step(tc_b.model_id, 0.0)
-    fut_a.result(); fut_b1.result(); fut_b2.result()
-    gn_a_i = await_future(rid_sa).get("grad_norm")
-    gn_b_i = await_future(rid_sb).get("grad_norm")
-    # Serialized per-tenant, same data (weights static under lr=0).
+    fut_sb = tc_b.optim_step(lr0)
+    for f in (fut_a, fut_b1, fut_sa, fut_b2, fut_sb):
+        f.result()
+    _, gn_a_i = probe(tc_a, tc_a.model_id, probe_a)
+    _, gn_b_i = probe(tc_b, tc_b.model_id, probe_b)
+    # Serialized per-tenant, same ops fully awaited (weights static: lr=0).
     tc_a.forward_backward(probe_a, "cross_entropy").result()
-    gn_a_s = step(tc_a.model_id, 0.0).get("grad_norm")
+    step(tc_a.model_id, 0.0)
     tc_b.forward_backward(probe_b, "cross_entropy").result()
     tc_b.forward_backward(probe_b, "cross_entropy").result()
-    gn_b_s = step(tc_b.model_id, 0.0).get("grad_norm")
+    step(tc_b.model_id, 0.0)
+    _, gn_a_s = probe(tc_a, tc_a.model_id, probe_a)
+    _, gn_b_s = probe(tc_b, tc_b.model_id, probe_b)
     check("P3 A interleaved == serialized", repr(gn_a_i) == repr(gn_a_s),
           f"{gn_a_i!r} vs {gn_a_s!r}")
     check("P3 B interleaved == serialized", repr(gn_b_i) == repr(gn_b_s),
@@ -150,8 +158,7 @@ def main():
     r = requests.post(f"{BASE}/api/v1/delete_model", headers=HDRS,
                       json={"model_id": tc_b.model_id})
     check("P4 delete B", r.status_code == 200, f"status={r.status_code}")
-    tc_a.forward_backward(probe_a, "cross_entropy").result()
-    gn_a_post = step(tc_a.model_id, 0.0).get("grad_norm")
+    _, gn_a_post = probe(tc_a, tc_a.model_id, probe_a)
     check("P4 A grad_norm after B's exit", repr(gn_a_post) == repr(gn_a_s),
           f"{gn_a_post!r} vs {gn_a_s!r}")
 

--- a/training/backends/miles/backend.py
+++ b/training/backends/miles/backend.py
@@ -7,6 +7,8 @@ forward_backward_only / apply_optimizer_step, pure-sum loss via rollout keys
 set in the converter."""
 import asyncio
 import logging
+import os
+import re
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any, Dict, List, Optional
@@ -43,7 +45,29 @@ class MilesHandle(BackendHandle):
     # fb/optim_step broadcasts interleave inconsistently across the DP actors
     # (mispaired collectives -> scrambled outputs; optim_step consuming a
     # later fb's grads). asyncio.Lock wakes waiters FIFO, so execution
-    # follows submission order.
+    # follows submission order. Pool-mode handles share the pool's lock:
+    # every broadcast rides the same actor group, so cross-tenant ops must
+    # serialize too (M2: N tenants, serialized train calls).
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+
+
+@dataclass
+class MilesPool:
+    """Shared multi-LoRA rails (M2): one boot serves N tenant adapters.
+
+    First create_model boots the pool; later creates register into it;
+    delete deregisters, and the last tenant out tears the pool down."""
+
+    train_group: Any
+    rollout_manager: Any
+    placement_group: Any            # create_placement_groups() dict
+    controller: Any                 # MultiLoRAController (named Ray actor)
+    args: Any                       # pool-boot Megatron Namespace (governs all tenants)
+    hf_path: str
+    base_model: str
+    router_ip: Optional[str] = None
+    router_port: Optional[int] = None
+    tenants: Dict[str, int] = field(default_factory=dict)   # model_id -> slot
     lock: asyncio.Lock = field(default_factory=asyncio.Lock)
 
 
@@ -55,6 +79,10 @@ class MilesBackend(TrainingBackend):
         # Lazy-import converter to avoid import errors when Miles is not installed
         self._converter = None
         self._builder = None
+        # Multi-LoRA pool (M2). _pool_admin serializes boot/join/teardown;
+        # lock order is always admin -> pool.lock.
+        self._pool: Optional[MilesPool] = None
+        self._pool_admin = asyncio.Lock()
 
     @property
     def converter(self):
@@ -71,6 +99,152 @@ class MilesBackend(TrainingBackend):
         return self._builder
 
     async def create_model(
+        self,
+        model_id: str,
+        request_id: str,
+        base_model: str,
+        num_gpus: int,
+        lora_config: Optional[Dict[str, Any]] = None,
+        parallelism: Optional[Dict[str, Any]] = None,
+        rl_config: Optional[Dict[str, Any]] = None,
+        rollout_config: Optional[Dict[str, Any]] = None,
+        debug_train_only: bool = False,
+        checkpoint_path: Optional[str] = None,
+        max_batch_size: int = 4096,
+        max_seq_len: int = 2048,
+        rlve_config: Optional[Dict[str, Any]] = None,
+        wandb_config: Optional[Dict[str, Any]] = None,
+        objective: str = "language_modeling",
+        num_labels: Optional[int] = None,
+        head_config: Optional[Dict[str, Any]] = None,
+    ) -> MilesHandle:
+        boot_kwargs = dict(
+            model_id=model_id, request_id=request_id, base_model=base_model,
+            num_gpus=num_gpus, lora_config=lora_config, parallelism=parallelism,
+            rl_config=rl_config, rollout_config=rollout_config,
+            debug_train_only=debug_train_only, checkpoint_path=checkpoint_path,
+            max_batch_size=max_batch_size, max_seq_len=max_seq_len,
+            rlve_config=rlve_config, wandb_config=wandb_config,
+            objective=objective, num_labels=num_labels, head_config=head_config,
+        )
+        # Mirror the builder's pool gate (slime_builder: env slots + LoRA rank).
+        slots = int(os.environ.get("TINKERCLOUD_MILES_MULTILORA_SLOTS", "0") or 0)
+        pool_eligible = slots > 0 and bool(lora_config and lora_config.get("rank", 0) > 0)
+        if not pool_eligible:
+            return await self._boot_model(**boot_kwargs)
+        async with self._pool_admin:
+            if self._pool is not None:
+                return await self._join_pool(
+                    model_id=model_id, request_id=request_id,
+                    base_model=base_model, lora_config=lora_config,
+                    debug_train_only=debug_train_only,
+                    checkpoint_path=checkpoint_path, rlve_config=rlve_config,
+                    objective=objective,
+                )
+            return await self._boot_model(**boot_kwargs)
+
+    async def _join_pool(
+        self,
+        model_id: str,
+        request_id: str,
+        base_model: str,
+        lora_config: Dict[str, Any],
+        debug_train_only: bool,
+        checkpoint_path: Optional[str],
+        rlve_config: Optional[Dict[str, Any]],
+        objective: str,
+    ) -> MilesHandle:
+        """Register a new tenant adapter into the live pool (caller holds
+        _pool_admin). The pool's boot args govern parallelism/batch shape;
+        only the tenant's LoRA rank/alpha are per-adapter."""
+        pool = self._pool
+        if objective != "language_modeling":
+            raise BackendError(
+                f"Miles is a language-modeling backend; objective {objective!r} "
+                f"requires a classification backend (automodel / megatron_bridge)",
+                backend="miles", operation="create_model",
+            )
+        if base_model != pool.base_model:
+            raise BackendError(
+                f"Multi-LoRA pool serves base model {pool.base_model!r}; "
+                f"cannot create {base_model!r} on it (one base per pool)",
+                backend="miles", operation="create_model",
+            )
+        if debug_train_only or rlve_config:
+            raise BackendError(
+                "Multi-LoRA pool mode supports neither debug_train_only nor RLVE",
+                backend="miles", operation="create_model",
+            )
+        if checkpoint_path:
+            raise BackendError(
+                "Resuming from a checkpoint into a multi-LoRA pool is not "
+                "supported yet (adapter-scoped resume unimplemented)",
+                backend="miles", operation="create_model",
+            )
+
+        from miles.utils.adapter_config import TinkerAdapterConfig
+
+        # Same rank/alpha derivation as the builder (slime_builder LoRA args).
+        rank = int(lora_config.get("rank", 0))
+        alpha = int(lora_config.get("alpha") or rank)
+        adapter_name = re.sub(r"[^A-Za-z0-9._-]", "-", model_id)
+        try:
+            registration = await pool.controller.register_adapter.remote(
+                adapter_name, TinkerAdapterConfig(rank=rank, alpha=alpha)
+            )
+        except Exception as e:
+            # Registry errors (slots full, name colliding/cleaning-up,
+            # rank > allocated max) surface here.
+            raise BackendError(
+                str(e), backend="miles", operation="create_model", original_error=e,
+            ) from e
+        adapter_slot = registration["slot"]
+
+        try:
+            async with pool.lock:
+                # Actors load the PENDING adapter into its slot and mark it
+                # for push; update_weights upserts exactly the pending set
+                # (LoRA B=0 => zero-delta) and promotes it to ACTIVE.
+                await pool.train_group.reconcile_adapters()
+                await pool.train_group.update_weights()
+        except Exception as e:
+            try:
+                await pool.controller.deregister_adapter.remote(adapter_name)
+                async with pool.lock:
+                    await pool.train_group.reconcile_adapters()
+            except Exception:
+                logger.warning(
+                    "[%s] Pool join rollback failed for adapter %s",
+                    request_id, adapter_name, exc_info=True,
+                )
+            raise BackendError(
+                str(e), backend="miles", operation="create_model", original_error=e,
+            ) from e
+
+        pool.tenants[model_id] = adapter_slot
+        logger.info(
+            "[%s] Multi-LoRA pool join: %s -> slot %d (%d tenants)",
+            request_id, adapter_name, adapter_slot, len(pool.tenants),
+        )
+        return MilesHandle(
+            model_id=model_id,
+            backend_type="miles",
+            train_group=pool.train_group,
+            rollout_manager=pool.rollout_manager,
+            placement_group=None,   # pool-owned; freed only at pool teardown
+            args=pool.args,
+            hf_path=pool.hf_path,
+            router_ip=pool.router_ip,
+            router_port=pool.router_port,
+            created_at=datetime.now().isoformat(),
+            training_run_id=model_id,
+            controller=pool.controller,
+            adapter_name=adapter_name,
+            adapter_slot=adapter_slot,
+            lock=pool.lock,
+        )
+
+    async def _boot_model(
         self,
         model_id: str,
         request_id: str,
@@ -153,7 +327,6 @@ class MilesBackend(TrainingBackend):
                 # (named actor; reconcile on the actors resolves it by name).
                 from miles.ray.multi_lora.controller import create_multilora_controller
                 from miles.utils.adapter_config import TinkerAdapterConfig
-                import re
 
                 router_ip, router_port = await rollout_manager.get_router_address.remote()
                 args.sglang_router_ip, args.sglang_router_port = router_ip, router_port
@@ -234,6 +407,23 @@ class MilesBackend(TrainingBackend):
                 adapter_name=adapter_name,
                 adapter_slot=adapter_slot,
             )
+
+            if multi_lora:
+                # First tenant boots the pool; later creates join it (M2).
+                pool = MilesPool(
+                    train_group=train_group,
+                    rollout_manager=rollout_manager,
+                    placement_group=pgs,
+                    controller=controller,
+                    args=args,
+                    hf_path=hf_path,
+                    base_model=base_model,
+                    router_ip=router_ip,
+                    router_port=router_port,
+                )
+                pool.tenants[model_id] = adapter_slot
+                handle.lock = pool.lock
+                self._pool = pool
 
             logger.info("[%s] Miles model %s created successfully", request_id, model_id)
             return handle
@@ -494,6 +684,14 @@ class MilesBackend(TrainingBackend):
         checkpoint_path: str,
     ) -> None:
         h: MilesHandle = handle  # type: ignore[assignment]
+        if h.adapter_slot is not None:
+            # train_group.load_checkpoint is a full-model resume broadcast;
+            # on shared rails it would clobber every co-tenant.
+            raise BackendError(
+                "load_checkpoint is not supported in multi-LoRA pool mode "
+                "(adapter-scoped resume unimplemented)",
+                backend="miles", operation="load_checkpoint",
+            )
         await h.lock.acquire()
         try:
             await h.train_group.load_checkpoint(checkpoint_path)
@@ -513,13 +711,16 @@ class MilesBackend(TrainingBackend):
 
     async def delete_model(self, handle: BackendHandle) -> None:
         h: MilesHandle = handle  # type: ignore[assignment]
+        if h.adapter_slot is not None and self._pool is not None:
+            await self._delete_pool_tenant(h)
+            return
         # Hold the op lock so teardown can't interleave with an in-flight
         # fb/step (delete-during-optim_step crash class).
         await h.lock.acquire()
         try:
             resources_freed = []
-            # Pool mode: the pool dies with this model (M1: one tenant per
-            # pool). Kill the named controller so the next create_model can
+            # Fallback for a pool handle that outlived its pool record:
+            # kill the named controller so the next create_model can
             # register a fresh one.
             if h.controller is not None:
                 try:
@@ -558,6 +759,66 @@ class MilesBackend(TrainingBackend):
             ) from e
         finally:
             h.lock.release()
+
+    async def _delete_pool_tenant(self, h: MilesHandle) -> None:
+        """Pool-mode delete (M2): deregister this tenant's adapter; the last
+        tenant out tears the pool down (controller name freed for reboot)."""
+        async with self._pool_admin:
+            pool = self._pool
+            if pool is None:
+                return
+            if len(pool.tenants) > 1 or h.model_id not in pool.tenants:
+                try:
+                    async with pool.lock:
+                        await pool.controller.deregister_adapter.remote(h.adapter_name)
+                        # Actors retire the slot: abort in-flight sampling,
+                        # save the final adapter ckpt, clear slot weights /
+                        # optimizer state / retained grads, free the slot.
+                        await pool.train_group.reconcile_adapters()
+                except Exception as e:
+                    raise BackendError(
+                        str(e), backend="miles", operation="delete_model", original_error=e,
+                    ) from e
+                pool.tenants.pop(h.model_id, None)
+                logger.info(
+                    "Pool tenant %s deregistered (slot %s); %d tenant(s) remain",
+                    h.model_id, h.adapter_slot, len(pool.tenants),
+                )
+                return
+            # Last tenant: the pool dies with it. Null the record even on a
+            # partial teardown — a half-dead pool must not accept joins.
+            try:
+                async with pool.lock:
+                    resources_freed = []
+                    try:
+                        await pool.controller.stop.remote()
+                    except Exception:
+                        logger.warning("Multi-LoRA controller stop failed; killing", exc_info=True)
+                    ray.kill(pool.controller, no_restart=True)
+                    resources_freed.append("multi_lora_controller")
+                    for actor in pool.train_group._actor_handles:
+                        ray.kill(actor, no_restart=True)
+                        resources_freed.append("actor")
+                    if pool.rollout_manager is not None:
+                        ray.kill(pool.rollout_manager, no_restart=True)
+                        resources_freed.append("rollout_manager")
+                    seen = set()
+                    for pg_tuple in (pool.placement_group or {}).values():
+                        pg_obj = pg_tuple[0] if isinstance(pg_tuple, tuple) else pg_tuple
+                        if pg_obj is not None and id(pg_obj) not in seen:
+                            seen.add(id(pg_obj))
+                            ray.util.remove_placement_group(pg_obj)
+                            resources_freed.append("placement_group")
+            except Exception as e:
+                raise BackendError(
+                    str(e), backend="miles", operation="delete_model", original_error=e,
+                ) from e
+            finally:
+                self._pool = None
+            logger.info(
+                "Miles pool torn down with last tenant %s, freed %d resources",
+                h.model_id, len(resources_freed),
+            )
 
     async def get_logprobs(
         self,


### PR DESCRIPTION
M2 of the multi-LoRA pool: N tenant models share one set of rails.

- First `create_model` boots the pool (M1 shape); later creates JOIN it:
  register adapter -> actors reconcile (load slot, mark pending) -> initial
  per-adapter zero-delta push (PENDING->ACTIVE). Join is sub-second vs a
  ~2-minute boot at 0.5B scale.
- `delete_model` deregisters the tenant (actors abort in-flight sampling,
  clear slot weights / optimizer state / retained grads, free the slot);
  the last tenant out tears the pool down (controller name freed).
- All pool handles share one FIFO op lock: every broadcast rides the same
  actor group, so cross-tenant ops serialize in submission order.
- `load_checkpoint` rejected on pool handles (full-model resume broadcast
  would clobber co-tenants; adapter-scoped resume is future work).
- New gate `scripts/gates/g4_pool_isolation.py` (pool-mode server): join,
  cross-tenant pinned-probe isolation, pipelined-interleave vs serialized,
  survive-co-tenant-delete. `g3_sl_basic.py` log path now env-overridable
  for concurrent per-tenant runs.

Cluster results (2 tenants, Qwen2.5-0.5B r32, disagg 2+2 on H200):
- G4 PASS: join 0s (boot 113s); tenant B logprobs + probe grad_norm
  bit-stable across tenant A's real optimizer steps (237.81900451025777);
  interleaved fb/step across tenants == serialized per-tenant, bit-identical
  (A 81.53626853086607, B 237.81900451025777); A bit-equal after B's
  delete. All values bit-identical across two independent pool boots.
- Per-tenant E2: two concurrent 30-step sl_basic runs on one pool, NLL
  2.803->2.2596 and 2.803->2.2610 (single-tenant pooled baseline
  2.80->2.26). Clean deregister + last-out teardown verified via API.

Depends on miles main (PR #5 rails, merged).
