### PR TITLE
verl: batch concurrent samples in vLLM (generate outside the handle lock)

### DIFF
--- a/scripts/gates/g8e_overlap_check.py
+++ b/scripts/gates/g8e_overlap_check.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""G8e overlap check: 8 concurrent samples (no-lock generate path) + fb/step
+submitted while samples are in flight, then a final sample (quiesce under
+real overlap). Fresh model; deleted at the end."""
+import json
+import os
+import time
+os.environ.setdefault("TINKER_BASE_URL", "http://localhost:8000")
+os.environ.setdefault("TINKER_API_KEY", "tml-dev-key")
+import requests
+import torch
+import tinker
+from tinker import types
+
+BASE, KEY = os.environ["TINKER_BASE_URL"], os.environ["TINKER_API_KEY"]
+PROMPT = [(1000 + j * 104729) % 50000 for j in range(30)]
+OUT = {"date": time.strftime("%Y-%m-%d %H:%M:%S"), "checks": {}}
+fails = []
+
+def check(name, ok, detail=""):
+    print(f"  {name}: {'PASS' if ok else 'FAIL'} {detail}", flush=True)
+    OUT["checks"][name] = {"ok": bool(ok), "detail": detail}
+    if not ok:
+        fails.append(name)
+
+def datums(n, salt=9):
+    out = []
+    for i in range(n):
+        toks = [(1000 + (salt * 31 + i) * 7919 + j * 104729) % 50000 for j in range(64)]
+        inp, tgt = toks[:-1], toks[1:]
+        out.append(types.Datum(
+            model_input=types.ModelInput.from_ints(inp),
+            loss_fn_inputs={
+                "weights": types.TensorData.from_torch(torch.ones(len(inp))),
+                "target_tokens": types.TensorData.from_torch(torch.tensor(tgt, dtype=torch.long)),
+            }))
+    return out
+
+sc = tinker.ServiceClient()
+t0 = time.time()
+tc = sc.create_lora_training_client(base_model="Qwen/Qwen2.5-0.5B", rank=32)
+print(f"model {tc.model_id} (boot {time.time()-t0:.1f}s)", flush=True)
+OUT["model_id"] = tc.model_id
+sampler = tc.save_weights_and_get_sampling_client()
+
+# warm-up sample (wake + first sync)
+sampler.sample(prompt=types.ModelInput.from_ints(PROMPT),
+               sampling_params=types.SamplingParams(temperature=1.0, max_tokens=8, seed=7),
+               num_samples=1).result()
+print("warm-up sample ok", flush=True)
+
+# 8 concurrent samples, then fb+step while in flight
+t0 = time.time()
+sfuts = [sampler.sample(prompt=types.ModelInput.from_ints(PROMPT),
+                        sampling_params=types.SamplingParams(temperature=1.0, max_tokens=64, seed=100 + i),
+                        num_samples=1) for i in range(8)]
+fbfut = tc.forward_backward(datums(4), "cross_entropy")
+stfut = tc.optim_step(types.AdamParams(learning_rate=0.0))
+print(f"submitted 8 samples + fb + step in {time.time()-t0:.2f}s", flush=True)
+
+fb = fbfut.result()
+ok_shapes = (len(fb.loss_fn_outputs) == 4 and
+             all(len(o["logprobs"].data) == 63 for o in fb.loss_fn_outputs))
+check("fb during in-flight samples returns correct shapes", ok_shapes,
+      f"n_out={len(fb.loss_fn_outputs)}")
+stfut.result()
+check("optim_step(lr=0) completes", True)
+
+sres = [f.result() for f in sfuts]
+ok_s = all(r.sequences and r.sequences[0].tokens for r in sres)
+check("all 8 concurrent samples return tokens", ok_s,
+      f"lens={[len(r.sequences[0].tokens) for r in sres]}")
+
+t0 = time.time()
+fin = sampler.sample(prompt=types.ModelInput.from_ints(PROMPT),
+                     sampling_params=types.SamplingParams(temperature=1.0, max_tokens=16, seed=7),
+                     num_samples=1).result()
+check("final sample after quiesce+train succeeds",
+      bool(fin.sequences and fin.sequences[0].tokens), f"{time.time()-t0:.1f}s")
+
+r = requests.post(f"{BASE}/api/v1/delete_model", json={"model_id": tc.model_id},
+                  headers={"X-API-Key": KEY, "Content-Type": "application/json"})
+check("delete_model", r.status_code == 200, f"http {r.status_code}")
+
+OUT["verdict"] = "PASS" if not fails else f"FAIL: {fails}"
+with open("/data/g8e_overlap_results.json", "w") as f:
+    json.dump(OUT, f, indent=2)
+print("G8e overlap:", OUT["verdict"], flush=True)

--- a/training/backends/verl/backend.py
+++ b/training/backends/verl/backend.py
@@ -30,6 +30,12 @@ from ..base import BackendError, BackendHandle, TrainingBackend, UnsupportedFeat
 logger = logging.getLogger(__name__)
 
 
+def _set_event() -> asyncio.Event:
+    e = asyncio.Event()
+    e.set()
+    return e
+
+
 @dataclass
 class VerlHandle(BackendHandle):
     """veRL-specific runtime state."""
@@ -51,6 +57,10 @@ class VerlHandle(BackendHandle):
     rollout_synced_version: int = -1  # weight_version last synced to vLLM
     lora_rank: int = 0
     _lock: asyncio.Lock = field(default_factory=asyncio.Lock)  # FIFO per handle
+    # Sample concurrency: generates run OUTSIDE _lock so vLLM batches them;
+    # training ops quiesce active samplers first (_quiesce_samplers).
+    _active_samplers: int = 0
+    _samplers_drained: asyncio.Event = field(default_factory=_set_event)
 
 
 class VerlBackend(TrainingBackend):
@@ -153,6 +163,7 @@ class VerlBackend(TrainingBackend):
         h: VerlHandle = handle  # type: ignore[assignment]
         async with h._lock:
             try:
+                await self._quiesce_samplers(h)
                 await asyncio.to_thread(self._ensure_training_ready, h)
                 await asyncio.to_thread(self._ensure_loss_fn, h, loss_fn)
                 td = await asyncio.to_thread(self._to_tensordict, h, data, loss_fn)
@@ -180,6 +191,7 @@ class VerlBackend(TrainingBackend):
         h: VerlHandle = handle  # type: ignore[assignment]
         async with h._lock:
             try:
+                await self._quiesce_samplers(h)
                 await asyncio.to_thread(self._ensure_training_ready, h)
                 params: Dict[str, Any] = {}
                 if learning_rate is not None:
@@ -226,6 +238,7 @@ class VerlBackend(TrainingBackend):
         h: VerlHandle = handle  # type: ignore[assignment]
         async with h._lock:
             try:
+                await self._quiesce_samplers(h)
                 await asyncio.to_thread(self._ensure_training_ready, h)
                 td = await asyncio.to_thread(self._to_tensordict, h, data, "cross_entropy", True)
                 from verl.utils import tensordict_utils as tu
@@ -263,6 +276,7 @@ class VerlBackend(TrainingBackend):
         h: VerlHandle = handle  # type: ignore[assignment]
         async with h._lock:
             try:
+                await self._quiesce_samplers(h)
                 await asyncio.to_thread(
                     h.worker_group.save_checkpoint, checkpoint_path, None, step_id or h.weight_version,
                 )
@@ -274,6 +288,7 @@ class VerlBackend(TrainingBackend):
         h: VerlHandle = handle  # type: ignore[assignment]
         async with h._lock:
             try:
+                await self._quiesce_samplers(h)
                 await asyncio.to_thread(h.worker_group.load_checkpoint, checkpoint_path)
             except Exception as e:
                 raise BackendError(str(e), backend="verl", operation="load_checkpoint", original_error=e) from e
@@ -326,7 +341,10 @@ class VerlBackend(TrainingBackend):
                 suggestion="model was created debug_train_only; recreate with rollout enabled",
             )
         # Hybrid timeshare: generation must not overlap training ops on the
-        # same GPUs, so sampling holds the handle FIFO lock too.
+        # same GPUs. Register as an active sampler under the FIFO lock (which
+        # serializes the wake/weight-sync), then generate WITHOUT the lock so
+        # concurrent sample requests batch inside vLLM; training ops quiesce
+        # samplers via _quiesce_samplers before touching the GPUs.
         async with h._lock:
             try:
                 await asyncio.to_thread(self._ensure_rollout_ready, h)
@@ -345,7 +363,14 @@ class VerlBackend(TrainingBackend):
                         "[%s] prompt_logprobs unsupported on verl sample path "
                         "(use forward/get_logprobs); returning None", request_id,
                     )
-
+                h._active_samplers += 1
+                h._samplers_drained.clear()
+            except (BackendError, UnsupportedFeatureError):
+                raise
+            except Exception as e:
+                raise BackendError(str(e), backend="verl", operation="sample", original_error=e) from e
+        try:
+            try:
                 vllm_sp = _to_vllm_sampling_params(sampling_params)
                 max_tokens = vllm_sp.get("max_tokens")
 
@@ -364,25 +389,29 @@ class VerlBackend(TrainingBackend):
                     return out
 
                 outs = await asyncio.gather(*[_one(i) for i in range(num_samples)])
-                sequences = []
-                for out in outs:
-                    if out.stop_reason == "aborted":
-                        raise BackendError(
-                            "rollout request aborted", backend="verl", operation="sample",
-                        )
-                    n_tok = len(out.token_ids)
-                    stop_reason = "length" if (max_tokens is not None and n_tok >= max_tokens) else "stop"
-                    sequences.append({
-                        "tokens": list(out.token_ids),
-                        "logprobs": list(out.log_probs) if out.log_probs is not None else None,
-                        "text": None,
-                        "stop_reason": stop_reason,
-                    })
-                return {"sequences": sequences, "prompt_logprobs": None}
-            except (BackendError, UnsupportedFeatureError):
-                raise
-            except Exception as e:
-                raise BackendError(str(e), backend="verl", operation="sample", original_error=e) from e
+            finally:
+                h._active_samplers -= 1
+                if h._active_samplers == 0:
+                    h._samplers_drained.set()
+            sequences = []
+            for out in outs:
+                if out.stop_reason == "aborted":
+                    raise BackendError(
+                        "rollout request aborted", backend="verl", operation="sample",
+                    )
+                n_tok = len(out.token_ids)
+                stop_reason = "length" if (max_tokens is not None and n_tok >= max_tokens) else "stop"
+                sequences.append({
+                    "tokens": list(out.token_ids),
+                    "logprobs": list(out.log_probs) if out.log_probs is not None else None,
+                    "text": None,
+                    "stop_reason": stop_reason,
+                })
+            return {"sequences": sequences, "prompt_logprobs": None}
+        except (BackendError, UnsupportedFeatureError):
+            raise
+        except Exception as e:
+            raise BackendError(str(e), backend="verl", operation="sample", original_error=e) from e
 
     async def prepare_for_generation(self, handle: BackendHandle) -> None:
         h: VerlHandle = handle  # type: ignore[assignment]
@@ -400,6 +429,13 @@ class VerlBackend(TrainingBackend):
                 ) from e
 
     # -------------------------------------------------------------- helpers
+
+    @staticmethod
+    async def _quiesce_samplers(h: VerlHandle) -> None:
+        """Drain in-flight generates. Call with h._lock HELD: new samplers
+        queue behind the lock; active ones finish without needing it."""
+        while h._active_samplers:
+            await h._samplers_drained.wait()
 
     @staticmethod
     def _ensure_training_ready(h: VerlHandle) -> None:


### PR DESCRIPTION
## Problem

`sample()` held the per-handle FIFO lock through generation, serializing every concurrent request — an RL rollout fanout of 128 took ~10.5 min/step with the GPUs mostly idle (found by the first `rl_basic` smoke on the verl backend).

## Fix

Samplers register under the lock (wake/weight-sync stays serialized), then generate **outside** it so vLLM batches concurrent requests. Training ops drain in-flight generates via `_quiesce_samplers()` before touching the GPUs (fb, optim_step, get_logprobs, save/load_checkpoint). A post-step weight sync can never run under an in-flight generate: a stale rollout version implies an optim_step happened, which quiesced all samplers first.

Effect: rl_basic sampling phase ~10.5 min → ~9 s (~65×); 15/15 RL steps healthy (accuracy 0.339→0.495, sampler-vs-trainer KL 2.1e-4–8.2e-4 nats throughout, 17.1 s/step flat).

## Regression (G8 suite re-run at dp=2 on this branch)

| Gate | Result |
|---|---|
| G8a provenance | corr 0.999638 / gap 0.0307 nats (dp=1 baseline 0.9996/0.031) |
| G8b post-step parity | corr 0.999837 / 0.032 nats |
| G8c timeshare | grad_norm **bit-identical** across arms (2456.51708984375, dp=2) |
| G8d RL smoke | 5 steps, max gap 0.032 nats |
| **G8e overlap (new gate)** | 8 concurrent samples + fb/step fired mid-flight + final sample — drain path exercised, correct shapes, no crash |

Adds `scripts/gates/g8e_overlap_check.py`.
