### PR TITLE
miles backend: co-batched fb across pool tenants (M3)

### DIFF
--- a/scripts/gates/README.md
+++ b/scripts/gates/README.md
@@ -15,6 +15,7 @@ rotate the server between runs (models are not auto-reaped).
 | `g3_sl_basic.py` | G3 end-to-end | 30-step SFT completes, NLL decreasing (2026-07-30: 2.80→2.28) |
 | `g4_pool_isolation.py` | G4 pool isolation (M2) | 2 tenants, 1 pool: join fast; B's pinned probe bit-stable across A's steps; interleaved ≡ serialized; A bit-equal after B's delete |
 | `g5_pinned_v0.py` | G5 pinned-v0 + sampler routing | v0 sampler == base, bit-stable across training; live != base; per-tenant routing (B live == base while A live differs) |
+| `g6_batch_invariance.py` | G6 batch-invariance (M3, AC1) | same tenant data solo vs co-batched with different co-tenant mixes ⇒ bit-identical per-tenant grad_norm + logprobs (needs `TINKERCLOUD_MILES_COBATCH_MAX_SAMPLES>=16`) |
 
 G4/G5 need a pool-mode server (`TINKERCLOUD_MILES_MULTILORA_SLOTS>0`). The
 per-tenant E₂ gate is two `g3_sl_basic.py` runs launched concurrently

--- a/scripts/gates/g6_batch_invariance.py
+++ b/scripts/gates/g6_batch_invariance.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""G6 batch-invariance gate (M3 co-batching, AC1).
+
+Server must be in pool mode with merging on:
+  TINKERCLOUD_MILES_MULTILORA_SLOTS>0, TINKERCLOUD_MILES_COBATCH_MAX_SAMPLES>=16.
+
+Same tenant data under different co-tenant mixes must produce identical
+per-tenant observables — the legality condition for cross-tenant co-batching.
+  P1: tenants A and B on one pool.
+  P2 solo baselines: fb alone + step(lr=0) per tenant -> grad_norm + logprobs.
+  P3 co-batched: a queue-blocking forward makes A's and B's fb land in the
+     dispatcher's merge window (verified via the co_batched_fb metric);
+     each tenant's grad_norm + per-datum logprobs must equal its solo run
+     bit-identically.
+  P4 asymmetric mix: A co-batched with a DIFFERENT B batch (other content,
+     other size) — A's observables still bit-equal (invariance to co-tenant
+     content, not just presence).
+PASS = every comparison bit-identical (repr equality).
+"""
+import os, sys, time
+
+os.environ.setdefault("TINKER_BASE_URL", "http://localhost:8000")
+os.environ.setdefault("TINKER_API_KEY", "tml-dev-key")
+BASE = os.environ["TINKER_BASE_URL"]
+KEY = os.environ["TINKER_API_KEY"]
+
+import requests
+import torch
+import tinker
+from tinker import types
+
+BASE_MODEL = "Qwen/Qwen2.5-0.5B"
+RANK = 32
+SEQ = 64
+HDRS = {"X-API-Key": KEY, "Content-Type": "application/json"}
+FAILS = []
+
+
+def check(name, ok, detail=""):
+    print(f"  {name}: {'PASS' if ok else 'FAIL'}{' ' + detail if detail else ''}", flush=True)
+    if not ok:
+        FAILS.append(name)
+
+
+def make_datums(n, salt, seq=SEQ):
+    out = []
+    for i in range(n):
+        toks = [(1000 + (salt * 31 + i) * 7919 + j * 104729) % 50000 for j in range(seq)]
+        inp, tgt = toks[:-1], toks[1:]
+        out.append(types.Datum(
+            model_input=types.ModelInput.from_ints(inp),
+            loss_fn_inputs={
+                "weights": types.TensorData.from_torch(
+                    torch.ones(len(inp), dtype=torch.float32)),
+                "target_tokens": types.TensorData.from_torch(
+                    torch.tensor(tgt, dtype=torch.long)),
+            },
+        ))
+    return out
+
+
+def step_lr0(model_id):
+    r = requests.post(f"{BASE}/api/v1/optim_step", headers=HDRS, json={
+        "model_id": model_id, "adam_params": {"learning_rate": 0.0},
+    })
+    r.raise_for_status()
+    rid = r.json()["request_id"]
+    deadline = time.time() + 600
+    while time.time() < deadline:
+        fr = requests.post(f"{BASE}/api/v1/retrieve_future/{rid}", headers=HDRS)
+        if fr.status_code == 200:
+            return fr.json()
+        if fr.status_code == 408:
+            time.sleep(2)
+            continue
+        print(f"STEP FAILED ({fr.status_code}):", fr.text[:2000])
+        sys.exit(2)
+    print("STEP TIMEOUT")
+    sys.exit(2)
+
+
+def lps_of(fb_result):
+    return repr([o["logprobs"].to_torch().tolist() for o in fb_result.loss_fn_outputs])
+
+
+def main():
+    sc = tinker.ServiceClient()
+
+    print("P1: two tenants on one pool", flush=True)
+    tc_a = sc.create_lora_training_client(base_model=BASE_MODEL, rank=RANK)
+    tc_b = sc.create_lora_training_client(base_model=BASE_MODEL, rank=RANK)
+    print(f"  A={tc_a.model_id} B={tc_b.model_id}", flush=True)
+
+    probe_a = make_datums(8, salt=1)
+    probe_b = make_datums(8, salt=2)
+    probe_b2 = make_datums(4, salt=7, seq=48)   # different content AND shape
+    blocker = make_datums(1, salt=9)
+
+    print("P2 solo baselines", flush=True)
+    ra = tc_a.forward_backward(probe_a, "cross_entropy").result()
+    lp_a_solo = lps_of(ra)
+    gn_a_solo = step_lr0(tc_a.model_id).get("grad_norm")
+    rb = tc_b.forward_backward(probe_b, "cross_entropy").result()
+    lp_b_solo = lps_of(rb)
+    gn_b_solo = step_lr0(tc_b.model_id).get("grad_norm")
+    print(f"  gnA_solo={gn_a_solo!r} gnB_solo={gn_b_solo!r}", flush=True)
+
+    def co_round(tag, a_ds, b_ds):
+        """Blocker forward occupies the dispatcher; both fb's queue behind it
+        and merge. Returns (a_result, b_result, merged_flag)."""
+        fut_blk = tc_a.forward(blocker, "cross_entropy")
+        fut_a = tc_a.forward_backward(a_ds, "cross_entropy")
+        fut_b = tc_b.forward_backward(b_ds, "cross_entropy")
+        fut_blk.result()
+        res_a, res_b = fut_a.result(), fut_b.result()
+        merged = any(
+            "co_batched_fb" in k for k in (res_a.metrics or {})
+        ) and any(
+            "co_batched_fb" in k for k in (res_b.metrics or {})
+        )
+        check(f"{tag} merge engaged", merged,
+              f"(metrics A={sorted((res_a.metrics or {}))})" if not merged else "")
+        return res_a, res_b
+
+    print("P3 co-batched: same probes, merged into one train call", flush=True)
+    res_a, res_b = co_round("P3", probe_a, probe_b)
+    gn_a_co = step_lr0(tc_a.model_id).get("grad_norm")
+    gn_b_co = step_lr0(tc_b.model_id).get("grad_norm")
+    check("P3 A grad_norm co==solo", repr(gn_a_co) == repr(gn_a_solo),
+          f"{gn_a_co!r} vs {gn_a_solo!r}")
+    check("P3 B grad_norm co==solo", repr(gn_b_co) == repr(gn_b_solo),
+          f"{gn_b_co!r} vs {gn_b_solo!r}")
+    check("P3 A logprobs co==solo", lps_of(res_a) == lp_a_solo)
+    check("P3 B logprobs co==solo", lps_of(res_b) == lp_b_solo)
+
+    print("P4 asymmetric mix: A with a different co-tenant batch", flush=True)
+    res_a, _ = co_round("P4", probe_a, probe_b2)
+    gn_a_mix = step_lr0(tc_a.model_id).get("grad_norm")
+    step_lr0(tc_b.model_id)   # clear B's probe_b2 grads
+    check("P4 A grad_norm mix==solo", repr(gn_a_mix) == repr(gn_a_solo),
+          f"{gn_a_mix!r} vs {gn_a_solo!r}")
+    check("P4 A logprobs mix==solo", lps_of(res_a) == lp_a_solo)
+
+    for m in (tc_b.model_id, tc_a.model_id):
+        requests.post(f"{BASE}/api/v1/delete_model", headers=HDRS, json={"model_id": m})
+    print("\nG6:", "PASS" if not FAILS else f"FAIL ({', '.join(FAILS)})")
+    sys.exit(0 if not FAILS else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/gates/g6_batch_invariance.py
+++ b/scripts/gates/g6_batch_invariance.py
@@ -94,7 +94,11 @@ def main():
     probe_a = make_datums(8, salt=1)
     probe_b = make_datums(8, salt=2)
     probe_b2 = make_datums(4, salt=7, seq=48)   # different content AND shape
-    blocker = make_datums(1, salt=9)
+    # Queue-occupier for the merge window. NOTE: must be >= DP size — a
+    # request with fewer samples than DP ranks crashes miles'
+    # get_data_iterator (num_local_gbs=0 -> ZeroDivisionError) and the
+    # failed future leaves the SDK re-polling forever (known gaps, 003).
+    blocker = make_datums(2, salt=9)
 
     print("P2 solo baselines", flush=True)
     ra = tc_a.forward_backward(probe_a, "cross_entropy").result()

--- a/training/backends/miles/backend.py
+++ b/training/backends/miles/backend.py
@@ -667,6 +667,9 @@ class MilesBackend(TrainingBackend):
             }
 
         try:
+            # Same sample-count gate as fb: a request smaller than the DP
+            # width crashes get_data_iterator on the actors (num_local_gbs=0).
+            self._validate_fb(h, data)
             pool = self._pool
             if h.adapter_slot is not None and pool is not None:
                 return await self._pool_run(pool, _run)
@@ -675,7 +678,7 @@ class MilesBackend(TrainingBackend):
                 return await _run()
             finally:
                 h.lock.release()
-        except BackendError:
+        except (BackendError, ValueError):
             raise
         except Exception as e:
             raise BackendError(

--- a/training/backends/miles/backend.py
+++ b/training/backends/miles/backend.py
@@ -58,11 +58,32 @@ class MilesHandle(BackendHandle):
 
 
 @dataclass
+class _PoolOp:
+    """One queued pool operation. kind 'fb' ops are mergeable; 'other' ops
+    run their closure; 'stop' ends the dispatcher."""
+
+    kind: str                                   # "fb" | "other" | "stop"
+    future: Optional[asyncio.Future] = None
+    run: Any = None                             # "other": async closure
+    # fb fields:
+    handle: Any = None
+    rollout_data: Any = None
+    loss_fn: Optional[str] = None
+    num_samples: int = 0
+
+
+@dataclass
 class MilesPool:
-    """Shared multi-LoRA rails (M2): one boot serves N tenant adapters.
+    """Shared multi-LoRA rails (M2/M3): one boot serves N tenant adapters.
 
     First create_model boots the pool; later creates register into it;
-    delete deregisters, and the last tenant out tears the pool down."""
+    delete deregisters, and the last tenant out tears the pool down.
+
+    All GPU-bound ops flow through `queue`, consumed by ONE dispatcher task
+    in strict FIFO — the pool's serializer (was an asyncio.Lock in M2; a
+    queue makes the M3 co-batch merge window explicit). Consecutive queued
+    fb ops with the same loss_fn merge into one mixed-slot train call, up
+    to `cobatch_max_samples` (0 = merging off; batch of 1 == M2 behavior)."""
 
     train_group: Any
     rollout_manager: Any
@@ -75,6 +96,9 @@ class MilesPool:
     router_port: Optional[int] = None
     tenants: Dict[str, int] = field(default_factory=dict)   # model_id -> slot
     lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    queue: "asyncio.Queue[_PoolOp]" = field(default_factory=asyncio.Queue)
+    dispatcher: Optional[asyncio.Task] = None
+    cobatch_max_samples: int = 0
 
 
 class MilesBackend(TrainingBackend):
@@ -206,18 +230,22 @@ class MilesBackend(TrainingBackend):
             ) from e
         adapter_slot = registration["slot"]
 
+        async def _load_and_push() -> None:
+            # Actors load the PENDING adapter into its slot and mark it
+            # for push; update_weights upserts exactly the pending set
+            # (LoRA B=0 => zero-delta) and promotes it to ACTIVE.
+            await pool.train_group.reconcile_adapters()
+            await pool.train_group.update_weights()
+
+        async def _rollback() -> None:
+            await pool.controller.deregister_adapter.remote(adapter_name)
+            await pool.train_group.reconcile_adapters()
+
         try:
-            async with pool.lock:
-                # Actors load the PENDING adapter into its slot and mark it
-                # for push; update_weights upserts exactly the pending set
-                # (LoRA B=0 => zero-delta) and promotes it to ACTIVE.
-                await pool.train_group.reconcile_adapters()
-                await pool.train_group.update_weights()
+            await self._pool_run(pool, _load_and_push)
         except Exception as e:
             try:
-                await pool.controller.deregister_adapter.remote(adapter_name)
-                async with pool.lock:
-                    await pool.train_group.reconcile_adapters()
+                await self._pool_run(pool, _rollback)
             except Exception:
                 logger.warning(
                     "[%s] Pool join rollback failed for adapter %s",
@@ -430,6 +458,15 @@ class MilesBackend(TrainingBackend):
                 )
                 pool.tenants[model_id] = adapter_slot
                 handle.lock = pool.lock
+                pool.cobatch_max_samples = int(
+                    os.environ.get("TINKERCLOUD_MILES_COBATCH_MAX_SAMPLES", "0") or 0
+                )
+                pool.dispatcher = asyncio.create_task(self._pool_dispatcher_loop(pool))
+                if pool.cobatch_max_samples > 0:
+                    logger.info(
+                        "Pool co-batching ON: merging consecutive fb up to %d samples",
+                        pool.cobatch_max_samples,
+                    )
                 self._pool = pool
 
             logger.info("[%s] Miles model %s created successfully", request_id, model_id)
@@ -474,6 +511,131 @@ class MilesBackend(TrainingBackend):
         if cleanup:
             logger.info("create_model failure teardown: released %s", sorted(cleanup))
 
+    # ---- Pool dispatcher: the pool's serializer + M3 co-batch window ----
+
+    async def _pool_submit(self, pool: MilesPool, op: _PoolOp) -> Any:
+        if pool.dispatcher is None or pool.dispatcher.done():
+            raise BackendError(
+                "pool dispatcher not running", backend="miles", operation="pool",
+            )
+        op.future = asyncio.get_running_loop().create_future()
+        pool.queue.put_nowait(op)
+        return await op.future
+
+    async def _pool_run(self, pool: MilesPool, run) -> Any:
+        """Serialize an async closure through the pool queue (strict FIFO)."""
+        return await self._pool_submit(pool, _PoolOp(kind="other", run=run))
+
+    async def _pool_dispatcher_loop(self, pool: MilesPool) -> None:
+        """Single consumer of pool.queue. FIFO order is the execution order;
+        the only transformation is merging CONSECUTIVE same-loss_fn fb ops
+        (any tenants) into one mixed-slot train call — an op of any other
+        kind ends the drain, so a step never overtakes or absorbs a later fb."""
+        carry: Optional[_PoolOp] = None
+        while True:
+            op = carry if carry is not None else await pool.queue.get()
+            carry = None
+            if op.kind == "stop":
+                if op.future is not None and not op.future.done():
+                    op.future.set_result(None)
+                return
+            if op.kind == "other":
+                try:
+                    result = await op.run()
+                    if not op.future.done():
+                        op.future.set_result(result)
+                except Exception as e:  # noqa: BLE001 — surfaced via the future
+                    if not op.future.done():
+                        op.future.set_exception(e)
+                continue
+            batch = [op]
+            total = op.num_samples
+            while pool.cobatch_max_samples > 0:
+                try:
+                    nxt = pool.queue.get_nowait()
+                except asyncio.QueueEmpty:
+                    break
+                if (
+                    nxt.kind == "fb"
+                    and nxt.loss_fn == op.loss_fn
+                    and total + nxt.num_samples <= pool.cobatch_max_samples
+                ):
+                    batch.append(nxt)
+                    total += nxt.num_samples
+                else:
+                    carry = nxt   # FIFO: this op becomes the next head
+                    break
+            try:
+                per_request = await self._execute_fb_batch(pool, batch)
+                for o, r in zip(batch, per_request):
+                    if not o.future.done():
+                        o.future.set_result(r)
+            except Exception as e:  # noqa: BLE001 — surfaced via the futures
+                for o in batch:
+                    if o.future is not None and not o.future.done():
+                        o.future.set_exception(e)
+
+    async def _execute_fb_batch(self, pool: MilesPool, batch: List[_PoolOp]) -> List[Dict[str, Any]]:
+        """One train call for 1..k merged fb requests; split results back."""
+        from miles.utils.ray_utils import Box
+        from miles.ray.tinker_group import merge_dp_sample_outputs
+
+        if pool.rollout_manager is not None and pool.args.offload_rollout:
+            await pool.rollout_manager.offload.remote()
+
+        merged = self.converter.merge_forward_backward_batches(
+            [o.rollout_data for o in batch]
+        )
+        if len(batch) > 1:
+            logger.info(
+                "Co-batched fb: %d requests / %d samples / tenants %s",
+                len(batch), sum(o.num_samples for o in batch),
+                sorted({o.handle.model_id for o in batch}),
+            )
+
+        results = await pool.train_group.forward_backward_only(0, Box(ray.put(merged)))
+
+        # Batch-global metrics (per-tenant scalar loss is not separable in a
+        # mixed batch; per-datum outputs below are exact per tenant).
+        summed: Dict[str, float] = {}
+        reporting = 0
+        for r in results or []:
+            loss_dict = (r or {}).get("loss") or {}
+            if loss_dict:
+                reporting += 1
+                for k, v in loss_dict.items():
+                    summed[k] = summed.get(k, 0.0) + float(v)
+        averaged = {k: v / reporting for k, v in summed.items()} if reporting else {}
+        metrics = {f"{k}:mean": v for k, v in averaged.items()}
+        if len(batch) > 1:
+            metrics["co_batched_fb:max"] = float(len(batch))
+
+        logprobs_list = merge_dp_sample_outputs(results or [], key="log_probs")
+        expected = sum(o.num_samples for o in batch)
+        if len(logprobs_list) != expected:
+            raise BackendError(
+                f"co-batched fb returned {len(logprobs_list)} per-sample "
+                f"outputs for {expected} samples",
+                backend="miles", operation="forward_backward",
+            )
+
+        per_request = []
+        offset = 0
+        for o in batch:
+            lps = logprobs_list[offset:offset + o.num_samples]
+            offset += o.num_samples
+            per_request.append({
+                "loss_fn_output_type": o.loss_fn,
+                "loss": averaged.get("loss"),
+                "metrics": dict(metrics),
+                "loss_fn_outputs": [
+                    {"logprobs": {"data": lp.tolist(), "shape": [len(lp)], "dtype": "float32"}}
+                    for lp in lps
+                ],
+                "deferred": False,
+            })
+        return per_request
+
     async def forward(
         self,
         handle: BackendHandle,
@@ -481,8 +643,8 @@ class MilesBackend(TrainingBackend):
         loss_fn: str,
     ) -> Dict[str, Any]:
         h: MilesHandle = handle  # type: ignore[assignment]
-        await h.lock.acquire()
-        try:
+
+        async def _run() -> Dict[str, Any]:
             from miles.utils.ray_utils import Box
 
             if h.rollout_manager is not None and h.args.offload_rollout:
@@ -504,14 +666,39 @@ class MilesBackend(TrainingBackend):
                 "metrics": {},
             }
 
+        try:
+            pool = self._pool
+            if h.adapter_slot is not None and pool is not None:
+                return await self._pool_run(pool, _run)
+            await h.lock.acquire()
+            try:
+                return await _run()
+            finally:
+                h.lock.release()
         except BackendError:
             raise
         except Exception as e:
             raise BackendError(
                 str(e), backend="miles", operation="forward", original_error=e,
             ) from e
-        finally:
-            h.lock.release()
+
+    @staticmethod
+    def _validate_fb(h: MilesHandle, data: List[Dict]) -> None:
+        from ...core.validators import RequestValidator
+        from ...config import get_config
+
+        is_rl = not h.args.debug_train_only
+        config = get_config()
+        allow_partial = getattr(config, "allow_partial_batches", False)
+        validator = RequestValidator(h.args, allow_partial_batches=allow_partial)
+        validation_error = validator.validate_forward_backward_request(
+            data, is_rl=is_rl,
+        )
+        if validation_error:
+            raise ValueError(
+                f"Request validation failed:\n{validation_error}\n\n"
+                f"{validator.get_config_summary()}"
+            )
 
     async def forward_backward(
         self,
@@ -520,6 +707,25 @@ class MilesBackend(TrainingBackend):
         loss_fn: str,
     ) -> Dict[str, Any]:
         h: MilesHandle = handle  # type: ignore[assignment]
+        pool = self._pool
+        if h.adapter_slot is not None and pool is not None:
+            # Pool path: validate + convert here (CPU), then queue the GPU
+            # work — the dispatcher serializes and may co-batch it (M3).
+            try:
+                self._validate_fb(h, data)
+                rollout_data = self.converter.forward_backward_to_backend(
+                    data, loss_fn, h.args, adapter_slot=h.adapter_slot,
+                )
+                return await self._pool_submit(pool, _PoolOp(
+                    kind="fb", handle=h, rollout_data=rollout_data,
+                    loss_fn=loss_fn, num_samples=len(data),
+                ))
+            except (BackendError, ValueError):
+                raise
+            except Exception as e:
+                raise BackendError(
+                    str(e), backend="miles", operation="forward_backward", original_error=e,
+                ) from e
         await h.lock.acquire()
         try:
             from miles.utils.ray_utils import Box
@@ -527,22 +733,7 @@ class MilesBackend(TrainingBackend):
             if h.rollout_manager is not None and h.args.offload_rollout:
                 await h.rollout_manager.offload.remote()
 
-            is_rl = not h.args.debug_train_only
-
-            from ...core.validators import RequestValidator
-            from ...config import get_config
-
-            config = get_config()
-            allow_partial = getattr(config, "allow_partial_batches", False)
-            validator = RequestValidator(h.args, allow_partial_batches=allow_partial)
-            validation_error = validator.validate_forward_backward_request(
-                data, is_rl=is_rl,
-            )
-            if validation_error:
-                raise ValueError(
-                    f"Request validation failed:\n{validation_error}\n\n"
-                    f"{validator.get_config_summary()}"
-                )
+            self._validate_fb(h, data)
 
             rollout_data = self.converter.forward_backward_to_backend(
                 data, loss_fn, h.args, adapter_slot=h.adapter_slot,
@@ -604,8 +795,8 @@ class MilesBackend(TrainingBackend):
         # adam_params accepted for contract uniformity (P4); Miles applies lr
         # only — betas/eps are Megatron args fixed at creation.
         h: MilesHandle = handle  # type: ignore[assignment]
-        await h.lock.acquire()
-        try:
+
+        async def _run() -> Dict[str, Any]:
             # TinkerTrainGroup: apply_optimizer_step(learning_rate) fans out to
             # the actors; _and_sync additionally pushes weights to SGLang.
             offload_train = h.args.offload_train if h.args else True
@@ -640,26 +831,42 @@ class MilesBackend(TrainingBackend):
                 "model_id": h.model_id,
             }
 
+        try:
+            pool = self._pool
+            if h.adapter_slot is not None and pool is not None:
+                return await self._pool_run(pool, _run)
+            await h.lock.acquire()
+            try:
+                return await _run()
+            finally:
+                h.lock.release()
         except BackendError:
             raise
         except Exception as e:
             raise BackendError(
                 str(e), backend="miles", operation="apply_optimizer_step", original_error=e,
             ) from e
-        finally:
-            h.lock.release()
 
     async def update_inference_weights(self, handle: BackendHandle) -> None:
         h: MilesHandle = handle  # type: ignore[assignment]
-        await h.lock.acquire()
-        try:
+
+        async def _run() -> None:
             await h.train_group.update_weights()
+
+        try:
+            pool = self._pool
+            if h.adapter_slot is not None and pool is not None:
+                await self._pool_run(pool, _run)
+                return
+            await h.lock.acquire()
+            try:
+                await _run()
+            finally:
+                h.lock.release()
         except Exception as e:
             raise BackendError(
                 str(e), backend="miles", operation="update_inference_weights", original_error=e,
             ) from e
-        finally:
-            h.lock.release()
 
     async def save_checkpoint(
         self,
@@ -668,25 +875,29 @@ class MilesBackend(TrainingBackend):
         step_id: Optional[int] = None,
     ) -> str:
         h: MilesHandle = handle  # type: ignore[assignment]
-        await h.lock.acquire()
-        try:
+
+        async def _run() -> str:
             offload_train = h.args.offload_train if h.args else False
             if offload_train:
                 logger.info("Skipping save_model (offload_train=True)")
                 return checkpoint_path
 
-            if step_id is None:
-                step_id = 0
-
-            await h.train_group.save_model(step_id)
+            await h.train_group.save_model(step_id if step_id is not None else 0)
             return checkpoint_path
 
+        try:
+            pool = self._pool
+            if h.adapter_slot is not None and pool is not None:
+                return await self._pool_run(pool, _run)
+            await h.lock.acquire()
+            try:
+                return await _run()
+            finally:
+                h.lock.release()
         except Exception as e:
             raise BackendError(
                 str(e), backend="miles", operation="save_checkpoint", original_error=e,
             ) from e
-        finally:
-            h.lock.release()
 
     async def load_checkpoint(
         self,
@@ -779,13 +990,15 @@ class MilesBackend(TrainingBackend):
             if pool is None:
                 return
             if len(pool.tenants) > 1 or h.model_id not in pool.tenants:
+                async def _retire() -> None:
+                    await pool.controller.deregister_adapter.remote(h.adapter_name)
+                    # Actors retire the slot: abort in-flight sampling,
+                    # save the final adapter ckpt, clear slot weights /
+                    # optimizer state / retained grads, free the slot.
+                    await pool.train_group.reconcile_adapters()
+
                 try:
-                    async with pool.lock:
-                        await pool.controller.deregister_adapter.remote(h.adapter_name)
-                        # Actors retire the slot: abort in-flight sampling,
-                        # save the final adapter ckpt, clear slot weights /
-                        # optimizer state / retained grads, free the slot.
-                        await pool.train_group.reconcile_adapters()
+                    await self._pool_run(pool, _retire)
                 except Exception as e:
                     raise BackendError(
                         str(e), backend="miles", operation="delete_model", original_error=e,
@@ -799,27 +1012,33 @@ class MilesBackend(TrainingBackend):
             # Last tenant: the pool dies with it. Null the record even on a
             # partial teardown — a half-dead pool must not accept joins.
             try:
-                async with pool.lock:
-                    resources_freed = []
-                    try:
-                        await pool.controller.stop.remote()
-                    except Exception:
-                        logger.warning("Multi-LoRA controller stop failed; killing", exc_info=True)
-                    ray.kill(pool.controller, no_restart=True)
-                    resources_freed.append("multi_lora_controller")
-                    for actor in pool.train_group._actor_handles:
-                        ray.kill(actor, no_restart=True)
-                        resources_freed.append("actor")
-                    if pool.rollout_manager is not None:
-                        ray.kill(pool.rollout_manager, no_restart=True)
-                        resources_freed.append("rollout_manager")
-                    seen = set()
-                    for pg_tuple in (pool.placement_group or {}).values():
-                        pg_obj = pg_tuple[0] if isinstance(pg_tuple, tuple) else pg_tuple
-                        if pg_obj is not None and id(pg_obj) not in seen:
-                            seen.add(id(pg_obj))
-                            ray.util.remove_placement_group(pg_obj)
-                            resources_freed.append("placement_group")
+                # Drain + stop the dispatcher first: FIFO means every
+                # already-queued op completes before the stop resolves, so
+                # the kills below never race an in-flight broadcast.
+                try:
+                    await self._pool_submit(pool, _PoolOp(kind="stop"))
+                except BackendError:
+                    pass  # dispatcher already dead — proceed to kills
+                resources_freed = []
+                try:
+                    await pool.controller.stop.remote()
+                except Exception:
+                    logger.warning("Multi-LoRA controller stop failed; killing", exc_info=True)
+                ray.kill(pool.controller, no_restart=True)
+                resources_freed.append("multi_lora_controller")
+                for actor in pool.train_group._actor_handles:
+                    ray.kill(actor, no_restart=True)
+                    resources_freed.append("actor")
+                if pool.rollout_manager is not None:
+                    ray.kill(pool.rollout_manager, no_restart=True)
+                    resources_freed.append("rollout_manager")
+                seen = set()
+                for pg_tuple in (pool.placement_group or {}).values():
+                    pg_obj = pg_tuple[0] if isinstance(pg_tuple, tuple) else pg_tuple
+                    if pg_obj is not None and id(pg_obj) not in seen:
+                        seen.add(id(pg_obj))
+                        ray.util.remove_placement_group(pg_obj)
+                        resources_freed.append("placement_group")
             except Exception as e:
                 raise BackendError(
                     str(e), backend="miles", operation="delete_model", original_error=e,

--- a/training/backends/miles/converter.py
+++ b/training/backends/miles/converter.py
@@ -64,6 +64,35 @@ class MilesDataConverter(DataConverter):
         if adapter_slot is not None:
             rollout_data["adapter_slots"] = [adapter_slot] * num_samples
 
+    @staticmethod
+    def merge_forward_backward_batches(batches: List[Any]) -> Any:
+        """Concatenate per-request rollout_data dicts into one mixed-slot
+        batch (M3 co-batching). Per-sample list keys concatenate in request
+        order; scalars must agree across requests (same-loss_fn merge rule);
+        dynamic_global_batch_size sums. The miles DP split slot-sorts each
+        partition, so merged order need not be slot-sorted here."""
+        if len(batches) == 1:
+            return batches[0]
+        keys = set(batches[0].keys())
+        assert all(set(b.keys()) == keys for b in batches), \
+            f"co-batch key mismatch: {[sorted(b.keys()) for b in batches]}"
+        sizes = [b["dynamic_global_batch_size"] for b in batches]
+        merged: Dict[str, Any] = {}
+        for key in batches[0]:
+            v0 = batches[0][key]
+            if key == "dynamic_global_batch_size":
+                merged[key] = sum(sizes)
+            elif isinstance(v0, list) and all(
+                isinstance(b[key], list) and len(b[key]) == n
+                for b, n in zip(batches, sizes)
+            ):
+                merged[key] = [x for b in batches for x in b[key]]
+            else:
+                assert all(repr(b[key]) == repr(v0) for b in batches), \
+                    f"co-batch scalar mismatch on {key!r}"
+                merged[key] = v0
+        return merged
+
     def backend_to_forward_result(
         self,
         result: Any,

--- a/training/routers/futures.py
+++ b/training/routers/futures.py
@@ -66,7 +66,8 @@ async def retrieve_future(
     Returns:
     - 408 (Request Timeout) if operation is still running
     - 200 with result if completed successfully
-    - 500 if failed
+    - 400 if the operation terminally failed (the SDK retries 408 and every
+      5xx indefinitely, so a failed future MUST return 4xx or clients hang)
 
     Benefits:
     - Storage abstraction instead of direct dict access
@@ -130,8 +131,10 @@ async def retrieve_future(
             error = result["error"]
         elif "error" in future:
             error = future["error"]
-        # Return 500 with error
-        raise HTTPException(status_code=500, detail=error or "Operation failed")
+        # Terminal failure -> 4xx: the SDK treats 408 and all 5xx as
+        # retryable, so 500 here turns a dead op into an infinite client
+        # poll loop (observed 2026-07-31, G6 blocker probe).
+        raise HTTPException(status_code=400, detail=error or "Operation failed")
 
     else:  # status == "pending"
         # Return 408 (Request Timeout) while pending
@@ -152,7 +155,7 @@ async def retrieve_future_body(
     Returns:
     - 408 (Request Timeout) if operation is still running
     - 200 with result if completed successfully
-    - 500 if failed
+    - 400 if the operation terminally failed
     """
     # Delegate to the path-based version which implements the correct behavior
     return await retrieve_future(


### PR DESCRIPTION
M3: consecutive queued forward_backward calls from different tenants merge
into ONE mixed-slot train call.

- Pool ops now flow through a single FIFO dispatcher task (replaces the
  pool lock; batch-of-1 == M2 behavior, verified). Consecutive fb ops with
  the same loss_fn merge, capped by TINKERCLOUD_MILES_COBATCH_MAX_SAMPLES
  (0 = off, default). Any other op ends the merge window, so global FIFO
  order — and per-tenant fb->step ordering — is preserved exactly.
- No miles-side changes: per-sample adapter_slots + slot-sorted DP
  partitions + span routing + retained per-slot grads are all upstream.
- Converter gains merge_forward_backward_batches (per-sample keys concat,
  scalars must agree, batch sizes sum). Per-datum outputs stay exact per
  tenant; scalar metrics are batch-global, tagged co_batched_fb.
- Two rider fixes: forward now runs the same sample-count validation as fb
  (a sub-DP-sized request crashed the actor data iterator with
  ZeroDivisionError); terminally failed futures return 400 instead of 500
  (the SDK retries every 5xx indefinitely — a dead op became an infinite
  client poll loop).

Cluster results (pool mode, COBATCH_MAX_SAMPLES=32, Qwen2.5-0.5B r32):
- G6 batch-invariance (new gate) PASS at E0: same tenant batch solo vs
  co-batched with an equal co-tenant load vs a different-size/content
  co-tenant load — per-tenant grad_norm and per-datum logprobs
  bit-identical in all mixes (A 246.99384797500525, B 315.10317010861695),
  merge engagement verified via the co_batched_fb metric.
- G4 isolation PASS unchanged under the dispatcher, values bit-identical
  to the M2 lock-based runs (81.53626853086607 / 237.81900451025777) —
  including a run where the pipelined round genuinely merged.
- Per-tenant E2: two concurrent 30-step SFT tenants, NLL 2.803->2.2597 /
  2.803->2.2611 (baseline 2.80->2.26).
