### PR TITLE
miles: stop tempering training logits (rollout_temperature 0.7 -> 1.0)

### DIFF
--- a/training/core/slime_builder.py
+++ b/training/core/slime_builder.py
@@ -462,7 +462,12 @@ class SlimeArgumentBuilder:
         args.rollout_num_gpus_per_engine = 1
         args.sglang_router_ip = None
         args.sglang_router_port = None
-        args.rollout_temperature = 0.7
+        # Must be 1.0: miles' loss hub divides training logits by this arg
+        # (logit_processors.get_responses, an RL importance-sampling
+        # convention), so any other value silently trains and reports
+        # log_softmax(z/T) for every loss fn. Tinker training logprobs are
+        # untempered; sampling temperature is per-request, never this arg.
+        args.rollout_temperature = 1.0
         args.rollout_top_p = 0.9
         args.rollout_top_k = 50
         args.rollout_max_response_len = 256

--- a/training/utils/sglang_client.py
+++ b/training/utils/sglang_client.py
@@ -47,7 +47,7 @@ class SGLangClient:
         Args:
             input_ids: List of input token IDs
             sampling_params: Sampling parameters dict with:
-                - temperature: float (default 0.7)
+                - temperature: float (default 1.0, matching the API schema default)
                 - top_p: float (default 0.9)
                 - max_tokens: int (default 256)
             prompt_logprobs: Whether to return prompt log probabilities
@@ -69,7 +69,7 @@ class SGLangClient:
         payload = {
             "input_ids": input_ids,
             "sampling_params": {
-                "temperature": sampling_params.get("temperature", 0.7),
+                "temperature": sampling_params.get("temperature", 1.0),
                 "top_p": sampling_params.get("top_p", 0.9),
                 "max_new_tokens": sampling_params.get("max_tokens", 256),
             },


### PR DESCRIPTION
## Problem

miles' loss hub divides training-side logits by `args.rollout_temperature` unconditionally (`logit_processors.get_responses` — an RL importance-sampling convention), and the builder hard-set 0.7 for every model. So every miles run trained and reported `log_softmax(z/0.7)`:

- fp32 HF-parity probe at face value: corr 0.99245, mean logprob gap **−0.998 nats**; re-evaluated at τ=0.7: corr 0.999815, +0.0094 nats (best-fit τ = 0.70 on all 8 probe sequences) — weights are faithful, the logit path tempers.
- Gradients were of the distorted objective too, not just reporting: sl_basic G3 started at NLL 2.80343 vs fp32 ground truth 2.46363 on the bit-identical batch, the excess decaying geometrically as training fit the tempered objective.

## Fix

- `slime_builder.py`: `rollout_temperature = 1.0`. Tinker training logprobs are untempered; sampling temperature is a per-request parameter, never this build-time arg.
- `sglang_client.py`: omitted-temperature sampling fallback 0.7 → 1.0, matching the API schema default (`requests.py` documents 1.0 — the two defaults disagreed).

## Cluster validation (tinkercloud-miles, pool mode, Qwen2.5-0.5B r32)

| Gate | Predicted | Measured |
|---|---|---|
| G_lp τ=1.0 HF-parity | corr ≈0.9998, gap ≤0.01 | **corr 0.999847, +0.00787 nats** (was 0.99245 / −0.998) |
| G1 split-invariance | bit-identical arms | **PASS** — grad_norm 124.59701055427654 across fb(8)+step ≡ 2×fb(4)+step ≡ rerun |
| G3 sl_basic 30-step | start ≈2.4638, end ≈2.237 | **start 2.4640951** (+0.00046 vs fp32), **end 2.2436590** |

Step-0 batch fingerprint (38055/27067 tokens) matches the verl backend exactly — same program, and the two backends now agree at start to 3e-4 nats.

Note: this changes the effective objective of all miles training runs; prior miles-lineage baseline numbers (e.g. G3 2.80 → 2.26) are superseded by the τ=1.0 lineage.
