### PR TITLE
verl backend M1: training path via veRL's upstream Tinker split primitives

### DIFF
--- a/scripts/gates/g_lp_hf_parity.py
+++ b/scripts/gates/g_lp_hf_parity.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Logprob-provenance parity probe: backend fb logprobs vs direct HF forward.
+
+Creates a fresh LoRA model (B=0 init => base-model logprobs), sends one
+fixed datum through forward_backward, and compares the returned per-token
+logprobs against a local HF fp32 forward on the same tokens.
+PASS bar: max|delta| within mixed-precision tolerance (~1e-2 bf16 / 1e-3 fp32).
+"""
+import os
+
+os.environ.setdefault("TINKER_BASE_URL", "http://localhost:8000")
+os.environ.setdefault("TINKER_API_KEY", "tml-dev-key")
+
+import torch
+import tinker
+from tinker import types
+
+BASE_MODEL = "Qwen/Qwen2.5-0.5B"
+SEQ = 48
+
+
+def main():
+    torch.manual_seed(7)
+    sc = tinker.ServiceClient()
+    tc = sc.create_lora_training_client(base_model=BASE_MODEL, rank=32)
+
+    from transformers import AutoModelForCausalLM
+    hf = AutoModelForCausalLM.from_pretrained(BASE_MODEL, torch_dtype=torch.float32)
+    vocab = hf.config.vocab_size
+    toks = torch.randint(100, min(vocab, 50000), (SEQ,)).tolist()
+
+    inp, tgt = toks[:-1], toks[1:]
+    datum = types.Datum(
+        model_input=types.ModelInput.from_ints(inp),
+        loss_fn_inputs={
+            "weights": types.TensorData.from_torch(torch.ones(len(inp), dtype=torch.float32)),
+            "target_tokens": types.TensorData.from_torch(torch.tensor(tgt, dtype=torch.long)),
+        },
+    )
+    out = tc.forward_backward([datum], loss_fn="cross_entropy").result()
+    lp_backend = torch.tensor(out.loss_fn_outputs[0]["logprobs"].data, dtype=torch.float32)
+
+    with torch.no_grad():
+        logits = hf(torch.tensor([toks])).logits[0, :-1].float()
+    lp_hf = torch.log_softmax(logits, dim=-1).gather(-1, torch.tensor(tgt).unsqueeze(-1)).squeeze(-1)
+
+    assert lp_backend.shape == lp_hf.shape, (lp_backend.shape, lp_hf.shape)
+    delta = (lp_backend - lp_hf).abs()
+    print(f"len={len(lp_hf)} max|d|={delta.max():.6f} mean|d|={delta.mean():.6f}")
+    print(f"backend mean lp={lp_backend.mean():.4f}  hf mean lp={lp_hf.mean():.4f}")
+    # correlation catches misalignment even when scales differ; absolute
+    # deltas are bf16-vs-fp32 noise (~1% relative at -14-nat random-token
+    # tails; measured 2026-07-31: corr 0.999859, mean-lp agreement 0.004)
+    corr = torch.corrcoef(torch.stack([lp_backend, lp_hf]))[0, 1]
+    mean_gap = (lp_backend.mean() - lp_hf.mean()).abs().item()
+    print(f"corr={corr:.6f} mean_gap={mean_gap:.6f}")
+    verdict = "PASS" if corr > 0.999 and mean_gap < 0.02 else "FAIL"
+    print(f"G_lp HF-parity (E1, bf16 tolerance): {verdict}")
+
+
+if __name__ == "__main__":
+    main()

--- a/training/backends/factory.py
+++ b/training/backends/factory.py
@@ -21,7 +21,7 @@ class BackendFactory:
         Instantiate the training backend for the given type.
 
         Args:
-            backend_type: "miles", "nemo_rl", "automodel", or "megatron_bridge"
+            backend_type: "miles", "nemo_rl", "verl", "automodel", or "megatron_bridge"
             backend_overrides: Optional backend-specific config overrides.
 
         Returns:
@@ -42,6 +42,11 @@ class BackendFactory:
             logger.info("Creating NeMo RL backend")
             return NemoRLBackend(overrides)
 
+        elif backend_type == "verl":
+            from .verl.backend import VerlBackend
+            logger.info("Creating veRL backend")
+            return VerlBackend(overrides)
+
         elif backend_type == "automodel":
             from .automodel.backend import AutomodelBackend
             logger.info("Creating Automodel classification backend")
@@ -55,5 +60,5 @@ class BackendFactory:
         else:
             raise ValueError(
                 f"Unknown backend: {backend_type!r}. "
-                f"Supported backends: miles, nemo_rl, automodel, megatron_bridge"
+                f"Supported backends: miles, nemo_rl, verl, automodel, megatron_bridge"
             )

--- a/training/backends/verl/__init__.py
+++ b/training/backends/verl/__init__.py
@@ -1,0 +1,4 @@
+"""veRL backend package. Design + narratives: specs/006-verl-backend/."""
+from .backend import VerlBackend, VerlHandle
+
+__all__ = ["VerlBackend", "VerlHandle"]

--- a/training/backends/verl/backend.py
+++ b/training/backends/verl/backend.py
@@ -1,0 +1,421 @@
+"""
+veRL backend — binds veRL's upstream Tinker split-training primitives
+(verl.workers.engine_workers_tinker) behind the TrainingBackend ABC.
+
+Execution model: EAGER (Miles-shaped, NOT R9-buffered). veRL upstream ships
+TinkerTrainingWorker with decoupled forward_backward (grad-accumulating,
+returns per-token logprobs) + optimizer_step (accepts lr/betas/eps/
+weight_decay) + optimizer_zero_grad. forward_backward here does real GPU
+work and returns real logprobs; apply_optimizer_step applies AdamParams and
+steps once.
+
+M1 scope: training path only (create_model/fb/step/forward/get_logprobs/
+checkpoints/delete). sample() raises UnsupportedFeatureError — rollout
+engine + weight sync land in M2. Narrative: specs/006-verl-backend/design.md.
+"""
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+import torch
+
+from ..base import BackendError, BackendHandle, TrainingBackend, UnsupportedFeatureError
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class VerlHandle(BackendHandle):
+    """veRL-specific runtime state."""
+
+    worker_group: Any = None          # RayWorkerGroup over TinkerTrainingWorker
+    resource_pool: Any = None         # RayResourcePool
+    config: Dict = field(default_factory=dict)
+    hf_path: str = ""
+    dp_size: int = 1
+    loss_fn_name: str = ""            # currently installed loss fn on workers
+    weight_version: int = 0
+    created_at: str = ""
+    _lock: asyncio.Lock = field(default_factory=asyncio.Lock)  # FIFO per handle
+
+
+class VerlBackend(TrainingBackend):
+    """veRL backend using upstream TinkerTrainingWorker split primitives."""
+
+    def __init__(self, overrides: Optional[Dict[str, Any]] = None):
+        self.overrides = overrides or {}
+        self._converter = None
+        self._builder = None
+
+    @property
+    def converter(self):
+        if self._converter is None:
+            from .converter import VerlDataConverter
+            self._converter = VerlDataConverter()
+        return self._converter
+
+    @property
+    def builder(self):
+        if self._builder is None:
+            from .builder import VerlArgumentBuilder
+            self._builder = VerlArgumentBuilder(overrides=self.overrides)
+        return self._builder
+
+    # ---------------------------------------------------------------- create
+
+    async def create_model(
+        self,
+        model_id: str,
+        request_id: str,
+        base_model: str,
+        num_gpus: int,
+        lora_config: Optional[Dict[str, Any]] = None,
+        parallelism: Optional[Dict[str, Any]] = None,
+        rl_config: Optional[Dict[str, Any]] = None,
+        rollout_config: Optional[Dict[str, Any]] = None,
+        debug_train_only: bool = False,
+        checkpoint_path: Optional[str] = None,
+        max_batch_size: int = 4096,
+        max_seq_len: int = 2048,
+        rlve_config: Optional[Dict[str, Any]] = None,
+        wandb_config: Optional[Dict[str, Any]] = None,
+        objective: str = "language_modeling",
+        num_labels: Optional[int] = None,
+        head_config: Optional[Dict[str, Any]] = None,
+    ) -> VerlHandle:
+        if objective != "language_modeling":
+            raise BackendError(
+                f"verl is a language-modeling backend; objective {objective!r} unsupported",
+                backend="verl", operation="create_model",
+            )
+        try:
+            cfg = self.builder.build_args(
+                base_model=base_model, num_gpus=num_gpus, lora_config=lora_config,
+                parallelism=parallelism, rl_config=rl_config,
+                rollout_config=rollout_config, max_seq_len=max_seq_len,
+            )
+            worker_group, resource_pool, dp_size = await asyncio.to_thread(
+                _boot_worker_group, cfg, model_id,
+            )
+            handle = VerlHandle(
+                model_id=model_id,
+                backend_type="verl",
+                worker_group=worker_group,
+                resource_pool=resource_pool,
+                config=cfg,
+                hf_path=cfg["hf_path"],
+                dp_size=dp_size,
+                created_at=datetime.now().isoformat(),
+            )
+            if checkpoint_path:
+                await self.load_checkpoint(handle, checkpoint_path)
+            logger.info("[%s] verl model %s created (dp=%d)", request_id, model_id, dp_size)
+            return handle
+        except BackendError:
+            raise
+        except Exception as e:
+            raise BackendError(str(e), backend="verl", operation="create_model", original_error=e) from e
+
+    # ------------------------------------------------------------- train ops
+
+    async def forward_backward(
+        self,
+        handle: BackendHandle,
+        data: List[Dict],
+        loss_fn: str,
+    ) -> Dict[str, Any]:
+        h: VerlHandle = handle  # type: ignore[assignment]
+        async with h._lock:
+            try:
+                await asyncio.to_thread(self._ensure_loss_fn, h, loss_fn)
+                td = await asyncio.to_thread(self._to_tensordict, h, data, loss_fn)
+                out = await asyncio.to_thread(_wg_call, h.worker_group.forward_backward, td)
+                logprobs = await asyncio.to_thread(self._model_output_logprobs, out, td)
+                loss_fn_outputs = self.converter.extract_logprobs(logprobs, data)
+                metrics = _scalar_metrics(out)
+                return {"loss_fn_outputs": loss_fn_outputs, "metrics": metrics, "deferred": False}
+            except BackendError:
+                raise
+            except Exception as e:
+                raise BackendError(str(e), backend="verl", operation="forward_backward", original_error=e) from e
+
+    async def apply_optimizer_step(
+        self,
+        handle: BackendHandle,
+        learning_rate: Optional[float] = None,
+        adam_params: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        h: VerlHandle = handle  # type: ignore[assignment]
+        async with h._lock:
+            try:
+                params: Dict[str, Any] = {}
+                if learning_rate is not None:
+                    params["lr"] = float(learning_rate)
+                ap = adam_params or {}
+                if ap.get("beta1") is not None or ap.get("beta2") is not None:
+                    params["betas"] = (float(ap.get("beta1", 0.9)), float(ap.get("beta2", 0.95)))
+                if ap.get("eps") is not None:
+                    params["eps"] = float(ap["eps"])
+                if ap.get("weight_decay") is not None:
+                    params["weight_decay"] = float(ap["weight_decay"])
+                unsupported = {k: v for k, v in ap.items()
+                               if k not in ("beta1", "beta2", "eps", "weight_decay", "grad_clip_norm") and v is not None}
+                if unsupported:
+                    logger.warning("verl optim_step ignoring AdamParams %s", sorted(unsupported))
+                if ap.get("grad_clip_norm") is not None:
+                    logger.warning("verl optim_step: grad_clip_norm set at engine build, not per step")
+
+                metrics = await asyncio.to_thread(
+                    _wg_scalar_call, h.worker_group.optimizer_step, params or None,
+                )
+                h.weight_version += 1
+                grad_norm = metrics.get("grad_norm")
+                return {"success": True, "grad_norm": grad_norm, "metrics": metrics}
+            except BackendError:
+                raise
+            except Exception as e:
+                raise BackendError(str(e), backend="verl", operation="apply_optimizer_step", original_error=e) from e
+
+    async def forward(
+        self,
+        handle: BackendHandle,
+        data: List[Dict],
+        loss_fn: str,
+    ) -> Dict[str, Any]:
+        logprobs = await self.get_logprobs(handle, data)
+        return {"loss_fn_outputs": logprobs, "metrics": {}}
+
+    async def get_logprobs(
+        self,
+        handle: BackendHandle,
+        data: List[Dict],
+    ) -> List[Any]:
+        h: VerlHandle = handle  # type: ignore[assignment]
+        async with h._lock:
+            try:
+                td = await asyncio.to_thread(self._to_tensordict, h, data, "cross_entropy")
+                from verl.utils import tensordict_utils as tu
+                tu.assign_non_tensor(td, compute_loss=False)
+                out = await asyncio.to_thread(_wg_call, h.worker_group.infer_batch, td)
+                logprobs = await asyncio.to_thread(self._model_output_logprobs, out, td)
+                return self.converter.extract_logprobs(logprobs, data)
+            except BackendError:
+                raise
+            except Exception as e:
+                raise BackendError(str(e), backend="verl", operation="get_logprobs", original_error=e) from e
+
+    # ------------------------------------------------------------ lifecycle
+
+    async def update_inference_weights(self, handle: BackendHandle) -> None:
+        # M1: no rollout engine attached; no-op until M2 wires
+        # ActorRolloutRefWorker.update_weights.
+        return None
+
+    async def save_checkpoint(
+        self,
+        handle: BackendHandle,
+        checkpoint_path: str,
+        step_id: Optional[int] = None,
+    ) -> str:
+        h: VerlHandle = handle  # type: ignore[assignment]
+        async with h._lock:
+            try:
+                await asyncio.to_thread(
+                    h.worker_group.save_checkpoint, checkpoint_path, None, step_id or h.weight_version,
+                )
+                return checkpoint_path
+            except Exception as e:
+                raise BackendError(str(e), backend="verl", operation="save_checkpoint", original_error=e) from e
+
+    async def load_checkpoint(self, handle: BackendHandle, checkpoint_path: str) -> None:
+        h: VerlHandle = handle  # type: ignore[assignment]
+        async with h._lock:
+            try:
+                await asyncio.to_thread(h.worker_group.load_checkpoint, checkpoint_path)
+            except Exception as e:
+                raise BackendError(str(e), backend="verl", operation="load_checkpoint", original_error=e) from e
+
+    async def delete_model(self, handle: BackendHandle) -> None:
+        h: VerlHandle = handle  # type: ignore[assignment]
+        try:
+            import ray
+            for w in getattr(h.worker_group, "workers", []) or []:
+                try:
+                    ray.kill(w)
+                except Exception:
+                    pass
+            if h.resource_pool is not None:
+                pgs = getattr(h.resource_pool, "pgs", None) or []
+                for pg in pgs:
+                    try:
+                        ray.util.remove_placement_group(pg)
+                    except Exception:
+                        pass
+            h.worker_group = None
+            h.resource_pool = None
+        except Exception as e:
+            raise BackendError(str(e), backend="verl", operation="delete_model", original_error=e) from e
+
+    async def sample(
+        self,
+        handle: BackendHandle,
+        request_id: str,
+        prompt_tokens: List[int],
+        num_samples: int,
+        sampling_params: Optional[Dict[str, Any]] = None,
+        prompt_logprobs: bool = False,
+        pinned_version: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        raise UnsupportedFeatureError(
+            "sample", backend="verl",
+            suggestion="M1 is training-path only; rollout engine lands in M2 (specs/006)",
+        )
+
+    async def prepare_for_generation(self, handle: BackendHandle) -> None:
+        raise UnsupportedFeatureError(
+            "prepare_for_generation", backend="verl",
+            suggestion="M1 is training-path only; rollout engine lands in M2 (specs/006)",
+        )
+
+    # -------------------------------------------------------------- helpers
+
+    def _ensure_loss_fn(self, h: VerlHandle, loss_fn: str) -> None:
+        if h.loss_fn_name == loss_fn:
+            return
+        from .losses import get_loss_fn
+        from functools import partial
+        h.worker_group.set_loss_fn(partial(_loss_dispatch, loss_name=loss_fn))
+        _ = get_loss_fn(loss_fn)  # validate name eagerly
+        h.loss_fn_name = loss_fn
+
+    def _to_tensordict(self, h: VerlHandle, data: List[Dict], loss_fn: str):
+        from tensordict import TensorDict
+        from verl.utils import tensordict_utils as tu
+        from verl.workers.utils.padding import left_right_2_no_padding
+
+        padded = self.converter.forward_backward_to_backend(data, loss_fn, h.config)
+
+        # DP divisibility: pad with zero-weight clones (pure-sum => zero grad
+        # contribution, E0-safe) instead of rejecting or trimming.
+        b = padded["input_ids"].shape[0]
+        remainder = b % h.dp_size
+        if remainder:
+            pad_n = h.dp_size - remainder
+            for key, t in padded.items():
+                clone = t[:1].repeat(pad_n, *([1] * (t.dim() - 1))).clone()
+                if key in ("weights", "advantages"):
+                    clone.zero_()
+                padded[key] = torch.cat([t, clone], dim=0)
+
+        global_token_num = padded["attention_mask"].sum(dim=-1).tolist()
+        td = TensorDict(padded, batch_size=[padded["input_ids"].shape[0]])
+        td = left_right_2_no_padding(td)
+        tu.assign_non_tensor(td, global_token_num=global_token_num)
+        return td
+
+    @staticmethod
+    def _model_output_logprobs(out, td) -> torch.Tensor:
+        """Gathered worker output -> padded [B, Rmax] logprobs."""
+        from verl.utils import tensordict_utils as tu
+        from verl.workers.utils.padding import no_padding_2_padding
+
+        lp = tu.get(out, "log_probs")
+        if lp is None:
+            raise BackendError("worker returned no log_probs", backend="verl", operation="forward_backward")
+        return no_padding_2_padding(lp, td)
+
+
+def _loss_dispatch(config=None, model_output=None, data=None, dp_group=None, loss_name: str = "cross_entropy"):
+    """Module-level picklable shim: resolves the loss by name inside the worker."""
+    from .losses import get_loss_fn
+    return get_loss_fn(loss_name)(config, model_output, data, dp_group)
+
+
+def _wg_call(method, td):
+    """Blocking worker-group data call: resolve DataProtoFuture if non-blocking."""
+    out = method(td)
+    if hasattr(out, "get"):
+        out = out.get()
+    return out
+
+
+def _wg_scalar_call(method, *args):
+    out = method(*args)
+    if isinstance(out, list):
+        # ONE_TO_ALL returns per-worker dicts; grad_norm identical post-clip
+        merged: Dict[str, Any] = {}
+        for d in out:
+            if isinstance(d, dict):
+                merged.update(d)
+        return merged
+    if hasattr(out, "get"):
+        out = out.get()
+    return out or {}
+
+
+def _scalar_metrics(out) -> Dict[str, Any]:
+    from verl.utils import tensordict_utils as tu
+    try:
+        metrics = tu.get(out, "metrics") or {}
+    except Exception:
+        metrics = {}
+    return {k: v for k, v in dict(metrics).items()
+            if isinstance(v, (int, float, str)) and not k.startswith("perf/")}
+
+
+def _boot_worker_group(cfg: Dict[str, Any], model_id: str):
+    """Boot a TinkerTrainingWorker RayWorkerGroup (training path only)."""
+    import ray
+    from verl.single_controller.ray import RayClassWithInitArgs, RayResourcePool, RayWorkerGroup
+    from verl.workers.config import FSDPEngineConfig, FSDPOptimizerConfig, HFModelConfig
+    from verl.workers.engine_workers import TrainingWorkerConfig
+    from verl.workers.engine_workers_tinker import TinkerTrainingWorker
+
+    if not ray.is_initialized():
+        ray.init(address="auto", ignore_reinit_error=True)
+
+    model = cfg["model"]
+    engine = cfg["engine"]
+    model_config = HFModelConfig(
+        path=model["path"],
+        use_remove_padding=model["use_remove_padding"],
+        lora_rank=model["lora_rank"],
+        lora_alpha=model["lora_alpha"],
+        target_modules=model["target_modules"],
+    )
+    engine_config = FSDPEngineConfig(
+        forward_only=False,
+        strategy=engine["strategy"],
+        fsdp_size=engine["fsdp_size"],
+        ulysses_sequence_parallel_size=engine["ulysses_sequence_parallel_size"],
+        use_remove_padding=engine["use_remove_padding"],
+        use_dynamic_bsz=engine["use_dynamic_bsz"],
+        micro_batch_size_per_gpu=engine["micro_batch_size_per_gpu"],
+        max_token_len_per_gpu=engine["max_token_len_per_gpu"],
+        infer_micro_batch_size_per_gpu=engine["infer_micro_batch_size_per_gpu"],
+        infer_max_token_len_per_gpu=engine["infer_max_token_len_per_gpu"],
+        param_offload=engine["param_offload"],
+        optimizer_offload=engine["optimizer_offload"],
+        grad_offload=engine["grad_offload"],
+    )
+    optimizer_config = FSDPOptimizerConfig(
+        lr=cfg["optim"]["lr"], lr_scheduler_type=cfg["optim"]["lr_scheduler_type"],
+    )
+    worker_config = TrainingWorkerConfig(
+        model_type="language_model",
+        model_config=model_config,
+        engine_config=engine_config,
+        optimizer_config=optimizer_config,
+        checkpoint_config=None,
+    )
+
+    ray_cls = RayClassWithInitArgs(cls=ray.remote(TinkerTrainingWorker), config=worker_config)
+    resource_pool = RayResourcePool(process_on_nodes=[cfg["num_gpus"]], name_prefix=f"verl_{model_id}")
+    wg = RayWorkerGroup(resource_pool=resource_pool, ray_cls_with_init=ray_cls)
+    wg.reset()
+
+    sp = engine["ulysses_sequence_parallel_size"]
+    dp_size = max(cfg["num_gpus"] // max(sp, 1), 1)
+    return wg, resource_pool, dp_size

--- a/training/backends/verl/backend.py
+++ b/training/backends/verl/backend.py
@@ -135,7 +135,12 @@ class VerlBackend(TrainingBackend):
                 logprobs = await asyncio.to_thread(self._model_output_logprobs, out, td)
                 loss_fn_outputs = self.converter.extract_logprobs(logprobs, data)
                 metrics = _scalar_metrics(out)
-                return {"loss_fn_outputs": loss_fn_outputs, "metrics": metrics, "deferred": False}
+                return {
+                    "loss_fn_output_type": loss_fn,
+                    "loss_fn_outputs": loss_fn_outputs,
+                    "metrics": metrics,
+                    "deferred": False,
+                }
             except BackendError:
                 raise
             except Exception as e:
@@ -185,7 +190,7 @@ class VerlBackend(TrainingBackend):
         loss_fn: str,
     ) -> Dict[str, Any]:
         logprobs = await self.get_logprobs(handle, data)
-        return {"loss_fn_outputs": logprobs, "metrics": {}}
+        return {"loss_fn_output_type": loss_fn, "loss_fn_outputs": logprobs, "metrics": {}}
 
     async def get_logprobs(
         self,
@@ -297,12 +302,15 @@ class VerlBackend(TrainingBackend):
 
         padded = self.converter.forward_backward_to_backend(data, loss_fn, h.config)
 
-        # DP divisibility: pad with zero-weight clones (pure-sum => zero grad
-        # contribution, E0-safe) instead of rejecting or trimming.
+        # Divisibility: engine needs per-DP-rank count % micro_batch_size == 0.
+        # Pad with zero-weight clones (pure-sum => zero grad, E0-safe)
+        # instead of rejecting or trimming.
+        micro_bs = int(h.config.get("engine", {}).get("micro_batch_size_per_gpu", 1) or 1)
+        multiple = h.dp_size * micro_bs
         b = padded["input_ids"].shape[0]
-        remainder = b % h.dp_size
+        remainder = b % multiple
         if remainder:
-            pad_n = h.dp_size - remainder
+            pad_n = multiple - remainder
             for key, t in padded.items():
                 clone = t[:1].repeat(pad_n, *([1] * (t.dim() - 1))).clone()
                 if key in ("weights", "advantages"):
@@ -312,7 +320,9 @@ class VerlBackend(TrainingBackend):
         global_token_num = padded["attention_mask"].sum(dim=-1).tolist()
         td = TensorDict(padded, batch_size=[padded["input_ids"].shape[0]])
         td = left_right_2_no_padding(td)
-        tu.assign_non_tensor(td, global_token_num=global_token_num)
+        # temperature: engine divides logits by it (logprob provenance);
+        # training-side logprobs are untempered in the Tinker contract
+        tu.assign_non_tensor(td, global_token_num=global_token_num, temperature=1.0)
         return td
 
     @staticmethod
@@ -361,8 +371,17 @@ def _scalar_metrics(out) -> Dict[str, Any]:
         metrics = tu.get(out, "metrics") or {}
     except Exception:
         metrics = {}
-    return {k: v for k, v in dict(metrics).items()
-            if isinstance(v, (int, float, str)) and not k.startswith("perf/")}
+    out_metrics = {}
+    for k, v in dict(metrics).items():
+        if k.startswith("perf/"):
+            continue
+        if hasattr(v, "data"):
+            v = v.data
+        if isinstance(v, (int, float)):
+            # SDK metric keys are "name:reduction" (chunked_fwdbwd_helpers)
+            key = k.replace(":", "_").replace("/", "_")
+            out_metrics[f"{key}:sum"] = float(v)
+    return out_metrics
 
 
 def _boot_worker_group(cfg: Dict[str, Any], model_id: str):

--- a/training/backends/verl/builder.py
+++ b/training/backends/verl/builder.py
@@ -31,7 +31,9 @@ class VerlArgumentBuilder(ArgumentBuilder):
 
         hf_path = self._resolve_hf_path(base_model)
 
-        lora_rank = int(lora_config.get("rank", lora_config.get("lora_rank", 0)) or 0)
+        # request payloads carry explicit None values — coalesce, don't .get()-default
+        lora_rank = int(lora_config.get("rank") or lora_config.get("lora_rank") or 0)
+        lora_alpha = float(lora_config.get("alpha") or lora_config.get("lora_alpha") or 32)
         target_modules = lora_config.get("target_modules") or "all-linear"
 
         cfg: Dict[str, Any] = {
@@ -44,7 +46,7 @@ class VerlArgumentBuilder(ArgumentBuilder):
                 # namespace (model.lora.rank) must stay 0 — duplicated-knob
                 # trap, specs/006 q2-plan.md
                 "lora_rank": lora_rank,
-                "lora_alpha": float(lora_config.get("alpha", lora_config.get("lora_alpha", 32))),
+                "lora_alpha": lora_alpha,
                 "target_modules": target_modules,
             },
             "engine": {

--- a/training/backends/verl/builder.py
+++ b/training/backends/verl/builder.py
@@ -1,0 +1,83 @@
+"""
+veRL argument builder: HF model + tinker knobs -> config dict.
+
+Returns a plain dict; VerlBackend materializes veRL dataclasses lazily on the
+server (where verl is importable). FSDP2 strategy first; Megatron later.
+"""
+import os
+from typing import Any, Dict, Optional
+
+from ..base import ArgumentBuilder
+
+
+class VerlArgumentBuilder(ArgumentBuilder):
+    def __init__(self, overrides: Optional[Dict[str, Any]] = None):
+        self.overrides = overrides or {}
+
+    def build_args(
+        self,
+        base_model: str,
+        num_gpus: int = 4,
+        lora_config: Optional[Dict[str, Any]] = None,
+        parallelism: Optional[Dict[str, Any]] = None,
+        rl_config: Optional[Dict[str, Any]] = None,
+        rollout_config: Optional[Dict[str, Any]] = None,
+        checkpoint_config: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> Dict[str, Any]:
+        parallelism = parallelism or {}
+        lora_config = lora_config or {}
+        max_seq_len = int(kwargs.get("max_seq_len", 2048))
+
+        hf_path = self._resolve_hf_path(base_model)
+
+        lora_rank = int(lora_config.get("rank", lora_config.get("lora_rank", 0)) or 0)
+        target_modules = lora_config.get("target_modules") or "all-linear"
+
+        cfg: Dict[str, Any] = {
+            "hf_path": hf_path,
+            "num_gpus": num_gpus,
+            "model": {
+                "path": hf_path,
+                "use_remove_padding": True,
+                # FSDP LoRA namespace ONLY (model.lora_rank); the Megatron
+                # namespace (model.lora.rank) must stay 0 — duplicated-knob
+                # trap, specs/006 q2-plan.md
+                "lora_rank": lora_rank,
+                "lora_alpha": float(lora_config.get("alpha", lora_config.get("lora_alpha", 32))),
+                "target_modules": target_modules,
+            },
+            "engine": {
+                "strategy": self.overrides.get("strategy", "fsdp2"),
+                "fsdp_size": num_gpus,
+                "ulysses_sequence_parallel_size": int(parallelism.get("sp_size", 1)),
+                "forward_only": False,
+                "use_remove_padding": True,
+                # fixed micro-batch (dynamic_bsz = batch-composition-dependent
+                # micro-partitioning; pure-sum makes it E0-safe but keep the
+                # default deterministic)
+                "use_dynamic_bsz": bool(self.overrides.get("use_dynamic_bsz", False)),
+                "micro_batch_size_per_gpu": int(self.overrides.get("micro_batch_size_per_gpu", 2)),
+                "max_token_len_per_gpu": max_seq_len * 4,
+                "infer_micro_batch_size_per_gpu": int(self.overrides.get("infer_micro_batch_size_per_gpu", 4)),
+                "infer_max_token_len_per_gpu": max_seq_len * 8,
+                "param_offload": bool(self.overrides.get("param_offload", False)),
+                "optimizer_offload": bool(self.overrides.get("optimizer_offload", False)),
+                "grad_offload": bool(self.overrides.get("grad_offload", False)),
+            },
+            "optim": {
+                # placeholder; client owns LR per optim_step (OptimStepParams)
+                "lr": 1e-6,
+                "lr_scheduler_type": "constant",
+            },
+            "max_seq_len": max_seq_len,
+        }
+        return cfg
+
+    @staticmethod
+    def _resolve_hf_path(base_model: str) -> str:
+        for root in filter(None, [os.environ.get("TINKERCLOUD_MODEL_ROOT"), "/data/models", "/root/models"]):
+            candidate = os.path.join(root, base_model)
+            if os.path.isdir(candidate):
+                return candidate
+        return base_model  # HF hub id / absolute path

--- a/training/backends/verl/converter.py
+++ b/training/backends/verl/converter.py
@@ -6,7 +6,8 @@ veRL's prompt_len > 0 requirement), responses = tokens[1:] right-padded.
 Engine log_probs[t] = logp(tokens[t+1] | tokens[:t+1]) then align 1:1 with
 client target_tokens / weights / advantages (all length N-1, Miles parity).
 
-Datum schemas (from tinker-cookbook):
+Datum schemas (from tinker-cookbook; arrives as Pydantic
+ForwardBackwardDatum OR plain dict — handle both):
   SFT: model_input.tokens = tokens[:-1], target_tokens = tokens[1:],
        weights = weights[1:]  (full seq = tokens[:-1] + [target_tokens[-1]])
   RL:  model_input.tokens = full rollout, loss_fn_inputs = {advantages,
@@ -19,45 +20,65 @@ import torch
 from ..base import DataConverter
 
 
-def _get_field(datum: Dict, *names):
-    """First present key among names, searching datum and loss_fn_inputs.
+def _attr_or_key(obj, field: str):
+    if obj is None:
+        return None
+    if isinstance(obj, dict):
+        return obj.get(field)
+    return getattr(obj, field, None)
 
-    hasattr-before-dict ordering matters: plain dicts expose .values (bound
-    method) — always check dict membership first (BUG: values-collision).
-    """
-    for holder in (datum, datum.get("loss_fn_inputs") or {}):
-        for name in names:
-            if isinstance(holder, dict):
-                if name in holder:
-                    return holder[name]
-            elif hasattr(holder, name):
-                return getattr(holder, name)
+
+def _tensor_data(obj, dtype) -> torch.Tensor:
+    """TensorData (pydantic .data / wire {'data': ...}) or raw list -> 1-D tensor."""
+    if obj is None:
+        return None
+    data = obj
+    if not isinstance(obj, (list, tuple, torch.Tensor)):
+        inner = _attr_or_key(obj, "data")
+        if inner is not None:
+            data = inner
+    if isinstance(data, torch.Tensor):
+        return data.detach().cpu().to(dtype).flatten()
+    try:
+        return torch.tensor(data, dtype=dtype).flatten()
+    except (TypeError, ValueError):
+        return None
+
+
+def _loss_input(datum, *names):
+    lfi = _attr_or_key(datum, "loss_fn_inputs")
+    for name in names:
+        v = _attr_or_key(lfi, name)
+        if v is not None:
+            return v
     return None
 
 
-def _as_1d_tensor(value, dtype):
-    if value is None:
-        return None
-    if isinstance(value, torch.Tensor):
-        return value.detach().to(dtype).flatten()
-    if isinstance(value, dict) and "data" in value:  # TensorData wire format
-        return torch.tensor(value["data"], dtype=dtype).flatten()
-    return torch.tensor(value, dtype=dtype).flatten()
+def _extract_tokens(datum) -> torch.Tensor:
+    toks: List[int] = []
+    model_input = _attr_or_key(datum, "model_input")
+    if model_input is not None:
+        chunks = _attr_or_key(model_input, "chunks")
+        if chunks:
+            for c in chunks:
+                t = _attr_or_key(c, "tokens")
+                if t is not None:
+                    toks.extend(t.tolist() if isinstance(t, torch.Tensor) else list(t))
+        else:
+            t = _attr_or_key(model_input, "tokens")
+            if t is not None:
+                toks = t.tolist() if isinstance(t, torch.Tensor) else list(t)
+    if not toks:
+        t = _attr_or_key(datum, "tokens")
+        if t is not None:
+            toks = t.tolist() if isinstance(t, torch.Tensor) else list(t)
+    assert toks, "datum has no tokens"
+    return torch.tensor(toks, dtype=torch.long)
 
 
-def _full_tokens(datum: Dict) -> torch.Tensor:
-    model_input = datum.get("model_input") or {}
-    tokens = _get_field({"model_input": None, **datum}, "tokens") or (
-        model_input.get("tokens") if isinstance(model_input, dict) else None
-    )
-    if tokens is None and isinstance(model_input, dict):
-        # chunked wire format: model_input {"chunks": [{"tokens": [...]}]}
-        chunks = model_input.get("chunks") or []
-        tokens = [t for c in chunks for t in c.get("tokens", [])]
-    tokens = _as_1d_tensor(tokens, torch.long)
-    assert tokens is not None and tokens.numel() > 0, "datum has no tokens"
-
-    target = _as_1d_tensor(_get_field(datum, "target_tokens"), torch.long)
+def _full_tokens(datum) -> torch.Tensor:
+    tokens = _extract_tokens(datum)
+    target = _tensor_data(_loss_input(datum, "target_tokens"), torch.long)
     if target is not None and target.numel() > 0:
         # SFT shape: model tokens are tokens[:-1]; append final target token
         return torch.cat([tokens, target[-1:]])
@@ -70,7 +91,7 @@ class VerlDataConverter(DataConverter):
 
     def forward_backward_to_backend(
         self,
-        data: List[Dict],
+        data: List[Any],
         loss_fn: str,
         args: Any,
     ) -> Dict[str, torch.Tensor]:
@@ -96,13 +117,13 @@ class VerlDataConverter(DataConverter):
             responses[i, : n - 1] = seq[1:]
             response_mask[i, : n - 1] = 1
 
-            w = _as_1d_tensor(_get_field(data[i], "weights"), torch.float32)
+            w = _tensor_data(_loss_input(data[i], "weights"), torch.float32)
             if w is not None:
                 weights[i, : min(len(w), n - 1)] = w[: n - 1]
-            adv = _as_1d_tensor(_get_field(data[i], "advantages"), torch.float32)
+            adv = _tensor_data(_loss_input(data[i], "advantages"), torch.float32)
             if adv is not None:
                 advantages[i, : min(len(adv), n - 1)] = adv[: n - 1]
-            lp = _as_1d_tensor(_get_field(data[i], "logprobs", "log_probs"), torch.float32)
+            lp = _tensor_data(_loss_input(data[i], "logprobs", "log_probs"), torch.float32)
             if lp is not None:
                 old_log_probs[i, : min(len(lp), n - 1)] = lp[: n - 1]
 
@@ -121,21 +142,21 @@ class VerlDataConverter(DataConverter):
             out["old_log_probs"] = old_log_probs
         return out
 
-    def forward_to_backend(self, data: List[Dict], args: Any) -> Any:
+    def forward_to_backend(self, data: List[Any], args: Any) -> Any:
         return self.forward_backward_to_backend(data, "cross_entropy", args)
 
-    def backend_to_forward_result(self, result: Any, data: List[Dict]) -> Dict[str, Any]:
+    def backend_to_forward_result(self, result: Any, data: List[Any]) -> Dict[str, Any]:
         return {"loss_fn_outputs": self.extract_logprobs(result, data), "metrics": {}}
 
-    def backend_to_forward_backward_result(self, result: Any, data: List[Dict]) -> Dict[str, Any]:
+    def backend_to_forward_backward_result(self, result: Any, data: List[Any]) -> Dict[str, Any]:
         return {"loss_fn_outputs": self.extract_logprobs(result, data), "metrics": {}}
 
     @staticmethod
-    def extract_logprobs(padded_logprobs: torch.Tensor, data: List[Dict]) -> List[Dict[str, Any]]:
+    def extract_logprobs(padded_logprobs: torch.Tensor, data: List[Any]) -> List[Dict[str, Any]]:
         """Datum-aligned per-sample logprobs (length N_i - 1 each)."""
         outputs = []
         for i, datum in enumerate(data):
             n = int(_full_tokens(datum).numel())
-            lp = padded_logprobs[i, : n - 1].detach().cpu()
+            lp = padded_logprobs[i, : n - 1].detach().float().cpu()
             outputs.append({"logprobs": {"data": lp.tolist(), "dtype": "float32", "shape": [n - 1]}})
         return outputs

--- a/training/backends/verl/converter.py
+++ b/training/backends/verl/converter.py
@@ -1,0 +1,141 @@
+"""
+veRL data converter: Tinker Datum list <-> veRL padded/left-right TensorDict.
+
+Layout: prompt = tokens[0:1] (prompt_len == 1 for every sample, satisfying
+veRL's prompt_len > 0 requirement), responses = tokens[1:] right-padded.
+Engine log_probs[t] = logp(tokens[t+1] | tokens[:t+1]) then align 1:1 with
+client target_tokens / weights / advantages (all length N-1, Miles parity).
+
+Datum schemas (from tinker-cookbook):
+  SFT: model_input.tokens = tokens[:-1], target_tokens = tokens[1:],
+       weights = weights[1:]  (full seq = tokens[:-1] + [target_tokens[-1]])
+  RL:  model_input.tokens = full rollout, loss_fn_inputs = {advantages,
+       logprobs (sampling), ...} aligned to tokens[1:].
+"""
+from typing import Any, Dict, List
+
+import torch
+
+from ..base import DataConverter
+
+
+def _get_field(datum: Dict, *names):
+    """First present key among names, searching datum and loss_fn_inputs.
+
+    hasattr-before-dict ordering matters: plain dicts expose .values (bound
+    method) — always check dict membership first (BUG: values-collision).
+    """
+    for holder in (datum, datum.get("loss_fn_inputs") or {}):
+        for name in names:
+            if isinstance(holder, dict):
+                if name in holder:
+                    return holder[name]
+            elif hasattr(holder, name):
+                return getattr(holder, name)
+    return None
+
+
+def _as_1d_tensor(value, dtype):
+    if value is None:
+        return None
+    if isinstance(value, torch.Tensor):
+        return value.detach().to(dtype).flatten()
+    if isinstance(value, dict) and "data" in value:  # TensorData wire format
+        return torch.tensor(value["data"], dtype=dtype).flatten()
+    return torch.tensor(value, dtype=dtype).flatten()
+
+
+def _full_tokens(datum: Dict) -> torch.Tensor:
+    model_input = datum.get("model_input") or {}
+    tokens = _get_field({"model_input": None, **datum}, "tokens") or (
+        model_input.get("tokens") if isinstance(model_input, dict) else None
+    )
+    if tokens is None and isinstance(model_input, dict):
+        # chunked wire format: model_input {"chunks": [{"tokens": [...]}]}
+        chunks = model_input.get("chunks") or []
+        tokens = [t for c in chunks for t in c.get("tokens", [])]
+    tokens = _as_1d_tensor(tokens, torch.long)
+    assert tokens is not None and tokens.numel() > 0, "datum has no tokens"
+
+    target = _as_1d_tensor(_get_field(datum, "target_tokens"), torch.long)
+    if target is not None and target.numel() > 0:
+        # SFT shape: model tokens are tokens[:-1]; append final target token
+        return torch.cat([tokens, target[-1:]])
+    return tokens
+
+
+class VerlDataConverter(DataConverter):
+    """Tinker Datum list -> padded left-right dict (backend nests it via
+    verl's left_right_2_no_padding at dispatch time)."""
+
+    def forward_backward_to_backend(
+        self,
+        data: List[Dict],
+        loss_fn: str,
+        args: Any,
+    ) -> Dict[str, torch.Tensor]:
+        seqs = [_full_tokens(d) for d in data]
+        n_lens = [int(s.numel()) for s in seqs]
+        resp_lens = [n - 1 for n in n_lens]
+        b, rmax = len(seqs), max(resp_lens)
+        smax = rmax + 1
+
+        input_ids = torch.zeros(b, smax, dtype=torch.long)
+        attention_mask = torch.zeros(b, smax, dtype=torch.long)
+        position_ids = torch.zeros(b, smax, dtype=torch.long)
+        responses = torch.zeros(b, rmax, dtype=torch.long)
+        response_mask = torch.zeros(b, rmax, dtype=torch.long)
+        weights = torch.zeros(b, rmax, dtype=torch.float32)
+        advantages = torch.zeros(b, rmax, dtype=torch.float32)
+        old_log_probs = torch.zeros(b, rmax, dtype=torch.float32)
+
+        for i, (seq, n) in enumerate(zip(seqs, n_lens)):
+            input_ids[i, :n] = seq
+            attention_mask[i, :n] = 1
+            position_ids[i, :n] = torch.arange(n)
+            responses[i, : n - 1] = seq[1:]
+            response_mask[i, : n - 1] = 1
+
+            w = _as_1d_tensor(_get_field(data[i], "weights"), torch.float32)
+            if w is not None:
+                weights[i, : min(len(w), n - 1)] = w[: n - 1]
+            adv = _as_1d_tensor(_get_field(data[i], "advantages"), torch.float32)
+            if adv is not None:
+                advantages[i, : min(len(adv), n - 1)] = adv[: n - 1]
+            lp = _as_1d_tensor(_get_field(data[i], "logprobs", "log_probs"), torch.float32)
+            if lp is not None:
+                old_log_probs[i, : min(len(lp), n - 1)] = lp[: n - 1]
+
+        out = {
+            "input_ids": input_ids,
+            "attention_mask": attention_mask,
+            "position_ids": position_ids,
+            "prompts": input_ids[:, :1],
+            "responses": responses,
+            "response_mask": response_mask,
+        }
+        if loss_fn == "cross_entropy":
+            out["weights"] = weights
+        else:
+            out["advantages"] = advantages
+            out["old_log_probs"] = old_log_probs
+        return out
+
+    def forward_to_backend(self, data: List[Dict], args: Any) -> Any:
+        return self.forward_backward_to_backend(data, "cross_entropy", args)
+
+    def backend_to_forward_result(self, result: Any, data: List[Dict]) -> Dict[str, Any]:
+        return {"loss_fn_outputs": self.extract_logprobs(result, data), "metrics": {}}
+
+    def backend_to_forward_backward_result(self, result: Any, data: List[Dict]) -> Dict[str, Any]:
+        return {"loss_fn_outputs": self.extract_logprobs(result, data), "metrics": {}}
+
+    @staticmethod
+    def extract_logprobs(padded_logprobs: torch.Tensor, data: List[Dict]) -> List[Dict[str, Any]]:
+        """Datum-aligned per-sample logprobs (length N_i - 1 each)."""
+        outputs = []
+        for i, datum in enumerate(data):
+            n = int(_full_tokens(datum).numel())
+            lp = padded_logprobs[i, : n - 1].detach().cpu()
+            outputs.append({"logprobs": {"data": lp.tolist(), "dtype": "float32", "shape": [n - 1]}})
+        return outputs

--- a/training/backends/verl/losses.py
+++ b/training/backends/verl/losses.py
@@ -20,7 +20,11 @@ def _padded_logprobs(model_output, data):
 
 
 def _dp_size(data):
-    v = data.get("dp_size", None)
+    from verl.utils import tensordict_utils as tu
+
+    v = tu.get_non_tensor_data(data=data, key="dp_size", default=1)
+    if hasattr(v, "data"):  # NonTensorData wrapper
+        v = v.data
     return int(v) if v is not None else 1
 
 

--- a/training/backends/verl/losses.py
+++ b/training/backends/verl/losses.py
@@ -1,0 +1,74 @@
+"""
+Pure-sum loss functions for the veRL backend (Thm 1 contract).
+
+Signature matches verl.workers.utils.losses: (config, model_output, data,
+dp_group) -> (loss, metrics). Per-micro-batch partial sums against a
+client-owned normalizer (1), scaled by dp_size to cancel FSDP's grad-averaging
+all-reduce — split-invariant by construction. We deliberately do NOT use
+veRL's sft_loss (flattened-roll boundary leak, see specs/006 q2-plan.md) or
+its batch-measured normalizers.
+"""
+import torch
+
+_METRIC_KEYS = ("weights", "advantages", "old_log_probs", "ref_log_prob")
+
+
+def _padded_logprobs(model_output, data):
+    from verl.workers.utils.padding import no_padding_2_padding
+
+    return no_padding_2_padding(model_output["log_probs"], data)
+
+
+def _dp_size(data):
+    v = data.get("dp_size", None)
+    return int(v) if v is not None else 1
+
+
+def cross_entropy_loss(config, model_output, data, dp_group=None):
+    """SFT: -sum(weights * logp(target)) * dp_size. Client owns normalization."""
+    log_prob = _padded_logprobs(model_output, data)  # [B, Rmax]
+    weights = data["weights"]
+    if weights.is_nested:
+        weights = weights.to_padded_tensor(0.0)
+    loss = -(log_prob * weights).sum() * _dp_size(data)
+    return loss, {"sum_weighted_logprob": -loss.detach().item() / max(_dp_size(data), 1)}
+
+
+def importance_sampling_loss(config, model_output, data, dp_group=None):
+    """RL: -sum(adv * exp(logp - logp_old)) * dp_size (Tinker importance_sampling).
+
+    old_log_probs are the client-supplied sampling logprobs; per-token IS ratio,
+    no clipping (clipping is client policy, not server policy).
+    """
+    log_prob = _padded_logprobs(model_output, data)
+    old_log_prob = data["old_log_probs"]
+    advantages = data["advantages"]
+    if old_log_prob.is_nested:
+        old_log_prob = old_log_prob.to_padded_tensor(0.0)
+    if advantages.is_nested:
+        advantages = advantages.to_padded_tensor(0.0)
+    mask = data["response_mask"]
+    if mask.is_nested:
+        mask = mask.to_padded_tensor(0)
+    mask = mask.to(log_prob.dtype)
+
+    ratio = torch.exp((log_prob - old_log_prob) * mask)
+    loss = -(advantages * ratio * mask).sum() * _dp_size(data)
+
+    with torch.no_grad():
+        denom = mask.sum().clamp(min=1)
+        ppo_kl = ((old_log_prob - log_prob) * mask).sum() / denom
+    return loss, {"ppo_kl": ppo_kl.detach().item()}
+
+
+LOSS_FNS = {
+    "cross_entropy": cross_entropy_loss,
+    "importance_sampling": importance_sampling_loss,
+    "ppo": importance_sampling_loss,
+}
+
+
+def get_loss_fn(name: str):
+    if name not in LOSS_FNS:
+        raise ValueError(f"verl backend: unsupported loss_fn {name!r} (have {sorted(LOSS_FNS)})")
+    return LOSS_FNS[name]


### PR DESCRIPTION
## What

Adds **veRL as a third training backend** (`TINKERCLOUD_BACKEND=verl`), M1 scope = training path only: `create_model` / `forward_backward` / `apply_optimizer_step` / `forward` / `get_logprobs` / checkpoints / `delete_model`. `sample` / `prepare_for_generation` raise `UnsupportedFeatureError` until M2 (rollout + weight sync).

Binds veRL's own in-tree Tinker split-training layer (`verl.workers.engine_workers_tinker.TinkerTrainingWorker`: grad-accumulating `forward_backward`, `optimizer_step(OptimStepParams)`, `optimizer_zero_grad`) behind the `TrainingBackend` ABC — **eager execution (Miles-shaped), not buffered**: fb does real GPU work and returns real per-token logprobs; optim_step maps client AdamParams onto veRL param-group overrides.

- `backends/verl/losses.py` — pure-sum `cross_entropy` + `importance_sampling` (×dp_size pre-compensation for FSDP grad averaging; client owns normalization; deliberately not veRL's `sft_loss`, whose packed-batch mask roll leaks across document boundaries)
- `backends/verl/converter.py` — Datum ↔ left-right padded layout (prompt_len=1, responses=tokens[1:]); N−1 datum-aligned logprob extraction; sub-DP batches padded with zero-weight clones (zero grad contribution under pure-sum)
- `backends/verl/builder.py` — FSDP2 engine config; FSDP LoRA namespace only (`model.lora_rank`; the Megatron `model.lora.rank` twin stays 0)
- `backends/verl/backend.py` — RayWorkerGroup boot, per-handle FIFO lock, SDK response contract (`loss_fn_output_type`, `name:reduction` metric keys)
- new gate `scripts/gates/g_lp_hf_parity.py` — backend logprobs vs fp32 HF reference

## Validation (tinkercloud-verl pod, 2×H200, Qwen2.5-0.5B r32, verl @ e961840)

- **G1 split-invariance: PASS BIT-IDENTICAL** — grad_norm `3127.593994140625` across fb(8)+step ≡ 2×fb(4)+step ≡ rerun (lr=0 arms)
- **G2 client order: PASS** — 8 ragged datums, per-datum logprob lengths exact
- **G3 sl_basic 30-step SFT: E₂** — NLL 2.4638 → 2.2374 (miles-lineage endpoint 2.80 → 2.26; start-NLL delta under investigation via same-pin A/B — G_lp rules out logprob computation)
- **G_lp HF-parity**: corr 0.999859, mean-logprob gap 0.004 nats (bf16 mixed-precision E₁)

## Caveats

- M1 is training-path only; RL recipes needing sampling wait for M2
- `grad_clip_norm` is engine-build-time, not per-step (warned)
- Requires a verl-capable image (deps: torch 2.8 / transformers 4.57); verl installed from source
