### PR TITLE
verl backend M2: rollout + sampling (vLLM hybrid timeshare); G8 gates green

### DIFF
--- a/scripts/gates/g8_verl_sampling.py
+++ b/scripts/gates/g8_verl_sampling.py
@@ -1,0 +1,325 @@
+#!/usr/bin/env python3
+"""G8 verl M2 sampling gates (2026-08-02).
+
+Validates the verl backend's rollout path: colocated vLLM server replicas in
+hybrid timeshare (sleep during training ops, wake + naive weight sync on
+sample). Model: Qwen/Qwen2.5-0.5B LoRA r32 (G1/G3 lineage).
+
+Gates:
+  G8a sampling sanity + logprob provenance (the TIM oracle in miniature):
+      sample(temp=1.0, seed=0, max_tokens=32, n=2) returns tokens+logprobs+
+      stop_reason; seeded determinism across reruns; training-engine
+      get_logprobs (via forward) on prompt+sampled tokens matches the
+      sampler's returned logprobs at bf16-class E1 (~1e-2 nats). The two
+      engines (vLLM rollout vs FSDP training) compute independently — this
+      parity IS the M2 headline number.
+  G8b weight-sync freshness: fb(8, cross_entropy) + optim_step(lr=1e-3),
+      sample again same prompt/seed: output must move vs G8a AND training-
+      engine logprobs on the NEW sample must again match the sampler at E1
+      (the lazy version-gated sync delivered the stepped weights, not v0).
+  G8c timeshare regression: G1 arms with rollout attached —
+      fb(8)+step(lr=0) == 2xfb(4)+step(lr=0) == rerun, grad_norm
+      bit-identical; then one more sample (wake after training) succeeds.
+  G8d (stretch): 5-step SDK-level RL smoke — sample 4, importance_sampling
+      datums (adv = reward - mean, logprobs from sampler), fb + step(1e-5);
+      sampler logprobs must track training logprobs at each step start
+      (IS ratio near 1).
+
+Writes /data/g8_results.json (or G8_RESULTS_PATH) with all measured numbers.
+"""
+import json
+import os
+import sys
+import time
+
+os.environ.setdefault("TINKER_BASE_URL", "http://localhost:8000")
+os.environ.setdefault("TINKER_API_KEY", "tml-dev-key")
+BASE = os.environ["TINKER_BASE_URL"]
+KEY = os.environ["TINKER_API_KEY"]
+RESULTS_PATH = os.environ.get("G8_RESULTS_PATH", "/data/g8_results.json")
+
+# env must be set before the SDK imports read it
+import requests  # noqa: E402
+import torch  # noqa: E402
+import tinker  # noqa: E402
+from tinker import types  # noqa: E402
+
+BASE_MODEL = "Qwen/Qwen2.5-0.5B"
+RANK = 32
+SEQ = 64
+PROMPT = [(1000 + j * 104729) % 50000 for j in range(30)]  # fixed ~30-token prompt
+MAX_TOKENS = 32
+HDRS = {"X-API-Key": KEY, "Content-Type": "application/json"}
+
+FAILS = []
+RESULTS = {"date": time.strftime("%Y-%m-%d %H:%M:%S"), "model": BASE_MODEL,
+           "rank": RANK, "gates": {}, "timings_s": {}}
+
+
+def check(name, ok, detail=""):
+    print(f"  {name}: {'PASS' if ok else 'FAIL'}{' ' + detail if detail else ''}", flush=True)
+    if not ok:
+        FAILS.append(name)
+    return ok
+
+
+def make_datums(n, salt=0):
+    out = []
+    for i in range(n):
+        toks = [(1000 + (salt * 31 + i) * 7919 + j * 104729) % 50000 for j in range(SEQ)]
+        inp, tgt = toks[:-1], toks[1:]
+        out.append(types.Datum(
+            model_input=types.ModelInput.from_ints(inp),
+            loss_fn_inputs={
+                "weights": types.TensorData.from_torch(
+                    torch.ones(len(inp), dtype=torch.float32)),
+                "target_tokens": types.TensorData.from_torch(
+                    torch.tensor(tgt, dtype=torch.long)),
+            },
+        ))
+    return out
+
+
+def raw_step(model_id, lr):
+    """optim_step via raw endpoint so grad_norm is readable from the future."""
+    r = requests.post(f"{BASE}/api/v1/optim_step", headers=HDRS, json={
+        "model_id": model_id,
+        "adam_params": {"learning_rate": lr},
+    })
+    r.raise_for_status()
+    rid = r.json()["request_id"]
+    deadline = time.time() + 600
+    while time.time() < deadline:
+        fr = requests.post(f"{BASE}/api/v1/retrieve_future/{rid}", headers=HDRS)
+        if fr.status_code == 200:
+            return fr.json()
+        if fr.status_code == 408:
+            time.sleep(2)
+            continue
+        print(f"STEP FAILED ({fr.status_code}):", fr.text[:2000])
+        sys.exit(2)
+    print("STEP TIMEOUT")
+    sys.exit(2)
+
+
+def sdk_sample(sampler, seed=0, n=2, max_tokens=MAX_TOKENS):
+    fut = sampler.sample(
+        prompt=types.ModelInput.from_ints(PROMPT),
+        sampling_params=types.SamplingParams(
+            temperature=1.0, max_tokens=max_tokens, seed=seed),
+        num_samples=n,
+    )
+    res = fut.result()
+    return [
+        (list(s.tokens),
+         [float(x) for x in s.logprobs] if s.logprobs is not None else None,
+         str(s.stop_reason))
+        for s in res.sequences
+    ]
+
+
+def train_logprobs(tc, full_tokens):
+    """Training-engine per-token logprobs on a full sequence, via forward.
+
+    Returns lp where lp[k] = logp(full[k+1] | full[:k+1]), length N-1.
+    """
+    inp, tgt = full_tokens[:-1], full_tokens[1:]
+    datum = types.Datum(
+        model_input=types.ModelInput.from_ints(inp),
+        loss_fn_inputs={
+            "weights": types.TensorData.from_torch(
+                torch.ones(len(inp), dtype=torch.float32)),
+            "target_tokens": types.TensorData.from_torch(
+                torch.tensor(tgt, dtype=torch.long)),
+        },
+    )
+    out = tc.forward([datum], loss_fn="cross_entropy").result()
+    return list(out.loss_fn_outputs[0]["logprobs"].data)
+
+
+def provenance(tc, sampled_tokens, sampler_lps):
+    """Compare training-engine logprobs vs sampler logprobs on sampled positions."""
+    full = PROMPT + list(sampled_tokens)
+    lp = train_logprobs(tc, full)
+    sl = lp[len(PROMPT) - 1:]
+    assert len(sl) == len(sampled_tokens), (len(sl), len(sampled_tokens))
+    a = torch.tensor(sl, dtype=torch.float64)
+    b = torch.tensor(sampler_lps, dtype=torch.float64)
+    gap = (a - b).abs()
+    corr = float(torch.corrcoef(torch.stack([a, b]))[0, 1]) if len(a) > 1 else float("nan")
+    return corr, float(gap.mean()), float(gap.max())
+
+
+def main():
+    sc = tinker.ServiceClient()
+
+    # ---- boot ----
+    t0 = time.time()
+    tc = sc.create_lora_training_client(base_model=BASE_MODEL, rank=RANK)
+    boot_s = time.time() - t0
+    RESULTS["timings_s"]["create_model_boot"] = round(boot_s, 1)
+    print(f"model_id: {tc.model_id} (boot {boot_s:.1f}s)", flush=True)
+
+    t0 = time.time()
+    sampler = tc.save_weights_and_get_sampling_client()
+    RESULTS["timings_s"]["create_sampler"] = round(time.time() - t0, 1)
+
+    # =================================================== G8a
+    print("\nG8a: sampling sanity + logprob provenance", flush=True)
+    g8a = {}
+    t0 = time.time()
+    s1 = sdk_sample(sampler, seed=0, n=2)
+    g8a["first_sample_latency_s"] = round(time.time() - t0, 1)
+    RESULTS["timings_s"]["first_sample_wake_sync"] = g8a["first_sample_latency_s"]
+
+    ok_shape = all(t and (lp is not None) and len(lp) == len(t) and sr
+                   for t, lp, sr in s1)
+    check("G8a sequences have tokens+logprobs+stop_reason", ok_shape,
+          f"stop_reasons={[sr for _, _, sr in s1]}")
+    g8a["stop_reasons"] = [sr for _, _, sr in s1]
+    g8a["sample_lens"] = [len(t) for t, _, _ in s1]
+
+    distinct = s1[0][0] != s1[1][0]
+    g8a["fanout_distinct"] = distinct
+    check("G8a num_samples fanout distinct (per-sample seed)", distinct)
+
+    t0 = time.time()
+    s2 = sdk_sample(sampler, seed=0, n=2)
+    g8a["second_sample_latency_s"] = round(time.time() - t0, 1)
+    det = all(s1[i][0] == s2[i][0] for i in range(2))
+    g8a["seeded_determinism"] = det
+    if not det:
+        print("  NOTE: identical seeded request returned different tokens "
+              "(vLLM per-request seed caveat) — noted, not a failure", flush=True)
+    else:
+        print("  G8a seeded determinism: rerun bit-identical", flush=True)
+
+    corr0, gap0, mx0 = provenance(tc, s1[0][0], s1[0][1])
+    corr1, gap1, mx1 = provenance(tc, s1[1][0], s1[1][1])
+    g8a["provenance"] = {
+        "s0": {"corr": corr0, "mean_abs_gap": gap0, "max_abs_gap": mx0},
+        "s1": {"corr": corr1, "mean_abs_gap": gap1, "max_abs_gap": mx1},
+    }
+    print(f"  provenance s0: corr={corr0:.6f} mean|gap|={gap0:.5f} max|gap|={mx0:.5f}", flush=True)
+    print(f"  provenance s1: corr={corr1:.6f} mean|gap|={gap1:.5f} max|gap|={mx1:.5f}", flush=True)
+    check("G8a sampler-vs-training logprob parity (E1)",
+          corr0 > 0.99 and corr1 > 0.99 and gap0 < 0.05 and gap1 < 0.05)
+    RESULTS["gates"]["G8a"] = g8a
+
+    # =================================================== G8b
+    print("\nG8b: weight-sync freshness", flush=True)
+    g8b = {}
+    ds = make_datums(8, salt=1)
+    t0 = time.time()
+    tc.forward_backward(ds, "cross_entropy").result()
+    res = raw_step(tc.model_id, 1e-3)
+    g8b["train_step_s"] = round(time.time() - t0, 1)
+    g8b["grad_norm"] = res.get("grad_norm")
+    print(f"  fb+step(lr=1e-3): grad_norm={g8b['grad_norm']!r}", flush=True)
+
+    t0 = time.time()
+    s3 = sdk_sample(sampler, seed=0, n=2)
+    g8b["post_step_sample_latency_s"] = round(time.time() - t0, 1)
+    RESULTS["timings_s"]["post_step_sample_resync"] = g8b["post_step_sample_latency_s"]
+
+    moved = (s3[0][0] != s1[0][0]) or (s3[0][1] != s1[0][1])
+    g8b["sampler_moved"] = moved
+    check("G8b sampler output moved after optim_step", moved)
+
+    corr3, gap3, mx3 = provenance(tc, s3[0][0], s3[0][1])
+    g8b["provenance_post_step"] = {"corr": corr3, "mean_abs_gap": gap3, "max_abs_gap": mx3}
+    print(f"  post-step provenance: corr={corr3:.6f} mean|gap|={gap3:.5f} max|gap|={mx3:.5f}", flush=True)
+    check("G8b post-step sampler-vs-training parity (sync delivered v1)",
+          corr3 > 0.99 and gap3 < 0.05)
+    RESULTS["gates"]["G8b"] = g8b
+
+    # =================================================== G8c
+    print("\nG8c: timeshare regression (G1 arms with rollout attached)", flush=True)
+    g8c = {"grad_norms": {}}
+    ds = make_datums(8, salt=3)
+    for arm, splits in [("A1", [ds]), ("B", [ds[:4], ds[4:]]), ("A2", [ds])]:
+        t0 = time.time()
+        for part in splits:
+            tc.forward_backward(part, "cross_entropy").result()
+        res = raw_step(tc.model_id, 0.0)
+        gn = res.get("grad_norm")
+        g8c["grad_norms"][arm] = gn
+        print(f"  {arm}: grad_norm={gn!r} ({time.time()-t0:.1f}s)", flush=True)
+    a1, b, a2 = (g8c["grad_norms"][k] for k in ("A1", "B", "A2"))
+    check("G8c split-invariance bit-identical", repr(a1) == repr(b) and a1 and a1 > 0,
+          f"A1={a1!r} B={b!r}")
+    check("G8c determinism bit-identical", repr(a1) == repr(a2), f"A2={a2!r}")
+
+    t0 = time.time()
+    s5 = sdk_sample(sampler, seed=0, n=1)
+    g8c["post_arms_sample_ok"] = bool(s5 and s5[0][0])
+    g8c["post_arms_sample_latency_s"] = round(time.time() - t0, 1)
+    check("G8c sample after training arms succeeds", g8c["post_arms_sample_ok"])
+    # lr=0 arms: weights unmoved since G8b -> seeded sample must be bit-stable
+    lr0_stable = s5[0][0] == s3[0][0]
+    g8c["lr0_sample_bit_stable"] = lr0_stable
+    check("G8c lr=0 round-trip leaves sampler bit-stable", lr0_stable)
+    RESULTS["gates"]["G8c"] = g8c
+
+    # =================================================== G8d (stretch)
+    print("\nG8d: 5-step RL smoke (importance_sampling)", flush=True)
+    g8d = {"steps": []}
+    try:
+        for step in range(5):
+            samples = sdk_sample(sampler, seed=1000 + step * 10, n=4)
+            rewards = [len(set(t)) / max(len(t), 1) for t, _, _ in samples]
+            mean_r = sum(rewards) / len(rewards)
+            advs = [r - mean_r for r in rewards]
+
+            # IS-ratio-at-step-start probe: training logprobs vs sampler logprobs
+            gaps = []
+            datums = []
+            for (toks, lps, _), adv in zip(samples, advs):
+                full = PROMPT + toks
+                n1 = len(full) - 1
+                p = len(PROMPT)
+                adv_vec = torch.zeros(n1, dtype=torch.float32)
+                lp_vec = torch.zeros(n1, dtype=torch.float32)
+                adv_vec[p - 1:] = adv
+                lp_vec[p - 1:] = torch.tensor(lps, dtype=torch.float32)
+                datums.append(types.Datum(
+                    model_input=types.ModelInput.from_ints(full),
+                    loss_fn_inputs={
+                        "advantages": types.TensorData.from_torch(adv_vec),
+                        "logprobs": types.TensorData.from_torch(lp_vec),
+                    },
+                ))
+            out = tc.forward_backward(datums, "importance_sampling").result()
+            for i, (toks, lps, _) in enumerate(samples):
+                tr = list(out.loss_fn_outputs[i]["logprobs"].data)[len(PROMPT) - 1:]
+                gaps.append(float(torch.tensor(tr).sub(torch.tensor(lps)).abs().mean()))
+            raw_step(tc.model_id, 1e-5)
+            step_gap = sum(gaps) / len(gaps)
+            g8d["steps"].append({"mean_abs_lp_gap": round(step_gap, 5),
+                                 "mean_reward": round(mean_r, 4)})
+            print(f"  step {step}: mean|lp_train-lp_samp|={step_gap:.5f} "
+                  f"mean_reward={mean_r:.4f}", flush=True)
+        max_gap = max(s["mean_abs_lp_gap"] for s in g8d["steps"])
+        check("G8d loop completes, IS ratio near 1 at step start", max_gap < 0.05,
+              f"max step gap {max_gap:.5f}")
+        g8d["status"] = "ran"
+    except Exception as e:  # stretch gate: report, don't block a-c verdicts
+        g8d["status"] = f"ERROR: {e}"
+        check("G8d RL smoke", False, str(e)[:500])
+    RESULTS["gates"]["G8d"] = g8d
+
+    # ---- wrap ----
+    RESULTS["model_id"] = tc.model_id
+    RESULTS["fails"] = FAILS
+    RESULTS["verdict"] = "PASS" if not FAILS else "FAIL"
+    with open(RESULTS_PATH, "w") as f:
+        json.dump(RESULTS, f, indent=2)
+    print(f"\nresults -> {RESULTS_PATH}")
+    print("G8:", "PASS" if not FAILS else f"FAIL ({', '.join(FAILS)})")
+    print(f"NOTE: model {tc.model_id} left resident; delete via "
+          f"POST /api/v1/delete_model when done.")
+    sys.exit(0 if not FAILS else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/training/backends/verl/backend.py
+++ b/training/backends/verl/backend.py
@@ -227,7 +227,7 @@ class VerlBackend(TrainingBackend):
         async with h._lock:
             try:
                 await asyncio.to_thread(self._ensure_training_ready, h)
-                td = await asyncio.to_thread(self._to_tensordict, h, data, "cross_entropy")
+                td = await asyncio.to_thread(self._to_tensordict, h, data, "cross_entropy", True)
                 from verl.utils import tensordict_utils as tu
                 tu.assign_non_tensor(td, compute_loss=False)
                 # rollout worker exposes the actor's infer path as compute_log_prob
@@ -350,10 +350,16 @@ class VerlBackend(TrainingBackend):
                 max_tokens = vllm_sp.get("max_tokens")
 
                 async def _one(i: int):
+                    sp_i = dict(vllm_sp)
+                    if sp_i.get("seed") is not None:
+                        # vLLM seeds per request; a fixed seed across the
+                        # num_samples fanout would return identical samples.
+                        # Derive per-sample seeds (deterministic across reruns).
+                        sp_i["seed"] = int(sp_i["seed"]) + i
                     out = await h.llm_client.generate(
                         f"{request_id}_{i}",
                         prompt_ids=list(prompt_tokens),
-                        sampling_params=dict(vllm_sp),
+                        sampling_params=sp_i,
                     )
                     return out
 
@@ -426,7 +432,7 @@ class VerlBackend(TrainingBackend):
         _ = get_loss_fn(loss_fn)  # validate name eagerly
         h.loss_fn_name = loss_fn
 
-    def _to_tensordict(self, h: VerlHandle, data: List[Dict], loss_fn: str):
+    def _to_tensordict(self, h: VerlHandle, data: List[Dict], loss_fn: str, infer: bool = False):
         from tensordict import TensorDict
         from verl.utils import tensordict_utils as tu
         from verl.workers.utils.padding import left_right_2_no_padding
@@ -435,8 +441,10 @@ class VerlBackend(TrainingBackend):
 
         # Divisibility: engine needs per-DP-rank count % micro_batch_size == 0.
         # Pad with zero-weight clones (pure-sum => zero grad, E0-safe)
-        # instead of rejecting or trimming.
-        micro_bs = int(h.config.get("engine", {}).get("micro_batch_size_per_gpu", 1) or 1)
+        # instead of rejecting or trimming. The infer path (compute_log_prob)
+        # partitions by infer_micro_batch_size_per_gpu, not the train one.
+        mb_key = "infer_micro_batch_size_per_gpu" if infer else "micro_batch_size_per_gpu"
+        micro_bs = int(h.config.get("engine", {}).get(mb_key, 1) or 1)
         multiple = h.dp_size * micro_bs
         b = padded["input_ids"].shape[0]
         remainder = b % multiple
@@ -475,9 +483,15 @@ def _loss_dispatch(config=None, model_output=None, data=None, dp_group=None, los
 
 
 def _wg_call(method, td):
-    """Blocking worker-group data call: resolve DataProtoFuture if non-blocking."""
+    """Blocking worker-group data call: resolve DataProtoFuture if non-blocking.
+
+    Blocking dispatches (e.g. compute_log_prob) return the TensorDict directly;
+    TensorDict also has .get(key), so type-check instead of duck-typing.
+    """
+    from tensordict import TensorDictBase
+
     out = method(td)
-    if hasattr(out, "get"):
+    if not isinstance(out, TensorDictBase) and hasattr(out, "get"):
         out = out.get()
     return out
 
@@ -524,8 +538,9 @@ def _to_vllm_sampling_params(sampling_params: Optional[Dict[str, Any]]) -> Dict[
         "logprobs": True,
     }
     top_k = sp.get("top_k")
-    if top_k not in (None, 0):
-        out["top_k"] = int(top_k)
+    # explicit -1 (disabled) when unset: never inherit engine/generation-config
+    # truncation the client didn't ask for
+    out["top_k"] = -1 if top_k in (None, 0, -1) else int(top_k)
     max_tokens = sp.get("max_tokens") or sp.get("max_new_tokens")
     if max_tokens:
         out["max_tokens"] = int(max_tokens)
@@ -584,6 +599,11 @@ def _compose_actor_rollout_config(cfg: Dict[str, Any]):
         f"actor_rollout_ref.rollout.enforce_eager={rollout['enforce_eager']}",
         "actor_rollout_ref.rollout.calculate_log_probs=True",
         "actor_rollout_ref.rollout.free_cache_engine=True",
+        # Tinker logprob provenance: sampler must report RAW model logprobs
+        # (training engine computes untempered); verl's default
+        # processed_logprobs returns post-processing renormalized values
+        # (measured ~1.3 nats off HF fp32 on Qwen2.5-0.5B, 2026-08-02)
+        "actor_rollout_ref.rollout.logprobs_mode=raw_logprobs",
         f"actor_rollout_ref.rollout.log_prob_use_dynamic_bsz={engine['use_dynamic_bsz']}",
         f"actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu={engine['infer_micro_batch_size_per_gpu']}",
         f"actor_rollout_ref.rollout.log_prob_max_token_len_per_gpu={engine['infer_max_token_len_per_gpu']}",
@@ -626,23 +646,38 @@ def _boot_worker_group(cfg: Dict[str, Any], model_id: str, enable_rollout: bool 
             process_on_nodes=[cfg["num_gpus"]], name_prefix=f"verl_{model_id}",
         )
         wg = RayWorkerGroup(resource_pool=resource_pool, ray_cls_with_init=ray_cls)
-        wg.init_model()
+        try:
+            wg.init_model()
 
-        # KNOWN LIMIT: vLLM server actors are Ray-named per replica rank
-        # (manager doesn't thread name_suffix), so at most ONE rollout-enabled
-        # verl model per Ray cluster; a second create_model fails loudly on
-        # the actor name. delete_model frees the names.
-        llm_manager = LLMServerManager.create(config=full, worker_group=wg)
-        ckpt_manager = CheckpointEngineManager(
-            config=omega_conf_to_dataclass(full.actor_rollout_ref.rollout.checkpoint_engine),
-            actor_wg=wg,
-            replicas=llm_manager.get_replicas(),
-        )
-        # canonical boot order (agent-loop harness): sleep -> sync -> sleep;
-        # vLLM never serves dummy weights, training starts with GPUs free
-        ckpt_manager.sleep_replicas()
-        ckpt_manager.update_weights(global_steps=0)
-        ckpt_manager.sleep_replicas()
+            # KNOWN LIMIT: vLLM server actors are Ray-named per replica rank
+            # (manager doesn't thread name_suffix), so at most ONE rollout-enabled
+            # verl model per Ray cluster; a second create_model fails loudly on
+            # the actor name. delete_model frees the names.
+            llm_manager = LLMServerManager.create(config=full, worker_group=wg)
+            ckpt_manager = CheckpointEngineManager(
+                config=omega_conf_to_dataclass(full.actor_rollout_ref.rollout.checkpoint_engine),
+                actor_wg=wg,
+                replicas=llm_manager.get_replicas(),
+            )
+            # canonical boot order (agent-loop harness): sleep -> sync -> sleep;
+            # vLLM never serves dummy weights, training starts with GPUs free
+            ckpt_manager.sleep_replicas()
+            ckpt_manager.update_weights(global_steps=0)
+            ckpt_manager.sleep_replicas()
+        except Exception:
+            # boot failure must not leak live actors/PG: the next create_model
+            # would hang forever on placement-group resources (runbook footgun 2)
+            for w in getattr(wg, "workers", []) or []:
+                try:
+                    ray.kill(w)
+                except Exception:
+                    pass
+            for pg in getattr(resource_pool, "pgs", None) or []:
+                try:
+                    ray.util.remove_placement_group(pg)
+                except Exception:
+                    pass
+            raise
 
         sp = cfg["engine"]["ulysses_sequence_parallel_size"]
         dp_size = max(cfg["num_gpus"] // max(sp, 1), 1)

--- a/training/backends/verl/backend.py
+++ b/training/backends/verl/backend.py
@@ -9,9 +9,13 @@ weight_decay) + optimizer_zero_grad. forward_backward here does real GPU
 work and returns real logprobs; apply_optimizer_step applies AdamParams and
 steps once.
 
-M1 scope: training path only (create_model/fb/step/forward/get_logprobs/
-checkpoints/delete). sample() raises UnsupportedFeatureError — rollout
-engine + weight sync land in M2. Narrative: specs/006-verl-backend/design.md.
+M2 adds rollout: TinkerActorRolloutRefWorker (actor_rollout role) boots
+colocated vLLM server replicas (LLMServerManager) in hybrid timeshare —
+replicas sleep during training ops and wake with a naive weight sync
+(CheckpointEngineManager) for sampling. update_inference_weights is lazy:
+versions are tracked on the handle and the sync happens on the next
+sample/prepare_for_generation, so pure-training runs never pay for it.
+Narrative: specs/006-verl-backend/design.md.
 """
 import asyncio
 import logging
@@ -30,7 +34,7 @@ logger = logging.getLogger(__name__)
 class VerlHandle(BackendHandle):
     """veRL-specific runtime state."""
 
-    worker_group: Any = None          # RayWorkerGroup over TinkerTrainingWorker
+    worker_group: Any = None          # RayWorkerGroup over Tinker*Worker
     resource_pool: Any = None         # RayResourcePool
     config: Dict = field(default_factory=dict)
     hf_path: str = ""
@@ -38,6 +42,14 @@ class VerlHandle(BackendHandle):
     loss_fn_name: str = ""            # currently installed loss fn on workers
     weight_version: int = 0
     created_at: str = ""
+    # M2 rollout state (hybrid timeshare)
+    has_rollout: bool = False
+    llm_manager: Any = None           # LLMServerManager (replicas + balancer)
+    llm_client: Any = None            # LLMServerClient (token-in-token-out)
+    ckpt_manager: Any = None          # CheckpointEngineManager (sleep/sync)
+    rollout_awake: bool = False
+    rollout_synced_version: int = -1  # weight_version last synced to vLLM
+    lora_rank: int = 0
     _lock: asyncio.Lock = field(default_factory=asyncio.Lock)  # FIFO per handle
 
 
@@ -96,22 +108,34 @@ class VerlBackend(TrainingBackend):
                 parallelism=parallelism, rl_config=rl_config,
                 rollout_config=rollout_config, max_seq_len=max_seq_len,
             )
-            worker_group, resource_pool, dp_size = await asyncio.to_thread(
-                _boot_worker_group, cfg, model_id,
+            enable_rollout = not debug_train_only
+            boot = await asyncio.to_thread(
+                _boot_worker_group, cfg, model_id, enable_rollout,
             )
             handle = VerlHandle(
                 model_id=model_id,
                 backend_type="verl",
-                worker_group=worker_group,
-                resource_pool=resource_pool,
+                worker_group=boot["worker_group"],
+                resource_pool=boot["resource_pool"],
                 config=cfg,
                 hf_path=cfg["hf_path"],
-                dp_size=dp_size,
+                dp_size=boot["dp_size"],
                 created_at=datetime.now().isoformat(),
+                has_rollout=enable_rollout,
+                llm_manager=boot.get("llm_manager"),
+                llm_client=boot.get("llm_client"),
+                ckpt_manager=boot.get("ckpt_manager"),
+                # boot does one naive sync so vLLM never serves dummy
+                # weights, then sleeps the replicas for training
+                rollout_synced_version=0 if enable_rollout else -1,
+                lora_rank=int(cfg["model"]["lora_rank"] or 0),
             )
             if checkpoint_path:
                 await self.load_checkpoint(handle, checkpoint_path)
-            logger.info("[%s] verl model %s created (dp=%d)", request_id, model_id, dp_size)
+            logger.info(
+                "[%s] verl model %s created (dp=%d, rollout=%s)",
+                request_id, model_id, handle.dp_size, enable_rollout,
+            )
             return handle
         except BackendError:
             raise
@@ -129,6 +153,7 @@ class VerlBackend(TrainingBackend):
         h: VerlHandle = handle  # type: ignore[assignment]
         async with h._lock:
             try:
+                await asyncio.to_thread(self._ensure_training_ready, h)
                 await asyncio.to_thread(self._ensure_loss_fn, h, loss_fn)
                 td = await asyncio.to_thread(self._to_tensordict, h, data, loss_fn)
                 out = await asyncio.to_thread(_wg_call, h.worker_group.forward_backward, td)
@@ -155,6 +180,7 @@ class VerlBackend(TrainingBackend):
         h: VerlHandle = handle  # type: ignore[assignment]
         async with h._lock:
             try:
+                await asyncio.to_thread(self._ensure_training_ready, h)
                 params: Dict[str, Any] = {}
                 if learning_rate is not None:
                     params["lr"] = float(learning_rate)
@@ -200,10 +226,13 @@ class VerlBackend(TrainingBackend):
         h: VerlHandle = handle  # type: ignore[assignment]
         async with h._lock:
             try:
+                await asyncio.to_thread(self._ensure_training_ready, h)
                 td = await asyncio.to_thread(self._to_tensordict, h, data, "cross_entropy")
                 from verl.utils import tensordict_utils as tu
                 tu.assign_non_tensor(td, compute_loss=False)
-                out = await asyncio.to_thread(_wg_call, h.worker_group.infer_batch, td)
+                # rollout worker exposes the actor's infer path as compute_log_prob
+                infer = getattr(h.worker_group, "infer_batch", None) or h.worker_group.compute_log_prob
+                out = await asyncio.to_thread(_wg_call, infer, td)
                 logprobs = await asyncio.to_thread(self._model_output_logprobs, out, td)
                 return self.converter.extract_logprobs(logprobs, data)
             except BackendError:
@@ -214,8 +243,15 @@ class VerlBackend(TrainingBackend):
     # ------------------------------------------------------------ lifecycle
 
     async def update_inference_weights(self, handle: BackendHandle) -> None:
-        # M1: no rollout engine attached; no-op until M2 wires
-        # ActorRolloutRefWorker.update_weights.
+        # Lazy: weight_version already advanced at optim_step; the actual
+        # vLLM sync happens on the next sample/prepare_for_generation
+        # (version-gated), so pure-training runs never pay wake/sync cost.
+        h: VerlHandle = handle  # type: ignore[assignment]
+        if h.has_rollout:
+            logger.debug(
+                "verl update_inference_weights deferred (v%d, synced v%d)",
+                h.weight_version, h.rollout_synced_version,
+            )
         return None
 
     async def save_checkpoint(
@@ -246,6 +282,16 @@ class VerlBackend(TrainingBackend):
         h: VerlHandle = handle  # type: ignore[assignment]
         try:
             import ray
+            # rollout server actors first (they hold engine refs into workers)
+            for replica in (h.llm_manager.get_replicas() if h.llm_manager else []):
+                for server in getattr(replica, "servers", []) or []:
+                    try:
+                        ray.kill(server)
+                    except Exception:
+                        pass
+            h.llm_manager = None
+            h.llm_client = None
+            h.ckpt_manager = None
             for w in getattr(h.worker_group, "workers", []) or []:
                 try:
                     ray.kill(w)
@@ -273,18 +319,103 @@ class VerlBackend(TrainingBackend):
         prompt_logprobs: bool = False,
         pinned_version: Optional[int] = None,
     ) -> Dict[str, Any]:
-        raise UnsupportedFeatureError(
-            "sample", backend="verl",
-            suggestion="M1 is training-path only; rollout engine lands in M2 (specs/006)",
-        )
+        h: VerlHandle = handle  # type: ignore[assignment]
+        if not h.has_rollout:
+            raise UnsupportedFeatureError(
+                "sample", backend="verl",
+                suggestion="model was created debug_train_only; recreate with rollout enabled",
+            )
+        # Hybrid timeshare: generation must not overlap training ops on the
+        # same GPUs, so sampling holds the handle FIFO lock too.
+        async with h._lock:
+            try:
+                await asyncio.to_thread(self._ensure_rollout_ready, h)
+
+                if pinned_version is not None and pinned_version != h.weight_version:
+                    # vLLM serves the live (base+adapter) route; a pinned
+                    # nonzero version is not honorable — BUG-015 aliasing
+                    # class, logged loudly rather than silently aliased.
+                    logger.warning(
+                        "[%s] pinned_version=%s not honored for %s (verl serves "
+                        "the live engine, v%d) — BUG-015 aliasing risk",
+                        request_id, pinned_version, h.model_id, h.weight_version,
+                    )
+                if prompt_logprobs:
+                    logger.warning(
+                        "[%s] prompt_logprobs unsupported on verl sample path "
+                        "(use forward/get_logprobs); returning None", request_id,
+                    )
+
+                vllm_sp = _to_vllm_sampling_params(sampling_params)
+                max_tokens = vllm_sp.get("max_tokens")
+
+                async def _one(i: int):
+                    out = await h.llm_client.generate(
+                        f"{request_id}_{i}",
+                        prompt_ids=list(prompt_tokens),
+                        sampling_params=dict(vllm_sp),
+                    )
+                    return out
+
+                outs = await asyncio.gather(*[_one(i) for i in range(num_samples)])
+                sequences = []
+                for out in outs:
+                    if out.stop_reason == "aborted":
+                        raise BackendError(
+                            "rollout request aborted", backend="verl", operation="sample",
+                        )
+                    n_tok = len(out.token_ids)
+                    stop_reason = "length" if (max_tokens is not None and n_tok >= max_tokens) else "stop"
+                    sequences.append({
+                        "tokens": list(out.token_ids),
+                        "logprobs": list(out.log_probs) if out.log_probs is not None else None,
+                        "text": None,
+                        "stop_reason": stop_reason,
+                    })
+                return {"sequences": sequences, "prompt_logprobs": None}
+            except (BackendError, UnsupportedFeatureError):
+                raise
+            except Exception as e:
+                raise BackendError(str(e), backend="verl", operation="sample", original_error=e) from e
 
     async def prepare_for_generation(self, handle: BackendHandle) -> None:
-        raise UnsupportedFeatureError(
-            "prepare_for_generation", backend="verl",
-            suggestion="M1 is training-path only; rollout engine lands in M2 (specs/006)",
-        )
+        h: VerlHandle = handle  # type: ignore[assignment]
+        if not h.has_rollout:
+            raise UnsupportedFeatureError(
+                "prepare_for_generation", backend="verl",
+                suggestion="model was created debug_train_only; recreate with rollout enabled",
+            )
+        async with h._lock:
+            try:
+                await asyncio.to_thread(self._ensure_rollout_ready, h)
+            except Exception as e:
+                raise BackendError(
+                    str(e), backend="verl", operation="prepare_for_generation", original_error=e,
+                ) from e
 
     # -------------------------------------------------------------- helpers
+
+    @staticmethod
+    def _ensure_training_ready(h: VerlHandle) -> None:
+        """Hybrid timeshare: sleep vLLM replicas before training ops."""
+        if h.has_rollout and h.rollout_awake:
+            h.ckpt_manager.sleep_replicas()
+            h.rollout_awake = False
+
+    @staticmethod
+    def _ensure_rollout_ready(h: VerlHandle) -> None:
+        """Wake vLLM replicas with current weights.
+
+        update_weights(naive) resumes replica weights, streams the trainer's
+        params (LoRA: base once, then adapter), and resumes kv_cache — correct
+        both for a version-stale sync and for a plain wake after sleep
+        (full-FT sleep discards weights, so wake-without-sync is unsafe).
+        """
+        if h.rollout_awake and h.rollout_synced_version == h.weight_version:
+            return
+        h.ckpt_manager.update_weights(global_steps=h.weight_version)
+        h.rollout_awake = True
+        h.rollout_synced_version = h.weight_version
 
     def _ensure_loss_fn(self, h: VerlHandle, loss_fn: str) -> None:
         if h.loss_fn_name == loss_fn:
@@ -384,16 +515,149 @@ def _scalar_metrics(out) -> Dict[str, Any]:
     return out_metrics
 
 
-def _boot_worker_group(cfg: Dict[str, Any], model_id: str):
-    """Boot a TinkerTrainingWorker RayWorkerGroup (training path only)."""
+def _to_vllm_sampling_params(sampling_params: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    """Tinker SamplingParams dict -> vLLM server generate sampling_params."""
+    sp = dict(sampling_params or {})
+    out: Dict[str, Any] = {
+        "temperature": float(sp.get("temperature") if sp.get("temperature") is not None else 1.0),
+        "top_p": float(sp.get("top_p") if sp.get("top_p") is not None else 1.0),
+        "logprobs": True,
+    }
+    top_k = sp.get("top_k")
+    if top_k not in (None, 0):
+        out["top_k"] = int(top_k)
+    max_tokens = sp.get("max_tokens") or sp.get("max_new_tokens")
+    if max_tokens:
+        out["max_tokens"] = int(max_tokens)
+    if sp.get("stop"):
+        out["stop"] = sp["stop"]
+    if sp.get("stop_token_ids"):
+        out["stop_token_ids"] = [int(t) for t in sp["stop_token_ids"]]
+    if sp.get("seed") is not None:
+        out["seed"] = int(sp["seed"])
+    return out
+
+
+def _compose_actor_rollout_config(cfg: Dict[str, Any]):
+    """Assemble a trainer-shaped OmegaConf for ActorRolloutRefWorker +
+    LLMServerManager from verl's packaged ppo_trainer defaults."""
+    import os as _os
+
+    from hydra import compose, initialize_config_dir
+    from hydra.core.global_hydra import GlobalHydra
+
+    import verl.trainer.config as _cfgpkg
+
+    model = cfg["model"]
+    engine = cfg["engine"]
+    rollout = cfg["rollout"]
+    micro_bs = int(engine["micro_batch_size_per_gpu"])
+    num_gpus = int(cfg["num_gpus"])
+
+    tm = model["target_modules"]
+    tm_override = "[" + ",".join(tm) + "]" if isinstance(tm, (list, tuple)) else str(tm)
+
+    overrides = [
+        f"actor_rollout_ref.model.path={model['path']}",
+        f"actor_rollout_ref.model.use_remove_padding={model['use_remove_padding']}",
+        f"actor_rollout_ref.model.lora_rank={model['lora_rank']}",
+        f"actor_rollout_ref.model.lora_alpha={model['lora_alpha']}",
+        f"actor_rollout_ref.model.target_modules={tm_override}",
+        f"actor_rollout_ref.actor.strategy={engine['strategy']}",
+        f"actor_rollout_ref.actor.ulysses_sequence_parallel_size={engine['ulysses_sequence_parallel_size']}",
+        f"actor_rollout_ref.actor.use_dynamic_bsz={engine['use_dynamic_bsz']}",
+        f"actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu={micro_bs}",
+        # unused by the Tinker split path (fb bypasses the mini-batch loop)
+        # but ActorConfig validates divisibility
+        f"actor_rollout_ref.actor.ppo_mini_batch_size={micro_bs * num_gpus}",
+        f"actor_rollout_ref.actor.ppo_max_token_len_per_gpu={engine['max_token_len_per_gpu']}",
+        f"actor_rollout_ref.actor.fsdp_config.fsdp_size={engine['fsdp_size']}",
+        f"actor_rollout_ref.actor.fsdp_config.param_offload={engine['param_offload']}",
+        f"actor_rollout_ref.actor.fsdp_config.optimizer_offload={engine['optimizer_offload']}",
+        f"actor_rollout_ref.actor.optim.lr={cfg['optim']['lr']}",
+        f"actor_rollout_ref.rollout.name={rollout['name']}",
+        f"actor_rollout_ref.rollout.mode={rollout['mode']}",
+        f"actor_rollout_ref.rollout.prompt_length={rollout['prompt_length']}",
+        f"actor_rollout_ref.rollout.response_length={rollout['response_length']}",
+        f"actor_rollout_ref.rollout.tensor_model_parallel_size={rollout['tensor_model_parallel_size']}",
+        f"actor_rollout_ref.rollout.gpu_memory_utilization={rollout['gpu_memory_utilization']}",
+        f"actor_rollout_ref.rollout.enforce_eager={rollout['enforce_eager']}",
+        "actor_rollout_ref.rollout.calculate_log_probs=True",
+        "actor_rollout_ref.rollout.free_cache_engine=True",
+        f"actor_rollout_ref.rollout.log_prob_use_dynamic_bsz={engine['use_dynamic_bsz']}",
+        f"actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu={engine['infer_micro_batch_size_per_gpu']}",
+        f"actor_rollout_ref.rollout.log_prob_max_token_len_per_gpu={engine['infer_max_token_len_per_gpu']}",
+        f"trainer.n_gpus_per_node={num_gpus}",
+        "trainer.nnodes=1",
+    ]
+
+    GlobalHydra.instance().clear()
+    with initialize_config_dir(config_dir=_os.path.dirname(_cfgpkg.__file__), version_base=None):
+        full = compose(config_name="ppo_trainer", overrides=overrides)
+    return full
+
+
+def _boot_worker_group(cfg: Dict[str, Any], model_id: str, enable_rollout: bool = False):
+    """Boot the verl worker group.
+
+    enable_rollout=False: TinkerTrainingWorker (M1 training-only path).
+    enable_rollout=True: TinkerActorRolloutRefWorker + colocated vLLM server
+    replicas; one naive weight sync at boot (load_format=dummy must never be
+    served), then replicas sleep until the first sample.
+    """
     import ray
     from verl.single_controller.ray import RayClassWithInitArgs, RayResourcePool, RayWorkerGroup
-    from verl.workers.config import FSDPEngineConfig, FSDPOptimizerConfig, HFModelConfig
-    from verl.workers.engine_workers import TrainingWorkerConfig
-    from verl.workers.engine_workers_tinker import TinkerTrainingWorker
 
     if not ray.is_initialized():
         ray.init(address="auto", ignore_reinit_error=True)
+
+    if enable_rollout:
+        from verl.checkpoint_engine import CheckpointEngineManager
+        from verl.utils import omega_conf_to_dataclass
+        from verl.workers.engine_workers_tinker import TinkerActorRolloutRefWorker
+        from verl.workers.rollout.llm_server import LLMServerManager
+
+        full = _compose_actor_rollout_config(cfg)
+        ray_cls = RayClassWithInitArgs(
+            cls=ray.remote(TinkerActorRolloutRefWorker),
+            config=full.actor_rollout_ref, role="actor_rollout",
+        )
+        resource_pool = RayResourcePool(
+            process_on_nodes=[cfg["num_gpus"]], name_prefix=f"verl_{model_id}",
+        )
+        wg = RayWorkerGroup(resource_pool=resource_pool, ray_cls_with_init=ray_cls)
+        wg.init_model()
+
+        # KNOWN LIMIT: vLLM server actors are Ray-named per replica rank
+        # (manager doesn't thread name_suffix), so at most ONE rollout-enabled
+        # verl model per Ray cluster; a second create_model fails loudly on
+        # the actor name. delete_model frees the names.
+        llm_manager = LLMServerManager.create(config=full, worker_group=wg)
+        ckpt_manager = CheckpointEngineManager(
+            config=omega_conf_to_dataclass(full.actor_rollout_ref.rollout.checkpoint_engine),
+            actor_wg=wg,
+            replicas=llm_manager.get_replicas(),
+        )
+        # canonical boot order (agent-loop harness): sleep -> sync -> sleep;
+        # vLLM never serves dummy weights, training starts with GPUs free
+        ckpt_manager.sleep_replicas()
+        ckpt_manager.update_weights(global_steps=0)
+        ckpt_manager.sleep_replicas()
+
+        sp = cfg["engine"]["ulysses_sequence_parallel_size"]
+        dp_size = max(cfg["num_gpus"] // max(sp, 1), 1)
+        return {
+            "worker_group": wg,
+            "resource_pool": resource_pool,
+            "dp_size": dp_size,
+            "llm_manager": llm_manager,
+            "llm_client": llm_manager.get_client(),
+            "ckpt_manager": ckpt_manager,
+        }
+
+    from verl.workers.config import FSDPEngineConfig, FSDPOptimizerConfig, HFModelConfig
+    from verl.workers.engine_workers import TrainingWorkerConfig
+    from verl.workers.engine_workers_tinker import TinkerTrainingWorker
 
     model = cfg["model"]
     engine = cfg["engine"]
@@ -437,4 +701,4 @@ def _boot_worker_group(cfg: Dict[str, Any], model_id: str):
 
     sp = engine["ulysses_sequence_parallel_size"]
     dp_size = max(cfg["num_gpus"] // max(sp, 1), 1)
-    return wg, resource_pool, dp_size
+    return {"worker_group": wg, "resource_pool": resource_pool, "dp_size": dp_size}

--- a/training/backends/verl/builder.py
+++ b/training/backends/verl/builder.py
@@ -73,6 +73,27 @@ class VerlArgumentBuilder(ArgumentBuilder):
                 "lr_scheduler_type": "constant",
             },
             "max_seq_len": max_seq_len,
+            # M2: vLLM rollout servers colocated with the training engine
+            # (hybrid timeshare: replicas sleep during training ops, wake +
+            # weight-sync for sampling). load_format stays "dummy" — the boot
+            # sequence does one naive update_weights so vLLM never serves
+            # dummy weights.
+            "rollout": {
+                "name": "vllm",
+                "mode": "async",
+                "prompt_length": max_seq_len,
+                "response_length": int(
+                    (rollout_config or {}).get("max_response_len")
+                    or self.overrides.get("response_length", 1024)
+                ),
+                "tensor_model_parallel_size": int((rollout_config or {}).get("tp_size") or 1),
+                "gpu_memory_utilization": float(
+                    self.overrides.get("rollout_gpu_memory_utilization", 0.5)
+                ),
+                # eager avoids cudagraph capture at every wake on small gate
+                # models; flip via overrides for throughput runs
+                "enforce_eager": bool(self.overrides.get("enforce_eager", True)),
+            },
         }
         return cfg
 

--- a/training/backends/verl/builder.py
+++ b/training/backends/verl/builder.py
@@ -33,7 +33,11 @@ class VerlArgumentBuilder(ArgumentBuilder):
 
         # request payloads carry explicit None values — coalesce, don't .get()-default
         lora_rank = int(lora_config.get("rank") or lora_config.get("lora_rank") or 0)
+        # verl's structured config types lora_alpha as int (omegaconf rejects
+        # 32.0 at the vLLM server-side merge); keep integral alphas as int
         lora_alpha = float(lora_config.get("alpha") or lora_config.get("lora_alpha") or 32)
+        if lora_alpha.is_integer():
+            lora_alpha = int(lora_alpha)
         target_modules = lora_config.get("target_modules") or "all-linear"
 
         cfg: Dict[str, Any] = {

--- a/training/models/requests.py
+++ b/training/models/requests.py
@@ -220,6 +220,9 @@ class SamplingParams(BaseModel):
     max_tokens: int = Field(default=256, ge=1, le=4096, description="Maximum tokens to generate")
     stop: Optional[List[str]] = Field(default=None, description="Stop sequences")
     stop_token_ids: Optional[List[int]] = Field(default=None, description="Stop token IDs")
+    # SDK SamplingParams carries seed; without this field pydantic silently
+    # drops it and seeded sampling is non-reproducible (found in verl M2 G8)
+    seed: Optional[int] = Field(default=None, description="Random seed for reproducible generation")
 
     @model_validator(mode="before")
     def convert_integer_stop_to_token_ids(cls, values):

--- a/training/utils/helpers.py
+++ b/training/utils/helpers.py
@@ -303,6 +303,10 @@ def find_model_with_rollout_manager(training_clients: Dict[str, Dict[str, Any]])
         if handle is not None and getattr(handle, "backend_type", None) == "nemo_rl":
             logger.debug(f"Found model with NemoRL backend: {model_id}")
             return model_id
+        # verl M2: handle carries its own rollout state (vLLM server replicas)
+        if handle is not None and getattr(handle, "has_rollout", False):
+            logger.debug(f"Found model with rollout-enabled handle: {model_id}")
+            return model_id
 
     logger.warning("No model with RolloutManager or NemoRL backend found")
     return None


### PR DESCRIPTION
## What

Completes the verl backend's sampling path (M1 left `sample`/`prepare_for_generation` as `UnsupportedFeatureError`):

- **Worker**: `TinkerActorRolloutRefWorker` (verl's upstream Tinker split-primitive worker, `actor_rollout` role) — same fb/step primitives, plus rollout engines and checkpoint engine. Worker config assembled from verl's packaged `ppo_trainer` defaults via hydra compose.
- **Sampling**: colocated vLLM server replicas (`LLMServerManager`), per-request token-in-token-out `generate` with logprobs; `num_samples` fanned out concurrently with per-sample derived seeds.
- **Hybrid timeshare**: replicas sleep during training ops, wake with a naive `CheckpointEngineManager` weight sync for sampling. Boot = sleep→sync→sleep (`load_format=dummy` never served). `update_inference_weights` is lazy — version-gated sync at the next sample, so pure-training runs pay nothing.
- **Logprob provenance**: `logprobs_mode=raw_logprobs` — verl's default `processed_logprobs` returns renormalized values (measured ~1.3 nats off fp32 HF); Tinker's contract is raw untempered logprobs. Caught by the new G8a parity oracle.
- 9 first-contact seam fixes (commit 2), incl. a backend-agnostic one: `SamplingParams.seed` was silently dropped by pydantic.

Known limit (documented in-code): one rollout-enabled verl model per Ray cluster (named vLLM server actors); second create fails loudly; delete frees the names.

## Cluster validation (tinkercloud-verl, Qwen2.5-0.5B r32, dp=1) — scripts/gates/g8_verl_sampling.py

| Gate | Result |
|---|---|
| G8a sampler-vs-training-engine logprob parity (independent engines) | **corr 0.9996, mean gap 0.031 nats** (bf16 E1) |
| G8b post-step resync freshness | output moved; **corr 0.99991, 0.028 nats** — sync delivered stepped weights |
| G8c timeshare regression | grad_norm **bit-identical** across fb(8)+step ≡ 2×fb(4)+step ≡ rerun with rollout attached; post-training sample OK |
| G8d 5-step importance-sampling RL smoke | completes; gap 0.023–0.032 nats each step (IS ≈ 1) |

Timings: boot 65s; steady sample 1.3s; sample with resync 2.6s; fb(8)+step 3.5s.

Note: requires 3 vllm-0.11 compat patches in the verl tree (fork PR, referenced in review) — no semantic engine changes.
