### PR TITLE
M4: reorder drain (per-tenant-FIFO co-batch relaxation), G7 gate, RL-on-pool fixes, P-mix harness

### DIFF
--- a/scripts/gates/g7_reorder_merge.py
+++ b/scripts/gates/g7_reorder_merge.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""G7 reorder-drain gate (M4).
+
+Server must be in pool mode with merging AND reordering on:
+  TINKERCLOUD_MILES_MULTILORA_SLOTS>0
+  TINKERCLOUD_MILES_COBATCH_MAX_SAMPLES>=16
+  TINKERCLOUD_MILES_COBATCH_REORDER=1
+
+Pipelined recipe traffic (fb+step back-to-back per tenant) never merges
+under the conservative drain: the tenant's own step closes the merge
+window microseconds after its fb (measured: 0 merges across a full
+2-tenant recipe arm). The reorder drain defers OTHER tenants' non-fb ops
+past the window — legal because only per-tenant submission order is
+contractual (isolation invariant, G4). This gate checks the relaxation:
+  P1: tenants A and B on one pool.
+  P2 solo baselines: fb alone + step(lr=0) per tenant -> grad_norm + logprobs.
+  P3 pipelined+reordered: [fb_A, step_A, fb_B, step_B] submitted back-to-back
+     behind a queue-blocking forward. Reorder drain must defer step_A and
+     merge fb_A+fb_B (co_batched_fb metric on BOTH), then replay the steps.
+     Logprobs must equal solo bit-identically; post-round probes (fb+lr0
+     step) must reproduce the solo grad_norms bit-identically — leftover or
+     mispaired grads would show as exact 2x norm multiples (pure-sum).
+  P4 natural pipelined rounds: no blocker, 5 rounds of per-tenant fb+step(lr0)
+     — logprobs must stay bit-stable every round; merge count reported
+     (timing-dependent, not asserted).
+PASS = every comparison bit-identical (repr equality).
+"""
+import os, sys, time
+
+os.environ.setdefault("TINKER_BASE_URL", "http://localhost:8000")
+os.environ.setdefault("TINKER_API_KEY", "tml-dev-key")
+BASE = os.environ["TINKER_BASE_URL"]
+KEY = os.environ["TINKER_API_KEY"]
+
+import requests
+import torch
+import tinker
+from tinker import types
+
+BASE_MODEL = "Qwen/Qwen2.5-0.5B"
+RANK = 32
+SEQ = 64
+HDRS = {"X-API-Key": KEY, "Content-Type": "application/json"}
+FAILS = []
+
+
+def check(name, ok, detail=""):
+    print(f"  {name}: {'PASS' if ok else 'FAIL'}{' ' + detail if detail else ''}", flush=True)
+    if not ok:
+        FAILS.append(name)
+
+
+def make_datums(n, salt, seq=SEQ):
+    out = []
+    for i in range(n):
+        toks = [(1000 + (salt * 31 + i) * 7919 + j * 104729) % 50000 for j in range(seq)]
+        inp, tgt = toks[:-1], toks[1:]
+        out.append(types.Datum(
+            model_input=types.ModelInput.from_ints(inp),
+            loss_fn_inputs={
+                "weights": types.TensorData.from_torch(
+                    torch.ones(len(inp), dtype=torch.float32)),
+                "target_tokens": types.TensorData.from_torch(
+                    torch.tensor(tgt, dtype=torch.long)),
+            },
+        ))
+    return out
+
+
+def step_lr0(model_id):
+    r = requests.post(f"{BASE}/api/v1/optim_step", headers=HDRS, json={
+        "model_id": model_id, "adam_params": {"learning_rate": 0.0},
+    })
+    r.raise_for_status()
+    rid = r.json()["request_id"]
+    deadline = time.time() + 600
+    while time.time() < deadline:
+        fr = requests.post(f"{BASE}/api/v1/retrieve_future/{rid}", headers=HDRS)
+        if fr.status_code == 200:
+            return fr.json()
+        if fr.status_code == 408:
+            time.sleep(2)
+            continue
+        print(f"STEP FAILED ({fr.status_code}):", fr.text[:2000])
+        sys.exit(2)
+    print("STEP TIMEOUT")
+    sys.exit(2)
+
+
+def lps_of(fb_result):
+    return repr([o["logprobs"].to_torch().tolist() for o in fb_result.loss_fn_outputs])
+
+
+def merged_flag(res):
+    return any("co_batched_fb" in k for k in (res.metrics or {}))
+
+
+LR0 = types.AdamParams(learning_rate=0.0)
+
+
+def main():
+    sc = tinker.ServiceClient()
+
+    print("P1: two tenants on one pool", flush=True)
+    tc_a = sc.create_lora_training_client(base_model=BASE_MODEL, rank=RANK)
+    tc_b = sc.create_lora_training_client(base_model=BASE_MODEL, rank=RANK)
+    print(f"  A={tc_a.model_id} B={tc_b.model_id}", flush=True)
+
+    probe_a = make_datums(8, salt=1)
+    probe_b = make_datums(8, salt=2)
+    blocker = make_datums(2, salt=9)   # >= DP size (known gap, 003)
+
+    print("P2 solo baselines", flush=True)
+    ra = tc_a.forward_backward(probe_a, "cross_entropy").result()
+    lp_a_solo = lps_of(ra)
+    gn_a_solo = step_lr0(tc_a.model_id).get("grad_norm")
+    rb = tc_b.forward_backward(probe_b, "cross_entropy").result()
+    lp_b_solo = lps_of(rb)
+    gn_b_solo = step_lr0(tc_b.model_id).get("grad_norm")
+    print(f"  gnA_solo={gn_a_solo!r} gnB_solo={gn_b_solo!r}", flush=True)
+
+    print("P3 pipelined fb+step per tenant, behind a blocker", flush=True)
+    fut_blk = tc_a.forward(blocker, "cross_entropy")
+    fut_a = tc_a.forward_backward(probe_a, "cross_entropy")
+    fut_sa = tc_a.optim_step(LR0)
+    fut_b = tc_b.forward_backward(probe_b, "cross_entropy")
+    fut_sb = tc_b.optim_step(LR0)
+    fut_blk.result()
+    res_a, res_b = fut_a.result(), fut_b.result()
+    fut_sa.result(), fut_sb.result()
+    check("P3 merge engaged (A)", merged_flag(res_a),
+          f"(metrics A={sorted((res_a.metrics or {}))})")
+    check("P3 merge engaged (B)", merged_flag(res_b))
+    check("P3 A logprobs pipelined==solo", lps_of(res_a) == lp_a_solo)
+    check("P3 B logprobs pipelined==solo", lps_of(res_b) == lp_b_solo)
+    # Post-round state probes: the deferred steps must have consumed exactly
+    # their own fb's grads (mispairing shows as 2x probe norms).
+    tc_a.forward_backward(probe_a, "cross_entropy").result()
+    gn_a_post = step_lr0(tc_a.model_id).get("grad_norm")
+    tc_b.forward_backward(probe_b, "cross_entropy").result()
+    gn_b_post = step_lr0(tc_b.model_id).get("grad_norm")
+    check("P3 A probe grad_norm post==solo", repr(gn_a_post) == repr(gn_a_solo),
+          f"{gn_a_post!r} vs {gn_a_solo!r}")
+    check("P3 B probe grad_norm post==solo", repr(gn_b_post) == repr(gn_b_solo),
+          f"{gn_b_post!r} vs {gn_b_solo!r}")
+
+    print("P4 natural pipelined rounds (no blocker), 5x", flush=True)
+    merges = 0
+    for rnd in range(5):
+        fut_a = tc_a.forward_backward(probe_a, "cross_entropy")
+        fut_sa = tc_a.optim_step(LR0)
+        fut_b = tc_b.forward_backward(probe_b, "cross_entropy")
+        fut_sb = tc_b.optim_step(LR0)
+        res_a, res_b = fut_a.result(), fut_b.result()
+        fut_sa.result(), fut_sb.result()
+        merges += int(merged_flag(res_a) and merged_flag(res_b))
+        check(f"P4 r{rnd} A logprobs stable", lps_of(res_a) == lp_a_solo)
+        check(f"P4 r{rnd} B logprobs stable", lps_of(res_b) == lp_b_solo)
+    print(f"  natural-traffic merge rounds: {merges}/5 (informational)", flush=True)
+
+    for m in (tc_b.model_id, tc_a.model_id):
+        requests.post(f"{BASE}/api/v1/delete_model", headers=HDRS, json={"model_id": m})
+    print("\nG7:", "PASS" if not FAILS else f"FAIL ({', '.join(FAILS)})")
+    sys.exit(0 if not FAILS else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/gates/q4_rl_tenant.py
+++ b/scripts/gates/q4_rl_tenant.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Q4 P-mix RL tenant (M4).
+
+rl_basic-equivalent GSM8K RL against the local TinkerCloud miles pool:
+Qwen2.5-0.5B LoRA r32, 16 groups x 8 = 128 samples/batch, max_tokens 256,
+lr 4e-5 (rl_basic default), importance_sampling loss. Sized so each fb
+matches the SFT tenants' 128-datum batches. Phase structure is the point:
+rollout generation occupies the shared SGLang engines while the train
+GPUs idle -- the bubble a co-tenant's SFT training fills (P-mix).
+
+Env: Q4RL_LOG_PATH (default /data/q4_rl), Q4RL_BATCHES (default 12).
+"""
+import asyncio
+import os
+
+os.environ.setdefault("TINKER_BASE_URL", "http://localhost:8000")
+os.environ.setdefault("TINKER_API_KEY", "tml-dev-key")
+
+from tinker_cookbook.recipes.math_rl.math_env import Gsm8kDatasetBuilder
+from tinker_cookbook.rl import train
+
+MODEL = "Qwen/Qwen2.5-0.5B"
+RENDERER = "qwen3"
+LOG_PATH = os.environ.get("Q4RL_LOG_PATH", "/data/q4_rl")
+BATCHES = int(os.environ.get("Q4RL_BATCHES", "12"))
+
+config = train.Config(
+    log_path=LOG_PATH,
+    model_name=MODEL,
+    renderer_name=RENDERER,
+    dataset_builder=Gsm8kDatasetBuilder(
+        batch_size=16,
+        group_size=8,
+        renderer_name=RENDERER,
+        model_name_for_tokenizer=MODEL,
+    ),
+    learning_rate=4e-5,
+    max_tokens=256,
+    lora_rank=32,
+    max_steps=BATCHES,
+    eval_every=0,
+    save_every=0,
+)
+
+if __name__ == "__main__":
+    asyncio.run(train.main(config))

--- a/training/backends/miles/backend.py
+++ b/training/backends/miles/backend.py
@@ -678,14 +678,32 @@ class MilesBackend(TrainingBackend):
         for o in batch:
             lps = logprobs_list[offset:offset + o.num_samples]
             offset += o.num_samples
+            # Observation contract: per-datum logprobs are datum-aligned —
+            # length == model_input token length. The RL path computes N-1
+            # (causal shift over a full-sequence response): front-pad, which
+            # keeps suffix (action-token) alignment. Longer than the datum is
+            # a layout error: refuse rather than guess (reassemble-or-refuse).
+            toks = (o.rollout_data or {}).get("tokens") or []
+            outs = []
+            for j, lp in enumerate(lps):
+                lp_list = lp.tolist()
+                full = len(toks[j]) if j < len(toks) else len(lp_list)
+                if len(lp_list) < full:
+                    lp_list = [0.0] * (full - len(lp_list)) + lp_list
+                elif len(lp_list) > full:
+                    raise BackendError(
+                        f"sample {j}: {len(lp_list)} logprobs for "
+                        f"{full}-token input",
+                        backend="miles", operation="forward_backward",
+                    )
+                outs.append({"logprobs": {
+                    "data": lp_list, "shape": [len(lp_list)], "dtype": "float32",
+                }})
             per_request.append({
                 "loss_fn_output_type": o.loss_fn,
                 "loss": averaged.get("loss"),
                 "metrics": dict(metrics),
-                "loss_fn_outputs": [
-                    {"logprobs": {"data": lp.tolist(), "shape": [len(lp)], "dtype": "float32"}}
-                    for lp in lps
-                ],
+                "loss_fn_outputs": outs,
                 "deferred": False,
             })
         return per_request

--- a/training/backends/miles/backend.py
+++ b/training/backends/miles/backend.py
@@ -65,6 +65,7 @@ class _PoolOp:
     kind: str                                   # "fb" | "other" | "stop"
     future: Optional[asyncio.Future] = None
     run: Any = None                             # "other": async closure
+    tenant: Optional[str] = None                # model_id; None = barrier op
     # fb fields:
     handle: Any = None
     rollout_data: Any = None
@@ -99,6 +100,10 @@ class MilesPool:
     queue: "asyncio.Queue[_PoolOp]" = field(default_factory=asyncio.Queue)
     dispatcher: Optional[asyncio.Task] = None
     cobatch_max_samples: int = 0
+    # Reorder drain: the merge window may defer OTHER tenants' non-fb ops
+    # (cross-tenant order is not contractual; per-tenant FIFO is preserved
+    # via the blocked-tenant rule). Off by default.
+    cobatch_reorder: bool = False
 
 
 class MilesBackend(TrainingBackend):
@@ -461,11 +466,16 @@ class MilesBackend(TrainingBackend):
                 pool.cobatch_max_samples = int(
                     os.environ.get("TINKERCLOUD_MILES_COBATCH_MAX_SAMPLES", "0") or 0
                 )
+                pool.cobatch_reorder = bool(int(
+                    os.environ.get("TINKERCLOUD_MILES_COBATCH_REORDER", "0") or 0
+                ))
                 pool.dispatcher = asyncio.create_task(self._pool_dispatcher_loop(pool))
                 if pool.cobatch_max_samples > 0:
                     logger.info(
-                        "Pool co-batching ON: merging consecutive fb up to %d samples",
+                        "Pool co-batching ON: merging consecutive fb up to %d samples"
+                        " (reorder drain %s)",
                         pool.cobatch_max_samples,
+                        "ON" if pool.cobatch_reorder else "off",
                     )
                 self._pool = pool
 
@@ -522,20 +532,48 @@ class MilesBackend(TrainingBackend):
         pool.queue.put_nowait(op)
         return await op.future
 
-    async def _pool_run(self, pool: MilesPool, run) -> Any:
-        """Serialize an async closure through the pool queue (strict FIFO)."""
-        return await self._pool_submit(pool, _PoolOp(kind="other", run=run))
+    async def _pool_run(self, pool: MilesPool, run, tenant: Optional[str] = None) -> Any:
+        """Serialize an async closure through the pool queue (strict FIFO).
+        `tenant` marks ownership for the reorder drain; None = barrier."""
+        return await self._pool_submit(pool, _PoolOp(kind="other", run=run, tenant=tenant))
 
     async def _pool_dispatcher_loop(self, pool: MilesPool) -> None:
         """Single consumer of pool.queue. FIFO order is the execution order;
-        the only transformation is merging CONSECUTIVE same-loss_fn fb ops
-        (any tenants) into one mixed-slot train call — an op of any other
-        kind ends the drain, so a step never overtakes or absorbs a later fb."""
+        the only transformation is merging same-loss_fn fb ops (any tenants)
+        into one mixed-slot train call.
+
+        Conservative drain (default): only CONSECUTIVE fb ops merge — an op
+        of any other kind ends the drain, so a step never overtakes or
+        absorbs a later fb. Pipelined recipe traffic (fb+step back-to-back
+        per tenant) therefore never merges: the tenant's own step closes
+        the window microseconds after its fb.
+
+        Reorder drain (cobatch_reorder): only PER-TENANT submission order is
+        contractual; cross-tenant order is scheduler freedom (isolation
+        invariant, gate G4). The drain may defer other ops past the merge
+        window and replay them, in order, right after the merged call.
+        Per-tenant FIFO is exact: once ANY op of tenant t is deferred, t is
+        blocked — its later fb cannot join the batch (would overtake the
+        deferred op) and its later ops all defer (keep relative order).
+        Barrier ops (tenant None: stop / pool admin) still end the drain."""
         carry: Optional[_PoolOp] = None
+        pending: List[_PoolOp] = []       # reorder drain: deferred ops
         while True:
-            op = carry if carry is not None else await pool.queue.get()
-            carry = None
+            if carry is not None:
+                # carry left the queue after everything now in pending —
+                # append keeps replay order == queue arrival order.
+                pending.append(carry)
+                carry = None
+            if pending:
+                op = pending.pop(0)
+            else:
+                op = await pool.queue.get()
             if op.kind == "stop":
+                for p in pending:         # drain deferred before stopping
+                    if p.future is not None and not p.future.done():
+                        p.future.set_exception(
+                            BackendError("pool stopped", backend="miles", operation="pool")
+                        )
                 if op.future is not None and not op.future.done():
                     op.future.set_result(None)
                 return
@@ -550,6 +588,8 @@ class MilesBackend(TrainingBackend):
                 continue
             batch = [op]
             total = op.num_samples
+            blocked = {p.tenant for p in pending}
+            deferred_now = 0
             while pool.cobatch_max_samples > 0:
                 try:
                     nxt = pool.queue.get_nowait()
@@ -558,13 +598,27 @@ class MilesBackend(TrainingBackend):
                 if (
                     nxt.kind == "fb"
                     and nxt.loss_fn == op.loss_fn
+                    and nxt.tenant not in blocked
                     and total + nxt.num_samples <= pool.cobatch_max_samples
                 ):
                     batch.append(nxt)
                     total += nxt.num_samples
+                elif (
+                    pool.cobatch_reorder
+                    and nxt.kind != "stop"
+                    and nxt.tenant is not None
+                ):
+                    pending.append(nxt)   # defer; replayed in order after the call
+                    blocked.add(nxt.tenant)
+                    deferred_now += 1
                 else:
                     carry = nxt   # FIFO: this op becomes the next head
                     break
+            if deferred_now:
+                logger.info(
+                    "Reorder drain: deferred %d op(s) past the merge window",
+                    deferred_now,
+                )
             try:
                 per_request = await self._execute_fb_batch(pool, batch)
                 for o, r in zip(batch, per_request):
@@ -672,7 +726,7 @@ class MilesBackend(TrainingBackend):
             self._validate_fb(h, data)
             pool = self._pool
             if h.adapter_slot is not None and pool is not None:
-                return await self._pool_run(pool, _run)
+                return await self._pool_run(pool, _run, tenant=h.model_id)
             await h.lock.acquire()
             try:
                 return await _run()
@@ -721,7 +775,7 @@ class MilesBackend(TrainingBackend):
                 )
                 return await self._pool_submit(pool, _PoolOp(
                     kind="fb", handle=h, rollout_data=rollout_data,
-                    loss_fn=loss_fn, num_samples=len(data),
+                    loss_fn=loss_fn, num_samples=len(data), tenant=h.model_id,
                 ))
             except (BackendError, ValueError):
                 raise
@@ -837,7 +891,7 @@ class MilesBackend(TrainingBackend):
         try:
             pool = self._pool
             if h.adapter_slot is not None and pool is not None:
-                return await self._pool_run(pool, _run)
+                return await self._pool_run(pool, _run, tenant=h.model_id)
             await h.lock.acquire()
             try:
                 return await _run()
@@ -859,7 +913,7 @@ class MilesBackend(TrainingBackend):
         try:
             pool = self._pool
             if h.adapter_slot is not None and pool is not None:
-                await self._pool_run(pool, _run)
+                await self._pool_run(pool, _run, tenant=h.model_id)
                 return
             await h.lock.acquire()
             try:
@@ -891,7 +945,7 @@ class MilesBackend(TrainingBackend):
         try:
             pool = self._pool
             if h.adapter_slot is not None and pool is not None:
-                return await self._pool_run(pool, _run)
+                return await self._pool_run(pool, _run, tenant=h.model_id)
             await h.lock.acquire()
             try:
                 return await _run()
@@ -1001,7 +1055,7 @@ class MilesBackend(TrainingBackend):
                     await pool.train_group.reconcile_adapters()
 
                 try:
-                    await self._pool_run(pool, _retire)
+                    await self._pool_run(pool, _retire, tenant=h.model_id)
                 except Exception as e:
                     raise BackendError(
                         str(e), backend="miles", operation="delete_model", original_error=e,

--- a/training/backends/miles/backend.py
+++ b/training/backends/miles/backend.py
@@ -20,6 +20,22 @@ from ..base import BackendError, BackendHandle, TrainingBackend
 logger = logging.getLogger(__name__)
 
 
+def _model_input_lens(data: List[Any]) -> List[int]:
+    """Per-datum model_input token lengths (the observation-contract unit:
+    fb logprobs are datum-aligned to these, NOT to rollout tokens which
+    append the final target)."""
+    from ...core.data_converter import TinkerDataConverter
+
+    lens = []
+    for d in data:
+        mi = d.get("model_input") if isinstance(d, dict) else getattr(d, "model_input", None)
+        try:
+            lens.append(len(TinkerDataConverter.extract_tokens_from_model_input(mi)))
+        except Exception:  # noqa: BLE001 — fall back to no-op alignment
+            lens.append(0)
+    return lens
+
+
 @dataclass
 class MilesHandle(BackendHandle):
     """Miles-specific runtime state."""
@@ -71,6 +87,7 @@ class _PoolOp:
     rollout_data: Any = None
     loss_fn: Optional[str] = None
     num_samples: int = 0
+    input_lens: Optional[List[int]] = None      # per-datum model_input lengths
 
 
 @dataclass
@@ -679,15 +696,17 @@ class MilesBackend(TrainingBackend):
             lps = logprobs_list[offset:offset + o.num_samples]
             offset += o.num_samples
             # Observation contract: per-datum logprobs are datum-aligned —
-            # length == model_input token length. The RL path computes N-1
-            # (causal shift over a full-sequence response): front-pad, which
-            # keeps suffix (action-token) alignment. Longer than the datum is
-            # a layout error: refuse rather than guess (reassemble-or-refuse).
-            toks = (o.rollout_data or {}).get("tokens") or []
+            # length == the datum's model_input token length (captured at
+            # submit; rollout tokens append the final target and are +1).
+            # The RL path computes one fewer (causal shift over a
+            # full-sequence response): front-pad, which keeps suffix
+            # (action-token) alignment. Longer than the datum is a layout
+            # error: refuse rather than guess (reassemble-or-refuse).
+            in_lens = o.input_lens or []
             outs = []
             for j, lp in enumerate(lps):
                 lp_list = lp.tolist()
-                full = len(toks[j]) if j < len(toks) else len(lp_list)
+                full = in_lens[j] if j < len(in_lens) and in_lens[j] > 0 else len(lp_list)
                 if len(lp_list) < full:
                     lp_list = [0.0] * (full - len(lp_list)) + lp_list
                 elif len(lp_list) > full:
@@ -794,6 +813,7 @@ class MilesBackend(TrainingBackend):
                 return await self._pool_submit(pool, _PoolOp(
                     kind="fb", handle=h, rollout_data=rollout_data,
                     loss_fn=loss_fn, num_samples=len(data), tenant=h.model_id,
+                    input_lens=_model_input_lens(data),
                 ))
             except (BackendError, ValueError):
                 raise

--- a/training/core/data_converter.py
+++ b/training/core/data_converter.py
@@ -21,11 +21,13 @@ class TinkerDataConverter:
 
     @staticmethod
     def _get_field(obj: Any, field: str) -> Any:
-        """Get field from either dict or Pydantic model."""
+        """Get field from either dict or Pydantic model. Dict lookup FIRST:
+        hasattr-first returns bound methods for key names that collide with
+        dict methods (e.g. "values" -> dict.values, hit by the RL path)."""
+        if isinstance(obj, dict):
+            return obj.get(field)
         if hasattr(obj, field):
             return getattr(obj, field)
-        elif isinstance(obj, dict):
-            return obj.get(field)
         return None
 
     @staticmethod


### PR DESCRIPTION
## What

**Reorder drain** (`TINKERCLOUD_MILES_COBATCH_REORDER`, default off): the pool dispatcher's merge window may defer OTHER tenants' non-fb ops and replay them in arrival order after the merged call. Only per-tenant submission order is contractual; cross-tenant order is scheduler freedom (G4 isolation invariant). Blocked-tenant rule keeps per-tenant FIFO exact: once any op of tenant t defers, t's later fb cannot join the batch. Motivation: pipelined recipe traffic (fb+step back-to-back) NEVER merges under the conservative drain — the tenant's own step closes the window (measured: 0 merges across a full 2-tenant recipe arm; cap size was never the constraint).

**RL-on-pool fixes** (first RL recipe through the pooled rails flushed three):
- `_get_field` checks dict before hasattr — `"values"` key collides with `dict.values` bound method (RL fb queries values/returns; SFT never did)
- pool fb logprobs now datum-aligned to the model_input length captured at submit (RL path computes N-1 under the causal shift; front-pad keeps action-suffix alignment; over-length is refused). Alignment verified by the kl_sample_train oracle: 0.003–0.02 nats
- companion miles fix (separate PR): client-supplied per-token RL tensors moved to GPU in get_rollout_data

**New gates + harness**: G7 (reorder-drain: pipelined fb+step must merge AND reproduce solo observables bit-identically; natural-traffic merge 4/5 rounds vs ~0 conservative); q4_rl_tenant.py (GSM8K RL tenant for P-mix).

## Gates (server26, all four in one chain)

G2 PASS (per-datum lengths exact under new alignment), G6 PASS, G7 PASS, G4 PASS — every invariance comparison bit-identical. Absolute probe values shift across chained gates because (slot,version) never recurs ⇒ fresh registration = fresh adapter init (by design).

## Measured (Q4)

- 8-tenant merged vs conservative: ±0.5% (merge-neutral when compute-bound, as the overhead-fraction model predicts); equilibrium merge width ~2 = the frontier a closed-loop client exposes
- P-mix (2 SFT + 2 RL, one pool): fixed workloads in 72% of dedicated-serial GPU-time (1.39x e2e), 1.11x steady-state (boots excluded) — SFT fills RL rollout bubbles; all tenants at E2, isolation gates bit-identical