### PR TITLE
miles backend: pinned-v0 -> base sampling + per-tenant sampler routing

### DIFF
--- a/scripts/gates/README.md
+++ b/scripts/gates/README.md
@@ -14,7 +14,14 @@ rotate the server between runs (models are not auto-reaped).
 | `g3_batch_probe.py` | G3 data-shape diagnostic | real shuffled NoRobots batch through fb, length audit |
 | `g3_sl_basic.py` | G3 end-to-end | 30-step SFT completes, NLL decreasing (2026-07-30: 2.80→2.28) |
 | `g4_pool_isolation.py` | G4 pool isolation (M2) | 2 tenants, 1 pool: join fast; B's pinned probe bit-stable across A's steps; interleaved ≡ serialized; A bit-equal after B's delete |
+| `g5_pinned_v0.py` | G5 pinned-v0 + sampler routing | v0 sampler == base, bit-stable across training; live != base; per-tenant routing (B live == base while A live differs) |
 
-G4 needs a pool-mode server (`TINKERCLOUD_MILES_MULTILORA_SLOTS>0`). The
+G4/G5 need a pool-mode server (`TINKERCLOUD_MILES_MULTILORA_SLOTS>0`). The
 per-tenant E₂ gate is two `g3_sl_basic.py` runs launched concurrently
 against the same pool-mode server (each creates its own tenant).
+
+Known gap (surfaced by G5 run 1): only the SDK's EPHEMERAL sampler flavor
+(`save_weights_and_get_sampling_client()`, name=None) registers a
+version-pinned sampler session. A NAMED `save_weights_for_sampler(name)` +
+`create_sampling_client(path)` yields an unpinned sampler served LIVE on
+both backends — snapshot-implying API, live semantics (BUG-015 class).

--- a/scripts/gates/g5_pinned_v0.py
+++ b/scripts/gates/g5_pinned_v0.py
@@ -104,8 +104,11 @@ def main():
     print("P1: tenant A + v0 sampler", flush=True)
     tc_a = sc.create_lora_training_client(base_model=BASE_MODEL, rank=RANK)
     print(f"  A={tc_a.model_id}", flush=True)
-    path = tc_a.save_weights_for_sampler("g5-ref-v0").result().path
-    pinned = tc_a.create_sampling_client(path)
+    # MUST be the ephemeral (unnamed) flavor: only that path registers the
+    # sampler session with a pinned weight_version — a named
+    # save_weights_for_sampler + create_sampling_client(path) yields an
+    # UNPINNED sampler served live (cost G5 run 1).
+    pinned = tc_a.save_weights_and_get_sampling_client()
     s0_toks, s0_lps = sdk_sample(pinned)
     print(f"  S0 tokens={s0_toks[:60]}...", flush=True)
 

--- a/scripts/gates/g5_pinned_v0.py
+++ b/scripts/gates/g5_pinned_v0.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""G5 pinned-v0 + sampler routing gate (M2 leftover, 003 R6 second half).
+
+Server must be in pool mode (TINKERCLOUD_MILES_MULTILORA_SLOTS>0).
+Phases:
+  P1: tenant A on pool; sampler saved at v0; greedy sample S0.
+  P2: A trains 3 real steps (adapter moves, upserted each step); the
+      pinned sampler re-samples S1 == S0 bit-identical — v0 routes to
+      BASE weights, the frozen-reference property (DPO ref for free).
+  P3: live sample of A (model_path routing, no session) — logprobs must
+      DIFFER from S0 (the adapter actually moved; also proves the pinned
+      match wasn't vacuous).
+  P4: tenant B joins (fresh slot, zero delta); live sample of B ==
+      S0 bit-identical (zero-delta ≡ base) while A's live differs —
+      per-tenant sampler routing (find-first would have collapsed them).
+PASS = every comparison as stated (repr equality on token/logprob lists).
+"""
+import os, sys, time
+
+os.environ.setdefault("TINKER_BASE_URL", "http://localhost:8000")
+os.environ.setdefault("TINKER_API_KEY", "tml-dev-key")
+BASE = os.environ["TINKER_BASE_URL"]
+KEY = os.environ["TINKER_API_KEY"]
+
+import requests
+import torch
+import tinker
+from tinker import types
+
+BASE_MODEL = "Qwen/Qwen2.5-0.5B"
+RANK = 32
+SEQ = 64
+PROMPT = [(1000 + j * 104729) % 50000 for j in range(24)]
+HDRS = {"X-API-Key": KEY, "Content-Type": "application/json"}
+GREEDY = {"temperature": 0.0, "max_tokens": 24, "top_p": 1.0, "top_k": -1}
+FAILS = []
+
+
+def check(name, ok, detail=""):
+    print(f"  {name}: {'PASS' if ok else 'FAIL'}{' ' + detail if detail else ''}", flush=True)
+    if not ok:
+        FAILS.append(name)
+
+
+def make_datums(n, salt):
+    out = []
+    for i in range(n):
+        toks = [(1000 + (salt * 31 + i) * 7919 + j * 104729) % 50000 for j in range(SEQ)]
+        inp, tgt = toks[:-1], toks[1:]
+        out.append(types.Datum(
+            model_input=types.ModelInput.from_ints(inp),
+            loss_fn_inputs={
+                "weights": types.TensorData.from_torch(
+                    torch.ones(len(inp), dtype=torch.float32)),
+                "target_tokens": types.TensorData.from_torch(
+                    torch.tensor(tgt, dtype=torch.long)),
+            },
+        ))
+    return out
+
+
+def await_future(rid, timeout=600):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        fr = requests.post(f"{BASE}/api/v1/retrieve_future/{rid}", headers=HDRS)
+        if fr.status_code == 200:
+            return fr.json()
+        if fr.status_code == 408:
+            time.sleep(2)
+            continue
+        print(f"FUTURE FAILED ({fr.status_code}):", fr.text[:2000])
+        sys.exit(2)
+    print("FUTURE TIMEOUT")
+    sys.exit(2)
+
+
+def sdk_sample(sampler):
+    fut = sampler.sample(
+        prompt=types.ModelInput.from_ints(PROMPT),
+        sampling_params=types.SamplingParams(temperature=0.0, max_tokens=24),
+        num_samples=1,
+    )
+    seq = fut.result().sequences[0]
+    return repr(list(seq.tokens)), repr([float(x) for x in seq.logprobs])
+
+
+def raw_live_sample(model_id):
+    """Live-engine sample routed to model_id via its tinker:// path."""
+    r = requests.post(f"{BASE}/api/v1/asample", headers=HDRS, json={
+        "num_samples": 1,
+        "prompt": {"tokens": PROMPT},
+        "sampling_params": GREEDY,
+        "model_path": f"tinker://{model_id}/weights/live",
+    })
+    r.raise_for_status()
+    res = await_future(r.json()["request_id"])
+    seq = res["sequences"][0]
+    return repr(list(seq["tokens"])), repr([float(x) for x in seq["logprobs"]])
+
+
+def main():
+    sc = tinker.ServiceClient()
+
+    print("P1: tenant A + v0 sampler", flush=True)
+    tc_a = sc.create_lora_training_client(base_model=BASE_MODEL, rank=RANK)
+    print(f"  A={tc_a.model_id}", flush=True)
+    path = tc_a.save_weights_for_sampler("g5-ref-v0").result().path
+    pinned = tc_a.create_sampling_client(path)
+    s0_toks, s0_lps = sdk_sample(pinned)
+    print(f"  S0 tokens={s0_toks[:60]}...", flush=True)
+
+    print("P2: A trains 3 real steps; pinned sampler must not move", flush=True)
+    train_a = make_datums(8, salt=3)
+    for i in range(3):
+        tc_a.forward_backward(train_a, "cross_entropy").result()
+        tc_a.optim_step(types.AdamParams(learning_rate=2e-4)).result()
+    s1_toks, s1_lps = sdk_sample(pinned)
+    check("P2 pinned tokens bit-stable", s1_toks == s0_toks)
+    check("P2 pinned logprobs bit-stable", s1_lps == s0_lps)
+
+    print("P3: A's LIVE sample must differ from base", flush=True)
+    a_toks, a_lps = raw_live_sample(tc_a.model_id)
+    check("P3 A live != base", a_lps != s0_lps,
+          "(logprobs identical — adapter never moved or route ignored)" if a_lps == s0_lps else "")
+
+    print("P4: tenant B (fresh) live == base; routing is per-tenant", flush=True)
+    tc_b = sc.create_lora_training_client(base_model=BASE_MODEL, rank=RANK)
+    print(f"  B={tc_b.model_id}", flush=True)
+    b_toks, b_lps = raw_live_sample(tc_b.model_id)
+    check("P4 B live == base (zero delta)", b_lps == s0_lps and b_toks == s0_toks)
+    check("P4 A/B routes distinct", a_lps != b_lps)
+
+    for m in (tc_b.model_id, tc_a.model_id):
+        requests.post(f"{BASE}/api/v1/delete_model", headers=HDRS, json={"model_id": m})
+    print("\nG5:", "PASS" if not FAILS else f"FAIL ({', '.join(FAILS)})")
+    sys.exit(0 if not FAILS else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/training/backends/miles/backend.py
+++ b/training/backends/miles/backend.py
@@ -40,6 +40,12 @@ class MilesHandle(BackendHandle):
     controller: Any = None            # MultiLoRAController (named Ray actor)
     adapter_name: Optional[str] = None
     adapter_slot: Optional[int] = None
+    # Weight version = successful optim steps applied. Sampler registration
+    # snapshots it (routers/checkpoints.py) so a sampler saved before any
+    # step pins v0. v0 == base model only for fresh-init LoRA (B=0 at init),
+    # hence created_from_checkpoint gates the v0->base sampling route.
+    weight_version: int = 0
+    created_from_checkpoint: bool = False
     # Serializes GPU-bound ops per model. The task manager runs request
     # handlers as concurrent asyncio tasks; without this, pipelined
     # fb/optim_step broadcasts interleave inconsistently across the DP actors
@@ -406,6 +412,7 @@ class MilesBackend(TrainingBackend):
                 controller=controller,
                 adapter_name=adapter_name,
                 adapter_slot=adapter_slot,
+                created_from_checkpoint=bool(checkpoint_path),
             )
 
             if multi_lora:
@@ -623,6 +630,9 @@ class MilesBackend(TrainingBackend):
                 if offload_rollout:
                     await h.rollout_manager.onload_kv.remote()
 
+            if results[0]["success"]:
+                h.weight_version += 1
+
             return {
                 "success": results[0]["success"],
                 "grad_norm": results[0]["grad_norm"],
@@ -695,6 +705,7 @@ class MilesBackend(TrainingBackend):
         await h.lock.acquire()
         try:
             await h.train_group.load_checkpoint(checkpoint_path)
+            h.created_from_checkpoint = True
 
             # Sync loaded weights to inference engine
             if h.rollout_manager is not None:
@@ -846,9 +857,12 @@ class MilesBackend(TrainingBackend):
     ) -> Dict[str, Any]:
         """Sample via per-request HTTP calls to the SGLang router.
 
-        pinned_version is accepted for contract uniformity but NOT honored:
-        Miles serves from the live SGLang engine (same BUG-015 aliasing class;
-        needs version-pinned sampling to fix).
+        Pool mode honors pinned_version==0 by routing to the BASE weights
+        (fresh-init LoRA delta is zero at v0, so v0 == base): a sampler
+        saved before any optim step is a frozen reference — DPO's ref model
+        with no second copy resident. Nonzero pins (and every pin outside
+        pool mode) are still served from the live engine — the BUG-015
+        aliasing class; logged loudly rather than silently aliased.
         """
         from ...utils.sglang_client import SGLangClient
 
@@ -861,12 +875,27 @@ class MilesBackend(TrainingBackend):
         client = SGLangClient(base_url=f"http://{h.router_ip}:{h.router_port}")
 
         # Pool mode: route to this model's adapter by engine-side slot name.
-        # (pinned v0 -> base routing not wired yet; see 003 R6.)
         lora_path = None
         if h.adapter_slot is not None:
-            from miles.utils.multi_lora import slot_lora_name
+            if pinned_version == 0 and not h.created_from_checkpoint:
+                pass  # v0 == base: no lora_path
+            else:
+                if pinned_version is not None:
+                    logger.warning(
+                        "[%s] pinned_version=%s not honorable for %s "
+                        "(nonzero or checkpoint-created); serving LIVE slot "
+                        "weights (v%d) — BUG-015 aliasing risk",
+                        request_id, pinned_version, h.model_id, h.weight_version,
+                    )
+                from miles.utils.multi_lora import slot_lora_name
 
-            lora_path = slot_lora_name(h.adapter_slot)
+                lora_path = slot_lora_name(h.adapter_slot)
+        elif pinned_version is not None and pinned_version != h.weight_version:
+            logger.warning(
+                "[%s] pinned_version=%s not honored for %s (non-pool miles "
+                "serves the live engine, v%d) — BUG-015 aliasing risk",
+                request_id, pinned_version, h.model_id, h.weight_version,
+            )
 
         sequences = []
         prompt_logprobs_result = None

--- a/training/routers/sampling.py
+++ b/training/routers/sampling.py
@@ -93,21 +93,28 @@ async def asample(
     """
     request_id = generate_request_id()
 
-    # Find model with RolloutManager
-    model_id = find_model_with_rollout_manager(training_clients)
-    if not model_id:
-        raise HTTPException(status_code=404, detail="No model with RolloutManager found")
-
     # Extract prompt tokens
     prompt_tokens = request.prompt.get_tokens()
 
     # BUG-015: resolve the sampler's pinned weight version (snapshot samplers,
     # e.g. DPO's frozen reference) so pinned logprob reads aren't served from
-    # the live refit-every-step engine.
+    # the live refit-every-step engine. The sampler also names its OWNING
+    # model — required routing under a multi-tenant pool, where find-first
+    # would serve a co-tenant's adapter.
     pinned_version = None
+    target_model_id = None
     if request.sampling_session_id and session_service is not None:
         info = session_service.get_sampler(request.sampling_session_id)
         pinned_version = getattr(info, "pinned_version", None) if info else None
+        target_model_id = getattr(info, "model_id", None) if info else None
+    if target_model_id is None and request.model_path:
+        # tinker://<model_id>/weights/... — the sampler URI names its model.
+        parts = request.model_path.removeprefix("tinker://").split("/")
+        if parts and parts[0] in training_clients:
+            target_model_id = parts[0]
+    model_id = target_model_id or find_model_with_rollout_manager(training_clients)
+    if not model_id:
+        raise HTTPException(status_code=404, detail="No model with RolloutManager found")
 
     async def execute():
         result_dict = await service.async_sample(
@@ -118,6 +125,7 @@ async def asample(
             prompt_logprobs=request.prompt_logprobs,
             training_clients=training_clients,
             pinned_version=pinned_version,
+            model_id=target_model_id,
         )
 
         # Convert to response model

--- a/training/services/sampling_service.py
+++ b/training/services/sampling_service.py
@@ -23,10 +23,19 @@ class SamplingService:
         self.backend = backend
 
     def _resolve_handle(
-        self, training_clients: Dict[str, Dict[str, Any]]
+        self,
+        training_clients: Dict[str, Dict[str, Any]],
+        model_id: Optional[str] = None,
     ) -> BackendHandle:
-        """Find the model serving rollouts and return its backend handle."""
-        model_id = find_model_with_rollout_manager(training_clients)
+        """Return the target model's backend handle.
+
+        An explicit model_id (from the requesting sampler's session) wins:
+        find-first is only correct when a single model serves rollouts, and
+        a multi-LoRA pool has one per tenant."""
+        if model_id and model_id not in training_clients:
+            raise RuntimeError(f"Sampler's model {model_id} no longer exists")
+        if not model_id:
+            model_id = find_model_with_rollout_manager(training_clients)
         if not model_id:
             raise RuntimeError("No model with RolloutManager found")
         handle = training_clients[model_id].get("backend_handle")
@@ -43,12 +52,14 @@ class SamplingService:
         prompt_logprobs: bool,
         training_clients: Dict[str, Dict[str, Any]],
         pinned_version: Optional[int] = None,
+        model_id: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         Async sampling for a single prompt.
 
         `pinned_version` (BUG-015): weight version the requesting sampler was
         created at; backends route pinned logprob reads off the live engine.
+        `model_id`: the sampler's owning model (multi-tenant routing).
 
         Returns:
             Dict with sequences and optional prompt_logprobs
@@ -57,7 +68,7 @@ class SamplingService:
             RuntimeError: If no model with RolloutManager found
             BackendError: If the inference engine is unavailable
         """
-        handle = self._resolve_handle(training_clients)
+        handle = self._resolve_handle(training_clients, model_id)
         logger.info(f"[{request_id}] Async sampling for {handle.model_id}")
         return await self.backend.sample(
             handle=handle,

--- a/training/services/session_service.py
+++ b/training/services/session_service.py
@@ -30,6 +30,9 @@ class SamplerInfo:
     # BUG-015: weight version of the owning model when this sampler was created.
     # None = unknown (e.g. restored from storage) -> served from live weights.
     pinned_version: Optional[int] = None
+    # Owning model: sampling requests carrying this sampler resolve their
+    # target model from here (multi-tenant pools break find-first routing).
+    model_id: Optional[str] = None
 
 
 @dataclass
@@ -130,6 +133,7 @@ class SessionService:
                     session_id=session_id,
                     base_model=sampler_data.get("base_model"),
                     model_path=sampler_data.get("model_path"),
+                    model_id=sampler_data.get("model_id"),
                 )
 
         logger.info(
@@ -322,6 +326,7 @@ class SessionService:
                 session_id=session_id,
                 base_model=base_model if base_model else None,
                 model_path=model_path,
+                model_id=model_id,
             )
 
             # Persist to storage
@@ -448,6 +453,7 @@ class SessionService:
             base_model=base_model if base_model else None,
             model_path=model_path,
             pinned_version=pinned_version,
+            model_id=model_id,
         )
 
         # Persist to storage


### PR DESCRIPTION
Two M2 leftovers, gate-verified on the pool:

- **Pinned-v0 route (R6 second half)**: MilesHandle tracks weight_version
  (successful optim steps); sampler registration snapshots it; pool-mode
  sample() honors pinned_version==0 by serving BASE weights (fresh-init
  LoRA v0 == base — DPO's frozen reference with no second copy;
  checkpoint-created models excluded). Unhonorable pins (nonzero /
  non-pool) warn loudly instead of silently aliasing.
- **Per-tenant sampler routing**: SamplerInfo now carries its owning
  model_id; /asample resolves the target from the sampler session (or
  tinker:// model_path) instead of find-first — which serves the wrong
  tenant's adapter under a multi-tenant pool.

New gate scripts/gates/g5_pinned_v0.py, PASS on cluster (pool mode,
Qwen2.5-0.5B r32): v0 sampler greedy tokens+logprobs bit-stable across
3 real optimizer steps; live sample != base; fresh co-tenant's live
sample == base bit-identical (zero-delta is bit-transparent through the
slot route) while the trained tenant's differs.

Known gap (documented in gates README): only the SDK's ephemeral flavor
(save_weights_and_get_sampling_client, name=None) registers a pinned
sampler session; a NAMED save + create_sampling_client(path) yields an
unpinned sampler served live on both backends.
