### PR TITLE
Cross-backend LoRA adapter interchange: migrate a training program between engines

### DIFF
--- a/scripts/gates/README.md
+++ b/scripts/gates/README.md
@@ -17,6 +17,13 @@ rotate the server between runs (models are not auto-reaped).
 | `g5_pinned_v0.py` | G5 pinned-v0 + sampler routing | v0 sampler == base, bit-stable across training; live != base; per-tenant routing (B live == base while A live differs) |
 | `g6_batch_invariance.py` | G6 batch-invariance (M3, AC1) | same tenant data solo vs co-batched with different co-tenant mixes ⇒ bit-identical per-tenant grad_norm + logprobs (needs `TINKERCLOUD_MILES_COBATCH_MAX_SAMPLES>=16`) |
 
+| `g9_adapter_interchange.py` | G9a adapter round-trip / G9b seam continuity | `export`: exported `hf_adapter/` reproduces the training engine's logprobs under fp32 HF+peft (corr > 0.999, gap < 0.03 nats). `import`: a model created FROM that checkpoint on another backend matches the source's logprobs on the same frozen probe batch |
+
+G9 is the Q5 migration seam gate (specs/007-q5-migration). Run `export` on
+the source pod, `kubectl cp` `/data/checkpoints/<run_id>/<name>` to the
+destination pod at the same path, then run `import` there with the
+exporter's JSON as `--reference`.
+
 G4/G5 need a pool-mode server (`TINKERCLOUD_MILES_MULTILORA_SLOTS>0`). The
 per-tenant E₂ gate is two `g3_sl_basic.py` runs launched concurrently
 against the same pool-mode server (each creates its own tenant).

--- a/scripts/gates/g9_adapter_interchange.py
+++ b/scripts/gates/g9_adapter_interchange.py
@@ -41,7 +41,10 @@ from tinker import types
 
 BASE_MODEL = os.environ.get("G9_BASE_MODEL", "Qwen/Qwen2.5-0.5B")
 RANK = int(os.environ.get("G9_RANK", "32"))
-SEQ = 64
+# 257 tokens => 256-token inputs after the target shift: miles' TE fused-attn
+# backward fails with CUDNN_STATUS_BAD_PARAM on short/odd sequence lengths
+# (63 crashed), so keep the probe on a power-of-two length.
+SEQ = 257
 N_TRAIN = 4          # datums per training step
 PROBE_SEED = 20260803
 CORR_BAR, GAP_BAR = 0.999, 0.03
@@ -85,7 +88,10 @@ def _train(tc, steps: int, lr: float) -> list[float]:
         st = tc.optim_step(types.AdamParams(learning_rate=lr))
         fb.result()
         res = st.result()
-        gn = getattr(res, "grad_norm", None)
+        # OptimStepResponse has no top-level grad_norm — it rides in metrics
+        # (key name varies by backend: grad_norm / optim/grad_norm / ...).
+        metrics = getattr(res, "metrics", None) or {}
+        gn = next((v for k, v in metrics.items() if "grad_norm" in k), None)
         norms.append(float(gn) if gn is not None else float("nan"))
         print(f"  step {step}: grad_norm={norms[-1]}")
     return norms

--- a/scripts/gates/g9_adapter_interchange.py
+++ b/scripts/gates/g9_adapter_interchange.py
@@ -68,14 +68,36 @@ def _datum(toks: list[int]) -> types.Datum:
     )
 
 
-def _probe_logprobs(tc, probe: list[list[int]]) -> list[float]:
-    """Backend's per-token logprobs on the frozen probe batch. forward_backward
-    accumulates grads but applies nothing — the observable is read-only as long
-    as no optim_step follows before the snapshot is taken."""
-    out = tc.forward_backward([_datum(t) for t in probe], loss_fn="cross_entropy").result()
+def _flatten_logprobs(outputs) -> list[float]:
+    """loss_fn_outputs entries are Pydantic LossFnOutput on some paths and
+    plain dicts on others; both index, only one has .get."""
     lps: list[float] = []
-    for o in out.loss_fn_outputs:
-        lps.extend(list(o["logprobs"].data))
+    for o in outputs or []:
+        try:
+            lp = o["logprobs"]
+        except Exception:
+            lp = getattr(o, "logprobs", None)
+        if lp is not None:
+            lps.extend(list(getattr(lp, "data", lp)))
+    return lps
+
+
+def _probe_logprobs(tc, probe: list[list[int]]) -> list[float]:
+    """Backend's per-token logprobs on the frozen probe batch.
+
+    Uses the forward-only primitive deliberately: forward_backward is not a
+    read-only observable on every backend — R9-buffering backends (nemo_rl)
+    execute nothing there and hand back zero placeholders, deferring the real
+    values to optim_step (001-P3). forward() means the same thing everywhere
+    and leaves no gradient state behind.
+    """
+    out = tc.forward([_datum(t) for t in probe], loss_fn="cross_entropy").result()
+    lps = _flatten_logprobs(out.loss_fn_outputs)
+    if not lps or not any(lps):
+        raise SystemExit(
+            "forward() returned no per-token logprobs — this backend's "
+            "forward-only path does not carry the observable the seam gate needs"
+        )
     return lps
 
 

--- a/scripts/gates/g9_adapter_interchange.py
+++ b/scripts/gates/g9_adapter_interchange.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""G9: cross-backend LoRA adapter interchange gates (Q5 migration seams).
+
+Two modes, both against a live TinkerCloud server plus a local fp32 HF oracle:
+
+  export  train N steps, snapshot the observable on a frozen probe batch,
+          save_state, then load the PUBLISHED hf_adapter/ into plain
+          HF+peft (fp32) and compare logprobs.
+          -> **G9a adapter round-trip fidelity**: does the exported adapter
+          reproduce the training engine's own distribution? Independently
+          checks rank slicing, alpha scaling, target-module coverage and
+          state-dict key naming (specs/007 §3 open risk (a)).
+
+  import  create a model FROM that checkpoint on a second backend, run the
+          same frozen probe batch, and compare to the exporter's JSON.
+          -> **G9b seam continuity**: the quantity the Q5 figure rests on.
+
+PASS bar: E1 (corr > 0.999 and |mean logprob gap| < 0.03 nats) — the
+cross-engine envelope measured in 006 (G_lp 0.004, G8a 0.031).
+
+Usage:
+  python3 -B scripts/gates/g9_adapter_interchange.py export \
+      --steps 3 --name g9-seam --out /data/g9_export_<backend>.json
+  # kubectl cp /data/checkpoints/<run_id>/<name> to the destination pod
+  python3 -B scripts/gates/g9_adapter_interchange.py import \
+      --resume tinker://<run_id>/weights/g9-seam \
+      --reference /data/g9_export_<backend>.json --out /data/g9_import_<backend>.json
+"""
+import argparse
+import json
+import os
+import sys
+
+os.environ.setdefault("TINKER_BASE_URL", "http://localhost:8000")
+os.environ.setdefault("TINKER_API_KEY", "tml-dev-key")
+
+import torch
+
+import tinker
+from tinker import types
+
+BASE_MODEL = os.environ.get("G9_BASE_MODEL", "Qwen/Qwen2.5-0.5B")
+RANK = int(os.environ.get("G9_RANK", "32"))
+SEQ = 64
+N_TRAIN = 4          # datums per training step
+PROBE_SEED = 20260803
+CORR_BAR, GAP_BAR = 0.999, 0.03
+
+
+def _tokens(seed: int, n: int, length: int) -> list[list[int]]:
+    """Deterministic token batches — identical on every backend and in the
+    offline oracle (no cookbook/dataset dependency in the seam gate)."""
+    g = torch.Generator().manual_seed(seed)
+    return torch.randint(100, 40000, (n, length), generator=g).tolist()
+
+
+def _datum(toks: list[int]) -> types.Datum:
+    inp, tgt = toks[:-1], toks[1:]
+    return types.Datum(
+        model_input=types.ModelInput.from_ints(inp),
+        loss_fn_inputs={
+            "weights": types.TensorData.from_torch(torch.ones(len(inp), dtype=torch.float32)),
+            "target_tokens": types.TensorData.from_torch(torch.tensor(tgt, dtype=torch.long)),
+        },
+    )
+
+
+def _probe_logprobs(tc, probe: list[list[int]]) -> list[float]:
+    """Backend's per-token logprobs on the frozen probe batch. forward_backward
+    accumulates grads but applies nothing — the observable is read-only as long
+    as no optim_step follows before the snapshot is taken."""
+    out = tc.forward_backward([_datum(t) for t in probe], loss_fn="cross_entropy").result()
+    lps: list[float] = []
+    for o in out.loss_fn_outputs:
+        lps.extend(list(o["logprobs"].data))
+    return lps
+
+
+def _train(tc, steps: int, lr: float) -> list[float]:
+    """Move the adapter off its B=0 init so the export carries real weights."""
+    norms = []
+    for step in range(steps):
+        batch = _tokens(PROBE_SEED + 1000 + step, N_TRAIN, SEQ)
+        fb = tc.forward_backward([_datum(t) for t in batch], loss_fn="cross_entropy")
+        st = tc.optim_step(types.AdamParams(learning_rate=lr))
+        fb.result()
+        res = st.result()
+        gn = getattr(res, "grad_norm", None)
+        norms.append(float(gn) if gn is not None else float("nan"))
+        print(f"  step {step}: grad_norm={norms[-1]}")
+    return norms
+
+
+def _compare(a: list[float], b: list[float], label_a: str, label_b: str) -> dict:
+    ta, tb = torch.tensor(a, dtype=torch.float64), torch.tensor(b, dtype=torch.float64)
+    assert ta.shape == tb.shape, f"length mismatch {ta.shape} vs {tb.shape}"
+    corr = float(torch.corrcoef(torch.stack([ta, tb]))[0, 1])
+    gap = float((ta.mean() - tb.mean()).abs())
+    verdict = "PASS" if corr > CORR_BAR and gap < GAP_BAR else "FAIL"
+    print(
+        f"{label_a} vs {label_b}: n={ta.numel()} corr={corr:.6f} "
+        f"mean_gap={gap:.6f} nats max|d|={float((ta - tb).abs().max()):.6f} -> {verdict}"
+    )
+    return {
+        "n": int(ta.numel()), "corr": corr, "mean_gap_nats": gap,
+        "max_abs_delta": float((ta - tb).abs().max()),
+        f"mean_lp_{label_a}": float(ta.mean()), f"mean_lp_{label_b}": float(tb.mean()),
+        "verdict": verdict,
+    }
+
+
+def _offline_adapter_logprobs(adapter_dir: str, probe: list[list[int]]) -> list[float]:
+    """fp32 HF + peft oracle: base model with the EXPORTED adapter attached."""
+    from peft import PeftModel
+    from transformers import AutoModelForCausalLM
+
+    model = AutoModelForCausalLM.from_pretrained(BASE_MODEL, torch_dtype=torch.float32)
+    model = PeftModel.from_pretrained(model, adapter_dir)
+    model.eval()
+
+    lps: list[float] = []
+    with torch.no_grad():
+        for toks in probe:
+            logits = model(torch.tensor([toks])).logits[0, :-1].float()
+            tgt = torch.tensor(toks[1:])
+            lp = torch.log_softmax(logits, -1).gather(-1, tgt.unsqueeze(-1)).squeeze(-1)
+            lps.extend(lp.tolist())
+    return lps
+
+
+def _resolve_local(path: str) -> str:
+    sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+    from training.backends.checkpoint_interchange import find_hf_adapter, resolve_checkpoint_root
+
+    root = resolve_checkpoint_root(path)
+    adapter = find_hf_adapter(root)
+    if adapter is None:
+        raise SystemExit(
+            f"G9a FAIL: no hf_adapter/ under {root} — this backend published no "
+            f"interchange artifact, so the checkpoint cannot migrate."
+        )
+    return adapter
+
+
+def run_export(args) -> dict:
+    probe = _tokens(PROBE_SEED, N_TRAIN, SEQ)
+    sc = tinker.ServiceClient()
+    tc = sc.create_lora_training_client(base_model=BASE_MODEL, rank=RANK)
+
+    print(f"training {args.steps} steps (lr={args.lr})")
+    norms = _train(tc, args.steps, args.lr)
+
+    lp_backend = _probe_logprobs(tc, probe)
+    saved = tc.save_state(args.name).result()
+    path = getattr(saved, "path", None) or args.name
+    print(f"saved: {path}")
+
+    adapter_dir = _resolve_local(path)
+    print(f"interchange adapter: {adapter_dir}")
+    with open(os.path.join(adapter_dir, "adapter_config.json")) as f:
+        adapter_cfg = json.load(f)
+    print(f"adapter_config: r={adapter_cfg.get('r')} alpha={adapter_cfg.get('lora_alpha')}")
+
+    lp_oracle = _offline_adapter_logprobs(adapter_dir, probe)
+    g9a = _compare(lp_backend, lp_oracle, "backend", "hf_peft_oracle")
+
+    return {
+        "gate": "G9a_adapter_roundtrip", "mode": "export",
+        "base_model": BASE_MODEL, "rank": RANK, "steps": args.steps, "lr": args.lr,
+        "checkpoint_path": path, "adapter_dir": adapter_dir, "adapter_config": adapter_cfg,
+        "grad_norms": norms, "probe_seed": PROBE_SEED,
+        "logprobs_backend": lp_backend, "result": g9a,
+    }
+
+
+def run_import(args) -> dict:
+    probe = _tokens(PROBE_SEED, N_TRAIN, SEQ)
+    with open(args.reference) as f:
+        ref = json.load(f)
+
+    sc = tinker.ServiceClient()
+    tc = sc.create_lora_training_client(
+        base_model=ref["base_model"], rank=ref["rank"], checkpoint_path=args.resume,
+    )
+    lp_dest = _probe_logprobs(tc, probe)
+
+    g9b = _compare(ref["logprobs_backend"], lp_dest, "source_backend", "dest_backend")
+    return {
+        "gate": "G9b_seam_continuity", "mode": "import",
+        "base_model": ref["base_model"], "rank": ref["rank"],
+        "resume_path": args.resume, "reference": args.reference,
+        "source_checkpoint": ref.get("checkpoint_path"),
+        "logprobs_backend": lp_dest, "result": g9b,
+    }
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("mode", choices=["export", "import"])
+    ap.add_argument("--steps", type=int, default=3)
+    ap.add_argument("--lr", type=float, default=1e-4)
+    ap.add_argument("--name", default="g9-seam")
+    ap.add_argument("--resume")
+    ap.add_argument("--reference")
+    ap.add_argument("--out")
+    args = ap.parse_args()
+
+    if args.mode == "import" and not (args.resume and args.reference):
+        ap.error("import mode needs --resume and --reference")
+
+    result = run_export(args) if args.mode == "export" else run_import(args)
+
+    if args.out:
+        with open(args.out, "w") as f:
+            json.dump(result, f, indent=2)
+        print(f"wrote {args.out}")
+    print(f"{result['gate']}: {result['result']['verdict']}")
+    return 0 if result["result"]["verdict"] == "PASS" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/gates/g9_adapter_interchange.py
+++ b/scripts/gates/g9_adapter_interchange.py
@@ -68,21 +68,24 @@ def _datum(toks: list[int]) -> types.Datum:
     )
 
 
-def _flatten_logprobs(outputs) -> list[float]:
+def _per_datum_logprobs(outputs) -> list[list[float]]:
     """loss_fn_outputs entries are Pydantic LossFnOutput on some paths and
-    plain dicts on others; both index, only one has .get."""
-    lps: list[float] = []
+    plain dicts on others; both index, only one has .get. Kept per-datum:
+    the datum is the alignment unit of the observation contract, and backends
+    disagree on the length by one (miles forward() yields L-1 where its
+    forward_backward yields L)."""
+    per_datum: list[list[float]] = []
     for o in outputs or []:
         try:
             lp = o["logprobs"]
         except Exception:
             lp = getattr(o, "logprobs", None)
         if lp is not None:
-            lps.extend(list(getattr(lp, "data", lp)))
-    return lps
+            per_datum.append(list(getattr(lp, "data", lp)))
+    return per_datum
 
 
-def _probe_logprobs(tc, probe: list[list[int]]) -> list[float]:
+def _probe_logprobs(tc, probe: list[list[int]]) -> list[list[float]]:
     """Backend's per-token logprobs on the frozen probe batch.
 
     Uses the forward-only primitive deliberately: forward_backward is not a
@@ -92,8 +95,8 @@ def _probe_logprobs(tc, probe: list[list[int]]) -> list[float]:
     and leaves no gradient state behind.
     """
     out = tc.forward([_datum(t) for t in probe], loss_fn="cross_entropy").result()
-    lps = _flatten_logprobs(out.loss_fn_outputs)
-    if not lps or not any(lps):
+    lps = _per_datum_logprobs(out.loss_fn_outputs)
+    if not lps or not any(any(d) for d in lps):
         raise SystemExit(
             "forward() returned no per-token logprobs — this backend's "
             "forward-only path does not carry the observable the seam gate needs"
@@ -119,9 +122,22 @@ def _train(tc, steps: int, lr: float) -> list[float]:
     return norms
 
 
-def _compare(a: list[float], b: list[float], label_a: str, label_b: str) -> dict:
-    ta, tb = torch.tensor(a, dtype=torch.float64), torch.tensor(b, dtype=torch.float64)
-    assert ta.shape == tb.shape, f"length mismatch {ta.shape} vs {tb.shape}"
+def _compare(a: list[list[float]], b: list[list[float]], label_a: str, label_b: str) -> dict:
+    """Align per datum — the unit of the observation contract. A length
+    disagreement is REPORTED, never silently absorbed: it is itself a
+    cross-path divergence (measured 2026-08-03: miles forward() returns
+    L-1 per datum where its forward_backward returns L)."""
+    assert len(a) == len(b), f"datum count {len(a)} vs {len(b)}"
+    trimmed = [(len(x), len(y)) for x, y in zip(a, b) if len(x) != len(y)]
+    if trimmed:
+        print(f"  WARNING per-datum length disagreement {label_a}/{label_b}: {trimmed[:4]}")
+    flat_a, flat_b = [], []
+    for x, y in zip(a, b):
+        n = min(len(x), len(y))
+        flat_a.extend(x[:n])
+        flat_b.extend(y[:n])
+    ta = torch.tensor(flat_a, dtype=torch.float64)
+    tb = torch.tensor(flat_b, dtype=torch.float64)
     corr = float(torch.corrcoef(torch.stack([ta, tb]))[0, 1])
     gap = float((ta.mean() - tb.mean()).abs())
     verdict = "PASS" if corr > CORR_BAR and gap < GAP_BAR else "FAIL"
@@ -130,14 +146,14 @@ def _compare(a: list[float], b: list[float], label_a: str, label_b: str) -> dict
         f"mean_gap={gap:.6f} nats max|d|={float((ta - tb).abs().max()):.6f} -> {verdict}"
     )
     return {
-        "n": int(ta.numel()), "corr": corr, "mean_gap_nats": gap,
+        "n": int(ta.numel()), "length_mismatches": trimmed, "corr": corr, "mean_gap_nats": gap,
         "max_abs_delta": float((ta - tb).abs().max()),
         f"mean_lp_{label_a}": float(ta.mean()), f"mean_lp_{label_b}": float(tb.mean()),
         "verdict": verdict,
     }
 
 
-def _offline_adapter_logprobs(adapter_dir: str, probe: list[list[int]]) -> list[float]:
+def _offline_adapter_logprobs(adapter_dir: str, probe: list[list[int]]) -> list[list[float]]:
     """fp32 HF + peft oracle: base model with the EXPORTED adapter attached."""
     from peft import PeftModel
     from transformers import AutoModelForCausalLM
@@ -146,13 +162,13 @@ def _offline_adapter_logprobs(adapter_dir: str, probe: list[list[int]]) -> list[
     model = PeftModel.from_pretrained(model, adapter_dir)
     model.eval()
 
-    lps: list[float] = []
+    lps: list[list[float]] = []
     with torch.no_grad():
         for toks in probe:
             logits = model(torch.tensor([toks])).logits[0, :-1].float()
             tgt = torch.tensor(toks[1:])
             lp = torch.log_softmax(logits, -1).gather(-1, tgt.unsqueeze(-1)).squeeze(-1)
-            lps.extend(lp.tolist())
+            lps.append(lp.tolist())
     return lps
 
 

--- a/tests/test_checkpoint_interchange.py
+++ b/tests/test_checkpoint_interchange.py
@@ -1,0 +1,101 @@
+"""Unit tests for the cross-backend HF PEFT adapter interchange.
+
+Filesystem-level contract only (no engine): URI resolution, publish/stage
+round-trip, atomicity of publish, and the "native artifact wins" rule.
+Design: specs/007-q5-migration/HANDOFF.md §2.1.
+"""
+import json
+import os
+
+import pytest
+
+from tinkercloud.training.backends import checkpoint_interchange as ci
+
+
+def _write_adapter(d, r=32, alpha=32, weights=b"fake-safetensors"):
+    os.makedirs(d, exist_ok=True)
+    with open(os.path.join(d, ci.ADAPTER_WEIGHTS_FILE), "wb") as f:
+        f.write(weights)
+    with open(os.path.join(d, ci.ADAPTER_CONFIG_FILE), "w") as f:
+        json.dump({"peft_type": "LORA", "r": r, "lora_alpha": alpha}, f)
+    return d
+
+
+class TestResolveCheckpointRoot:
+    def test_tinker_uri_maps_to_run_and_name(self):
+        assert ci.resolve_checkpoint_root("tinker://run-abc/weights/ckpt-1") == (
+            f"{ci.CHECKPOINT_BASE}/run-abc/ckpt-1"
+        )
+
+    def test_filesystem_path_passes_through(self, tmp_path):
+        assert ci.resolve_checkpoint_root(str(tmp_path)) == str(tmp_path)
+
+    def test_create_makes_the_directory(self, tmp_path):
+        target = str(tmp_path / "nested" / "root")
+        ci.resolve_checkpoint_root(target, create=True)
+        assert os.path.isdir(target)
+
+
+class TestPublishAndStage:
+    def test_round_trip(self, tmp_path):
+        src = _write_adapter(str(tmp_path / "native" / "model"))
+        root = str(tmp_path / "ckpt")
+        os.makedirs(root)
+
+        published = ci.export_hf_adapter(src, root)
+        assert published == os.path.join(root, ci.HF_ADAPTER_DIRNAME)
+        assert ci.find_hf_adapter(root) == published
+        assert ci.read_adapter_config(root)["r"] == 32
+
+        dest = str(tmp_path / "other_backend" / "weights" / "model")
+        assert ci.stage_hf_adapter(root, dest) == dest
+        with open(os.path.join(dest, ci.ADAPTER_WEIGHTS_FILE), "rb") as f:
+            assert f.read() == b"fake-safetensors"
+
+    def test_publish_without_adapter_is_a_no_op(self, tmp_path):
+        src = str(tmp_path / "full_finetune")
+        os.makedirs(src)
+        root = str(tmp_path / "ckpt")
+        os.makedirs(root)
+        assert ci.export_hf_adapter(src, root) is None
+        assert ci.find_hf_adapter(root) is None
+        assert ci.read_adapter_config(root) is None
+
+    def test_publish_replaces_a_previous_adapter(self, tmp_path):
+        root = str(tmp_path / "ckpt")
+        os.makedirs(root)
+        ci.export_hf_adapter(_write_adapter(str(tmp_path / "s1"), weights=b"v1"), root)
+        ci.export_hf_adapter(_write_adapter(str(tmp_path / "s2"), weights=b"v2"), root)
+        with open(os.path.join(root, ci.HF_ADAPTER_DIRNAME, ci.ADAPTER_WEIGHTS_FILE), "rb") as f:
+            assert f.read() == b"v2"
+        # no staging tmp left behind for a cross-pod reader to trip on
+        assert not os.path.exists(os.path.join(root, ci.HF_ADAPTER_DIRNAME + ".tmp"))
+
+    def test_native_artifact_wins_over_interchange_copy(self, tmp_path):
+        root = str(tmp_path / "ckpt")
+        os.makedirs(root)
+        ci.export_hf_adapter(_write_adapter(str(tmp_path / "src"), weights=b"interchange"), root)
+
+        dest = _write_adapter(str(tmp_path / "native"), weights=b"native")
+        assert ci.stage_hf_adapter(root, dest) is None
+        with open(os.path.join(dest, ci.ADAPTER_WEIGHTS_FILE), "rb") as f:
+            assert f.read() == b"native"
+
+    def test_stage_without_published_adapter_is_a_no_op(self, tmp_path):
+        root = str(tmp_path / "ckpt")
+        os.makedirs(root)
+        assert ci.stage_hf_adapter(root, str(tmp_path / "dest")) is None
+
+    def test_missing_adapter_config_still_publishes_weights(self, tmp_path):
+        src = str(tmp_path / "src")
+        os.makedirs(src)
+        with open(os.path.join(src, ci.ADAPTER_WEIGHTS_FILE), "wb") as f:
+            f.write(b"w")
+        root = str(tmp_path / "ckpt")
+        os.makedirs(root)
+        assert ci.export_hf_adapter(src, root) is not None
+        assert ci.read_adapter_config(root) is None
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_checkpoint_interchange.py
+++ b/tests/test_checkpoint_interchange.py
@@ -1,21 +1,29 @@
 """Unit tests for the cross-backend HF PEFT adapter interchange.
 
 Filesystem-level contract only (no engine): URI resolution, publish/stage
-round-trip, atomicity of publish, and the "native artifact wins" rule.
-Design: specs/007-q5-migration/HANDOFF.md §2.1.
+round-trip, atomicity of publish, PEFT key normalization, and the "native
+artifact wins" rule. Design: specs/007-q5-migration/HANDOFF.md §2.1.
 """
 import json
 import os
 
 import pytest
+import torch
+from safetensors.torch import load_file, save_file
 
 from tinkercloud.training.backends import checkpoint_interchange as ci
 
+BARE_KEY = "model.layers.0.self_attn.q_proj.lora_A.weight"
 
-def _write_adapter(d, r=32, alpha=32, weights=b"fake-safetensors"):
+
+def _write_adapter(d, r=32, alpha=32, key=BARE_KEY, value=1.0):
+    """A minimal but REAL adapter: the publish path parses safetensors."""
     os.makedirs(d, exist_ok=True)
-    with open(os.path.join(d, ci.ADAPTER_WEIGHTS_FILE), "wb") as f:
-        f.write(weights)
+    save_file(
+        {key: torch.full((2, 2), value)},
+        os.path.join(d, ci.ADAPTER_WEIGHTS_FILE),
+        metadata={"format": "pt"},
+    )
     with open(os.path.join(d, ci.ADAPTER_CONFIG_FILE), "w") as f:
         json.dump({"peft_type": "LORA", "r": r, "lora_alpha": alpha}, f)
     return d
@@ -49,8 +57,8 @@ class TestPublishAndStage:
 
         dest = str(tmp_path / "other_backend" / "weights" / "model")
         assert ci.stage_hf_adapter(root, dest) == dest
-        with open(os.path.join(dest, ci.ADAPTER_WEIGHTS_FILE), "rb") as f:
-            assert f.read() == b"fake-safetensors"
+        staged = load_file(os.path.join(dest, ci.ADAPTER_WEIGHTS_FILE))
+        assert list(staged) == [ci.PEFT_PREFIX + BARE_KEY]
 
     def test_publish_without_adapter_is_a_no_op(self, tmp_path):
         src = str(tmp_path / "full_finetune")
@@ -64,22 +72,22 @@ class TestPublishAndStage:
     def test_publish_replaces_a_previous_adapter(self, tmp_path):
         root = str(tmp_path / "ckpt")
         os.makedirs(root)
-        ci.export_hf_adapter(_write_adapter(str(tmp_path / "s1"), weights=b"v1"), root)
-        ci.export_hf_adapter(_write_adapter(str(tmp_path / "s2"), weights=b"v2"), root)
-        with open(os.path.join(root, ci.HF_ADAPTER_DIRNAME, ci.ADAPTER_WEIGHTS_FILE), "rb") as f:
-            assert f.read() == b"v2"
+        ci.export_hf_adapter(_write_adapter(str(tmp_path / "s1"), value=1.0), root)
+        ci.export_hf_adapter(_write_adapter(str(tmp_path / "s2"), value=2.0), root)
+        published = load_file(os.path.join(root, ci.HF_ADAPTER_DIRNAME, ci.ADAPTER_WEIGHTS_FILE))
+        assert float(next(iter(published.values()))[0, 0]) == 2.0
         # no staging tmp left behind for a cross-pod reader to trip on
         assert not os.path.exists(os.path.join(root, ci.HF_ADAPTER_DIRNAME + ".tmp"))
 
     def test_native_artifact_wins_over_interchange_copy(self, tmp_path):
         root = str(tmp_path / "ckpt")
         os.makedirs(root)
-        ci.export_hf_adapter(_write_adapter(str(tmp_path / "src"), weights=b"interchange"), root)
+        ci.export_hf_adapter(_write_adapter(str(tmp_path / "src"), value=1.0), root)
 
-        dest = _write_adapter(str(tmp_path / "native"), weights=b"native")
+        dest = _write_adapter(str(tmp_path / "native"), value=7.0)
         assert ci.stage_hf_adapter(root, dest) is None
-        with open(os.path.join(dest, ci.ADAPTER_WEIGHTS_FILE), "rb") as f:
-            assert f.read() == b"native"
+        native = load_file(os.path.join(dest, ci.ADAPTER_WEIGHTS_FILE))
+        assert float(next(iter(native.values()))[0, 0]) == 7.0
 
     def test_stage_without_published_adapter_is_a_no_op(self, tmp_path):
         root = str(tmp_path / "ckpt")
@@ -87,14 +95,31 @@ class TestPublishAndStage:
         assert ci.stage_hf_adapter(root, str(tmp_path / "dest")) is None
 
     def test_missing_adapter_config_still_publishes_weights(self, tmp_path):
-        src = str(tmp_path / "src")
-        os.makedirs(src)
-        with open(os.path.join(src, ci.ADAPTER_WEIGHTS_FILE), "wb") as f:
-            f.write(b"w")
+        src = _write_adapter(str(tmp_path / "src"))
+        os.remove(os.path.join(src, ci.ADAPTER_CONFIG_FILE))
         root = str(tmp_path / "ckpt")
         os.makedirs(root)
         assert ci.export_hf_adapter(src, root) is not None
         assert ci.read_adapter_config(root) is None
+
+
+class TestPeftKeyNormalization:
+    def test_bare_megatron_keys_gain_the_peft_prefix(self, tmp_path):
+        """Miles/Bridge exports bare module paths; PeftModel.from_pretrained
+        silently loads NOTHING from those (measured: corr 0.806 vs 0.99964)."""
+        root = str(tmp_path / "ckpt")
+        os.makedirs(root)
+        ci.export_hf_adapter(_write_adapter(str(tmp_path / "src")), root)
+        keys = list(load_file(os.path.join(root, ci.HF_ADAPTER_DIRNAME, ci.ADAPTER_WEIGHTS_FILE)))
+        assert keys == [ci.PEFT_PREFIX + BARE_KEY]
+
+    def test_already_peft_keyed_weights_are_left_alone(self, tmp_path):
+        root = str(tmp_path / "ckpt")
+        os.makedirs(root)
+        src = _write_adapter(str(tmp_path / "src"), key=ci.PEFT_PREFIX + BARE_KEY)
+        ci.export_hf_adapter(src, root)
+        keys = list(load_file(os.path.join(root, ci.HF_ADAPTER_DIRNAME, ci.ADAPTER_WEIGHTS_FILE)))
+        assert keys == [ci.PEFT_PREFIX + BARE_KEY]   # not double-prefixed
 
 
 if __name__ == "__main__":

--- a/training/backends/checkpoint_interchange.py
+++ b/training/backends/checkpoint_interchange.py
@@ -55,6 +55,38 @@ def find_hf_adapter(checkpoint_root: str) -> Optional[str]:
     return None
 
 
+PEFT_PREFIX = "base_model.model."
+
+
+def _write_peft_keyed(weights_src: str, weights_dst: str) -> None:
+    """Copy the adapter weights, normalizing state-dict keys to the PEFT
+    convention (`base_model.model.<module>.lora_{A,B}.weight`).
+
+    Miles/Megatron-Bridge exports bare module paths (`model.layers.0...`).
+    `PeftModel.from_pretrained` matches those against nothing, WARNS about
+    missing adapter keys, and returns the base model — a silent zero-delta
+    load. Measured 2026-08-03: unkeyed round-trip corr 0.806 / gap 0.986
+    nats vs 0.99964 / 0.0033 after normalization.
+    """
+    try:
+        from safetensors.torch import load_file, save_file
+    except ImportError:
+        logger.warning("safetensors unavailable; publishing adapter keys unmodified")
+        shutil.copy2(weights_src, weights_dst)
+        return
+
+    state = load_file(weights_src)
+    if any(k.startswith(PEFT_PREFIX) for k in state):
+        shutil.copy2(weights_src, weights_dst)   # already PEFT-keyed: keep bytes
+        return
+    logger.info("Re-keying %d adapter tensors to the PEFT convention", len(state))
+    save_file(
+        {f"{PEFT_PREFIX}{k}": v for k, v in state.items()},
+        weights_dst,
+        metadata={"format": "pt"},
+    )
+
+
 def export_hf_adapter(src_dir: str, checkpoint_root: str) -> Optional[str]:
     """Publish an adapter a backend just wrote into the interchange dir.
 
@@ -72,7 +104,7 @@ def export_hf_adapter(src_dir: str, checkpoint_root: str) -> Optional[str]:
     tmp = dest + ".tmp"
     shutil.rmtree(tmp, ignore_errors=True)
     os.makedirs(tmp, exist_ok=True)
-    shutil.copy2(weights_src, os.path.join(tmp, ADAPTER_WEIGHTS_FILE))
+    _write_peft_keyed(weights_src, os.path.join(tmp, ADAPTER_WEIGHTS_FILE))
 
     config_src = os.path.join(src_dir, ADAPTER_CONFIG_FILE)
     if os.path.isfile(config_src):

--- a/training/backends/checkpoint_interchange.py
+++ b/training/backends/checkpoint_interchange.py
@@ -1,0 +1,124 @@
+"""Cross-backend checkpoint interchange.
+
+One canonical artifact next to (never instead of) each backend's native
+checkpoint::
+
+    <checkpoint_root>/hf_adapter/
+    ├── adapter_model.safetensors   # PEFT-standard keys
+    └── adapter_config.json         # peft_type / r / lora_alpha / target_modules
+
+Every backend writes it on save_checkpoint and reads it on resume, so a
+program can move between engines; native formats stay for same-backend
+fast resume. Design + measured seam gates: specs/007-q5-migration/HANDOFF.md.
+"""
+import json
+import logging
+import os
+import shutil
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+CHECKPOINT_BASE = "/data/checkpoints"
+HF_ADAPTER_DIRNAME = "hf_adapter"
+ADAPTER_WEIGHTS_FILE = "adapter_model.safetensors"
+ADAPTER_CONFIG_FILE = "adapter_config.json"
+
+
+def resolve_checkpoint_root(path: str, create: bool = False) -> str:
+    """tinker://<run_id>/weights/<name> -> <CHECKPOINT_BASE>/<run_id>/<name>.
+
+    Filesystem paths pass through. Mirrors the URI shape minted by
+    CheckpointService.save_weights.
+    """
+    if path.startswith("tinker://"):
+        parts = path[len("tinker://"):].split("/")
+        run_id = parts[0]
+        name = parts[-1] if len(parts) > 2 else "default"
+        local = os.path.join(CHECKPOINT_BASE, run_id, name)
+    else:
+        local = path
+    if create:
+        os.makedirs(local, exist_ok=True)
+    return local
+
+
+def hf_adapter_dir(checkpoint_root: str) -> str:
+    return os.path.join(checkpoint_root, HF_ADAPTER_DIRNAME)
+
+
+def find_hf_adapter(checkpoint_root: str) -> Optional[str]:
+    """Return the interchange dir if it holds a usable adapter, else None."""
+    candidate = hf_adapter_dir(checkpoint_root)
+    if os.path.isfile(os.path.join(candidate, ADAPTER_WEIGHTS_FILE)):
+        return candidate
+    return None
+
+
+def export_hf_adapter(src_dir: str, checkpoint_root: str) -> Optional[str]:
+    """Publish an adapter a backend just wrote into the interchange dir.
+
+    src_dir is the backend-native location of the PEFT pair. Returns the
+    interchange dir, or None when the backend produced no adapter (full
+    fine-tune, or a save that predates the first optimizer step).
+    """
+    weights_src = os.path.join(src_dir, ADAPTER_WEIGHTS_FILE)
+    if not os.path.isfile(weights_src):
+        logger.info("No %s under %s; skipping interchange export", ADAPTER_WEIGHTS_FILE, src_dir)
+        return None
+
+    dest = hf_adapter_dir(checkpoint_root)
+    # Publish atomically: a reader on another pod must never see half a copy.
+    tmp = dest + ".tmp"
+    shutil.rmtree(tmp, ignore_errors=True)
+    os.makedirs(tmp, exist_ok=True)
+    shutil.copy2(weights_src, os.path.join(tmp, ADAPTER_WEIGHTS_FILE))
+
+    config_src = os.path.join(src_dir, ADAPTER_CONFIG_FILE)
+    if os.path.isfile(config_src):
+        shutil.copy2(config_src, os.path.join(tmp, ADAPTER_CONFIG_FILE))
+    else:
+        logger.warning("No %s under %s — importers must be told r/alpha", ADAPTER_CONFIG_FILE, src_dir)
+
+    shutil.rmtree(dest, ignore_errors=True)
+    os.replace(tmp, dest)
+    logger.info("Published interchange adapter %s -> %s", src_dir, dest)
+    return dest
+
+
+def stage_hf_adapter(checkpoint_root: str, dest_dir: str) -> Optional[str]:
+    """Materialize the interchange adapter in a backend's own load layout.
+
+    No-op (returns None) when there is nothing to stage or when dest_dir
+    already holds an adapter — a backend's native artifact always wins over
+    the interchange copy of itself.
+    """
+    src = find_hf_adapter(checkpoint_root)
+    if src is None:
+        return None
+    if os.path.isfile(os.path.join(dest_dir, ADAPTER_WEIGHTS_FILE)):
+        return None
+
+    os.makedirs(dest_dir, exist_ok=True)
+    for name in (ADAPTER_WEIGHTS_FILE, ADAPTER_CONFIG_FILE):
+        srcfile = os.path.join(src, name)
+        if os.path.isfile(srcfile):
+            shutil.copy2(srcfile, os.path.join(dest_dir, name))
+    logger.info("Staged interchange adapter %s -> %s", src, dest_dir)
+    return dest_dir
+
+
+def read_adapter_config(checkpoint_root: str) -> Optional[dict]:
+    """r/alpha/target_modules of the interchange adapter, if published."""
+    src = find_hf_adapter(checkpoint_root)
+    if src is None:
+        return None
+    path = os.path.join(src, ADAPTER_CONFIG_FILE)
+    if not os.path.isfile(path):
+        return None
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except Exception:
+        logger.warning("Unreadable %s", path, exc_info=True)
+        return None

--- a/training/backends/miles/backend.py
+++ b/training/backends/miles/backend.py
@@ -16,8 +16,38 @@ from typing import Any, Dict, List, Optional
 import ray
 
 from ..base import BackendError, BackendHandle, TrainingBackend
+from ..checkpoint_interchange import (
+    CHECKPOINT_BASE,
+    export_hf_adapter,
+    resolve_checkpoint_root,
+)
 
 logger = logging.getLogger(__name__)
+
+_ADAPTER_CHECKPOINT_BASE = os.path.join(CHECKPOINT_BASE, "adapters")
+
+
+def _adapter_save_dir(adapter_name: str) -> str:
+    """Per-tenant dir miles writes adapter checkpoints into. Without it
+    (config.save=None) miles skips per-adapter checkpoints entirely."""
+    return os.path.join(_ADAPTER_CHECKPOINT_BASE, adapter_name)
+
+
+def _publish_adapter(adapter_save_dir: str, checkpoint_path: str, adapter_name: Optional[str]) -> None:
+    """Copy the newest per-adapter HF PEFT pair miles wrote into the
+    cross-backend interchange dir (specs/007 §2.1)."""
+    ckpt_root = os.path.join(adapter_save_dir, "checkpoints")
+    if not os.path.isdir(ckpt_root):
+        logger.warning("Adapter %s: no checkpoints under %s to publish", adapter_name, ckpt_root)
+        return
+    steps = [d for d in os.listdir(ckpt_root) if d.startswith("step_") and d[5:].isdigit()]
+    if not steps:
+        logger.warning("Adapter %s: no step_* checkpoint in %s", adapter_name, ckpt_root)
+        return
+    latest = max(steps, key=lambda d: int(d[5:]))
+    export_hf_adapter(
+        os.path.join(ckpt_root, latest), resolve_checkpoint_root(checkpoint_path, create=True),
+    )
 
 
 def _model_input_lens(data: List[Any]) -> List[int]:
@@ -56,6 +86,9 @@ class MilesHandle(BackendHandle):
     controller: Any = None            # MultiLoRAController (named Ray actor)
     adapter_name: Optional[str] = None
     adapter_slot: Optional[int] = None
+    # Where miles writes this adapter's per-step checkpoints (Megatron shard +
+    # HF PEFT pair); source of the cross-backend interchange export.
+    adapter_save_dir: Optional[str] = None
     # Weight version = successful optim steps applied. Sampler registration
     # snapshots it (routers/checkpoints.py) so a sampler saved before any
     # step pins v0. v0 == base model only for fresh-init LoRA (B=0 at init),
@@ -240,9 +273,11 @@ class MilesBackend(TrainingBackend):
         rank = int(lora_config.get("rank", 0))
         alpha = int(lora_config.get("alpha") or rank)
         adapter_name = re.sub(r"[^A-Za-z0-9._-]", "-", model_id)
+        adapter_save_dir = _adapter_save_dir(adapter_name)
         try:
             registration = await pool.controller.register_adapter.remote(
-                adapter_name, TinkerAdapterConfig(rank=rank, alpha=alpha)
+                adapter_name,
+                TinkerAdapterConfig(rank=rank, alpha=alpha, save=adapter_save_dir),
             )
         except Exception as e:
             # Registry errors (slots full, name colliding/cleaning-up,
@@ -297,6 +332,7 @@ class MilesBackend(TrainingBackend):
             controller=pool.controller,
             adapter_name=adapter_name,
             adapter_slot=adapter_slot,
+            adapter_save_dir=adapter_save_dir,
             lock=pool.lock,
         )
 
@@ -378,6 +414,7 @@ class MilesBackend(TrainingBackend):
             controller = None
             adapter_name = None
             adapter_slot = None
+            adapter_save_dir = None
             if multi_lora:
                 # Mirror the upstream driver boot: router -> controller
                 # (named actor; reconcile on the actors resolves it by name).
@@ -393,9 +430,12 @@ class MilesBackend(TrainingBackend):
                 await controller.start.remote()
 
                 adapter_name = re.sub(r"[^A-Za-z0-9._-]", "-", model_id)
+                adapter_save_dir = _adapter_save_dir(adapter_name)
                 registration = await controller.register_adapter.remote(
                     adapter_name,
-                    TinkerAdapterConfig(rank=args.lora_rank, alpha=args.lora_alpha),
+                    TinkerAdapterConfig(
+                        rank=args.lora_rank, alpha=args.lora_alpha, save=adapter_save_dir,
+                    ),
                 )
                 adapter_slot = registration["slot"]
                 logger.info(
@@ -462,6 +502,7 @@ class MilesBackend(TrainingBackend):
                 controller=controller,
                 adapter_name=adapter_name,
                 adapter_slot=adapter_slot,
+                adapter_save_dir=adapter_save_dir,
                 created_from_checkpoint=bool(checkpoint_path),
             )
 
@@ -977,7 +1018,19 @@ class MilesBackend(TrainingBackend):
                 logger.info("Skipping save_model (offload_train=True)")
                 return checkpoint_path
 
+            # Pool mode: save_due_adapter_checkpoints gates on
+            # step % save_interval == 0, so interval 1 makes the CLIENT's
+            # save_state the trigger (a save_state at step 0 still writes
+            # nothing — miles skips adapters that never stepped).
+            if h.adapter_slot is not None and h.args is not None:
+                h.args.save_interval = 1
+
             await h.train_group.save_model(step_id if step_id is not None else 0)
+
+            if h.adapter_save_dir:
+                await asyncio.to_thread(
+                    _publish_adapter, h.adapter_save_dir, checkpoint_path, h.adapter_name,
+                )
             return checkpoint_path
 
         try:

--- a/training/backends/miles/backend.py
+++ b/training/backends/miles/backend.py
@@ -11,6 +11,7 @@ import os
 import re
 from dataclasses import dataclass, field
 from datetime import datetime
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 import ray
@@ -27,13 +28,18 @@ logger = logging.getLogger(__name__)
 _ADAPTER_CHECKPOINT_BASE = os.path.join(CHECKPOINT_BASE, "adapters")
 
 
-def _adapter_save_dir(adapter_name: str) -> str:
+def _adapter_save_dir(adapter_name: str) -> Path:
     """Per-tenant dir miles writes adapter checkpoints into. Without it
-    (config.save=None) miles skips per-adapter checkpoints entirely."""
-    return os.path.join(_ADAPTER_CHECKPOINT_BASE, adapter_name)
+    (config.save=None) miles skips per-adapter checkpoints entirely.
+
+    Path, not str: TinkerAdapterConfig.save is annotated `str | Path | None`
+    but miles only ever does `config.save / "checkpoints"` — a str explodes
+    at adapter registration (declared type wider than the honored one).
+    """
+    return Path(_ADAPTER_CHECKPOINT_BASE) / adapter_name
 
 
-def _publish_adapter(adapter_save_dir: str, checkpoint_path: str, adapter_name: Optional[str]) -> None:
+def _publish_adapter(adapter_save_dir: Path, checkpoint_path: str, adapter_name: Optional[str]) -> None:
     """Copy the newest per-adapter HF PEFT pair miles wrote into the
     cross-backend interchange dir (specs/007 §2.1)."""
     ckpt_root = os.path.join(adapter_save_dir, "checkpoints")
@@ -88,7 +94,7 @@ class MilesHandle(BackendHandle):
     adapter_slot: Optional[int] = None
     # Where miles writes this adapter's per-step checkpoints (Megatron shard +
     # HF PEFT pair); source of the cross-backend interchange export.
-    adapter_save_dir: Optional[str] = None
+    adapter_save_dir: Optional[Path] = None
     # Weight version = successful optim steps applied. Sampler registration
     # snapshots it (routers/checkpoints.py) so a sampler saved before any
     # step pins v0. v0 == base model only for fresh-init LoRA (B=0 at init),
@@ -1018,12 +1024,20 @@ class MilesBackend(TrainingBackend):
                 logger.info("Skipping save_model (offload_train=True)")
                 return checkpoint_path
 
-            # Pool mode: save_due_adapter_checkpoints gates on
-            # step % save_interval == 0, so interval 1 makes the CLIENT's
-            # save_state the trigger (a save_state at step 0 still writes
-            # nothing — miles skips adapters that never stepped).
-            if h.adapter_slot is not None and h.args is not None:
-                h.args.save_interval = 1
+            # Pool mode: save_due_adapter_checkpoints only writes adapters with
+            # registry step > 0 at a save-interval multiple (interval is 1 at
+            # pool boot, slime_builder). The registry step is miles' own
+            # training-loop counter and nothing advances it here — the CLIENT
+            # owns the loop — so publish our weight version (= applied optimizer
+            # steps) as the step this checkpoint represents.
+            if h.adapter_slot is not None and h.controller is not None:
+                if h.weight_version <= 0:
+                    logger.info(
+                        "Adapter %s has taken no optimizer step; nothing to checkpoint",
+                        h.adapter_name,
+                    )
+                    return checkpoint_path
+                await h.controller.set_adapter_step.remote(h.adapter_name, h.weight_version)
 
             await h.train_group.save_model(step_id if step_id is not None else 0)
 

--- a/training/backends/nemo_rl/backend.py
+++ b/training/backends/nemo_rl/backend.py
@@ -18,6 +18,11 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from ..base import BackendError, BackendHandle, TrainingBackend
+from ..checkpoint_interchange import (
+    export_hf_adapter,
+    resolve_checkpoint_root,
+    stage_hf_adapter,
+)
 
 if TYPE_CHECKING:
     from .generation import NemoRLBatchAccumulator
@@ -134,10 +139,19 @@ class NemoRLBackend(TrainingBackend):
             )
             logger.info("[%s] NeMo RL config built, hf_path=%s", request_id, hf_path)
 
+            # Policy(weights_path=...) goes straight to the checkpoint
+            # manager's load_checkpoint, so it needs the resolved <root>/weights
+            # dir — not the tinker:// URI — and a foreign adapter staged into
+            # the layout that loader sniffs.
+            init_weights_path = (
+                _stage_foreign_adapter(_resolve_checkpoint_path(checkpoint_path))
+                if checkpoint_path else None
+            )
+
             policy, policy_generation, cluster, tokenizer, loss_fn = await asyncio.to_thread(
                 _init_nemo_rl_components,
                 config_dict=config_dict,
-                checkpoint_path=checkpoint_path,
+                checkpoint_path=init_weights_path,
                 debug_train_only=debug_train_only,
             )
 
@@ -621,6 +635,12 @@ class NemoRLBackend(TrainingBackend):
                 checkpointing_cfg=checkpointing_cfg,
             )
 
+            # LoRA runs write the PEFT pair under <weights>/model; publish it
+            # as the cross-backend interchange artifact (specs/007 §2.1).
+            await asyncio.to_thread(
+                export_hf_adapter, f"{weights_path}/model", local_path,
+            )
+
             logger.info("NeMo RL checkpoint saved to %s", local_path)
             return checkpoint_path  # Return original URI for metadata consistency
 
@@ -640,7 +660,7 @@ class NemoRLBackend(TrainingBackend):
         h: NemoRLHandle = handle  # type: ignore[assignment]
         try:
             local_path = _resolve_checkpoint_path(checkpoint_path)
-            weights_path = f"{local_path}/weights"
+            weights_path = _stage_foreign_adapter(local_path)
             optimizer_path = f"{local_path}/optimizer"
             # Only load optimizer state if it exists (checkpoint may be weights-only)
             if not os.path.exists(optimizer_path):
@@ -897,27 +917,19 @@ async def _ensure_generation_ready(handle) -> None:
 # Internal helper functions (called via asyncio.to_thread)
 # ---------------------------------------------------------------------------
 
-_CHECKPOINT_BASE = "/data/checkpoints"
-
-
 def _resolve_checkpoint_path(path: str) -> str:
-    """Convert tinker:// URI to local filesystem path.
+    """tinker://<run_id>/weights/<name> -> /data/checkpoints/<run_id>/<name>."""
+    return resolve_checkpoint_root(path, create=True)
 
-    checkpoint_service generates: tinker://<run_id>/weights/<name>
-    We map this to: /data/checkpoints/<run_id>/<name>
 
-    Plain filesystem paths are returned as-is.
-    """
-    if path.startswith("tinker://"):
-        parts = path[len("tinker://"):].split("/")
-        # parts: [model_id, "weights", checkpoint_name]
-        run_id = parts[0]
-        name = parts[-1] if len(parts) > 2 else "default"
-        import os
-        local = os.path.join(_CHECKPOINT_BASE, run_id, name)
-        os.makedirs(local, exist_ok=True)
-        return local
-    return path
+def _stage_foreign_adapter(local_path: str) -> str:
+    """Return the weights_path to load, materializing an interchange adapter
+    written by ANOTHER backend into the layout automodel's loader sniffs
+    (<weights>/model/adapter_model.safetensors). No-op for our own saves."""
+    weights_path = f"{local_path}/weights"
+    stage_hf_adapter(local_path, f"{weights_path}/model")
+    return weights_path
+
 
 def _init_nemo_rl_components(
     config_dict: Dict[str, Any],

--- a/training/backends/verl/backend.py
+++ b/training/backends/verl/backend.py
@@ -26,6 +26,12 @@ from typing import Any, Dict, List, Optional
 import torch
 
 from ..base import BackendError, BackendHandle, TrainingBackend, UnsupportedFeatureError
+from ..checkpoint_interchange import (
+    HF_ADAPTER_DIRNAME,
+    find_hf_adapter,
+    read_adapter_config,
+    resolve_checkpoint_root,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -118,6 +124,19 @@ class VerlBackend(TrainingBackend):
                 parallelism=parallelism, rl_config=rl_config,
                 rollout_config=rollout_config, max_seq_len=max_seq_len,
             )
+
+            # A checkpoint carrying an interchange adapter (written by another
+            # backend, or by us) is attached at model build time — verl's PEFT
+            # path wraps the module BEFORE FSDP, so it cannot be a post-boot
+            # load_checkpoint. Native verl shards still resume that way.
+            adapter_dir = None
+            if checkpoint_path:
+                ckpt_root = resolve_checkpoint_root(checkpoint_path)
+                adapter_dir = find_hf_adapter(ckpt_root)
+                if adapter_dir:
+                    cfg["model"]["lora_adapter_path"] = adapter_dir
+                    _adopt_adapter_shape(ckpt_root, cfg["model"])
+
             enable_rollout = not debug_train_only
             boot = await asyncio.to_thread(
                 _boot_worker_group, cfg, model_id, enable_rollout,
@@ -140,11 +159,11 @@ class VerlBackend(TrainingBackend):
                 rollout_synced_version=0 if enable_rollout else -1,
                 lora_rank=int(cfg["model"]["lora_rank"] or 0),
             )
-            if checkpoint_path:
+            if checkpoint_path and adapter_dir is None:
                 await self.load_checkpoint(handle, checkpoint_path)
             logger.info(
-                "[%s] verl model %s created (dp=%d, rollout=%s)",
-                request_id, model_id, handle.dp_size, enable_rollout,
+                "[%s] verl model %s created (dp=%d, rollout=%s, adapter=%s)",
+                request_id, model_id, handle.dp_size, enable_rollout, adapter_dir,
             )
             return handle
         except BackendError:
@@ -277,9 +296,19 @@ class VerlBackend(TrainingBackend):
         async with h._lock:
             try:
                 await self._quiesce_samplers(h)
+                local_path = resolve_checkpoint_root(checkpoint_path, create=True)
                 await asyncio.to_thread(
-                    h.worker_group.save_checkpoint, checkpoint_path, None, step_id or h.weight_version,
+                    h.worker_group.save_checkpoint, local_path, None, step_id or h.weight_version,
                 )
+                if h.lora_rank > 0:
+                    # verl writes FSDP-sharded .pt only; no PEFT export path
+                    # yet (specs/007 §3.5) — say so rather than leaving a
+                    # silently unmigratable checkpoint behind.
+                    logger.warning(
+                        "verl checkpoint %s has no %s/ (verl PEFT export unimplemented): "
+                        "usable for verl resume, not for cross-backend migration",
+                        local_path, HF_ADAPTER_DIRNAME,
+                    )
                 return checkpoint_path
             except Exception as e:
                 raise BackendError(str(e), backend="verl", operation="save_checkpoint", original_error=e) from e
@@ -289,7 +318,16 @@ class VerlBackend(TrainingBackend):
         async with h._lock:
             try:
                 await self._quiesce_samplers(h)
-                await asyncio.to_thread(h.worker_group.load_checkpoint, checkpoint_path)
+                local_path = resolve_checkpoint_root(checkpoint_path)
+                if find_hf_adapter(local_path):
+                    # PeftModel.from_pretrained wraps pre-FSDP: only create_model
+                    # can attach an interchange adapter.
+                    raise BackendError(
+                        "verl imports an interchange adapter at create_model "
+                        "(lora_adapter_path), not via load_checkpoint",
+                        backend="verl", operation="load_checkpoint",
+                    )
+                await asyncio.to_thread(h.worker_group.load_checkpoint, local_path)
             except Exception as e:
                 raise BackendError(str(e), backend="verl", operation="load_checkpoint", original_error=e) from e
 
@@ -589,6 +627,33 @@ def _to_vllm_sampling_params(sampling_params: Optional[Dict[str, Any]]) -> Dict[
     return out
 
 
+def _adopt_adapter_shape(checkpoint_root: str, model_cfg: Dict[str, Any]) -> None:
+    """Adopt the interchange adapter's r/alpha over the request's.
+
+    PeftModel.from_pretrained honors adapter_config.json, but verl's rollout
+    LoRA plumbing reads model.lora_rank/lora_alpha — leaving them disagreeing
+    changes the effective alpha/r scaling on one side only (silent rescale at
+    the migration seam; specs/007 §1.3).
+    """
+    cfg = read_adapter_config(checkpoint_root)
+    if not cfg:
+        logger.warning(
+            "Interchange adapter at %s has no adapter_config.json; keeping requested "
+            "rank=%s alpha=%s", checkpoint_root, model_cfg.get("lora_rank"), model_cfg.get("lora_alpha"),
+        )
+        return
+    for key, cfg_key in (("lora_rank", "r"), ("lora_alpha", "lora_alpha")):
+        want = cfg.get(cfg_key)
+        if want is None:
+            continue
+        have = model_cfg.get(key)
+        if have != want:
+            logger.warning(
+                "Interchange adapter %s=%s overrides requested %s=%s", cfg_key, want, key, have,
+            )
+            model_cfg[key] = want
+
+
 def _compose_actor_rollout_config(cfg: Dict[str, Any]):
     """Assemble a trainer-shaped OmegaConf for ActorRolloutRefWorker +
     LLMServerManager from verl's packaged ppo_trainer defaults."""
@@ -614,6 +679,10 @@ def _compose_actor_rollout_config(cfg: Dict[str, Any]):
         f"actor_rollout_ref.model.lora_rank={model['lora_rank']}",
         f"actor_rollout_ref.model.lora_alpha={model['lora_alpha']}",
         f"actor_rollout_ref.model.target_modules={tm_override}",
+        *(
+            [f"actor_rollout_ref.model.lora_adapter_path={model['lora_adapter_path']}"]
+            if model.get("lora_adapter_path") else []
+        ),
         f"actor_rollout_ref.actor.strategy={engine['strategy']}",
         f"actor_rollout_ref.actor.ulysses_sequence_parallel_size={engine['ulysses_sequence_parallel_size']}",
         f"actor_rollout_ref.actor.use_dynamic_bsz={engine['use_dynamic_bsz']}",
@@ -738,6 +807,7 @@ def _boot_worker_group(cfg: Dict[str, Any], model_id: str, enable_rollout: bool 
         lora_rank=model["lora_rank"],
         lora_alpha=model["lora_alpha"],
         target_modules=model["target_modules"],
+        lora_adapter_path=model.get("lora_adapter_path"),
     )
     engine_config = FSDPEngineConfig(
         forward_only=False,

--- a/training/core/slime_builder.py
+++ b/training/core/slime_builder.py
@@ -235,7 +235,13 @@ class SlimeArgumentBuilder:
             # checkpoint resume is specified (see miles/utils/arguments.py:1452-1460)
             '--ref-load', megatron_checkpoint_path,
             '--save', self.default_save_dir,
-            '--save-interval', '20000',  # ~100 batches (each batch ~200 microbatches)
+            # Pool mode: save_due_adapter_checkpoints only writes adapters at a
+            # save-interval multiple, and the interval lives on the ACTORS' args
+            # copy — interval 1 makes the client's save_state the trigger (saves
+            # are skipped when the step dir already exists). This is what
+            # publishes the cross-backend adapter (specs/007).
+            # Dedicated mode: ~100 batches (each batch ~200 microbatches).
+            '--save-interval', '1' if multi_lora_slots > 0 else '20000',
         ]
 
         if multi_lora_slots > 0:


### PR DESCRIPTION
Lets a training program move between backends. Every backend publishes an HF
PEFT adapter next to (never instead of) its native checkpoint:

```
<checkpoint_root>/hf_adapter/{adapter_model.safetensors, adapter_config.json}
```

and consumes one on resume. Native formats keep serving same-backend fast
resume. New `training/backends/checkpoint_interchange.py` owns the shared
tinker:// resolution, atomic publish, staging, and PEFT key normalization;
per-backend wiring is thin.

## Measured on the cluster (Qwen2.5-0.5B r32 all-linear, 4x256 frozen probe)

One adapter trained on miles (Megatron), imported into NeMo RL
(DTensor/automodel), then into veRL (FSDP/peft):

| Gate | Result |
|---|---|
| G9a miles export vs fp32 HF+peft oracle | corr **0.999660** / gap **0.003867** nats |
| **G9b miles -> NeMo RL** | corr **0.999777** / gap **0.000118** nats |
| G9a nemo_rl export vs oracle | corr **0.999550** / gap **0.023498** nats |
| **G9b NeMo RL -> veRL** | corr **0.999849** / gap **0.000602** nats |

Bar was E1 (corr > 0.999, gap < 0.03 nats); both seams land an order of
magnitude inside it. Weights-only by design — optimizer moments do not
survive the hop, and the resulting transient is meant to be measured, not
hidden.

## Per backend

- **miles** (export): each pool adapter gets a save dir and `--save-interval 1`
  at boot, so the client's `save_state` is the save trigger; the newest
  per-adapter PEFT pair is published. Adapter-scoped *import* is still
  unsupported.
- **nemo_rl** (both): publishes the pair automodel already writes under
  `<weights>/model`; stages a foreign adapter into that layout on resume.
- **verl** (import): attaches via `model.lora_adapter_path` at create_model —
  PeftModel wraps pre-FSDP, so it cannot be a post-boot load — adopting the
  adapter's r/alpha so the rollout LoRA plumbing cannot disagree with it.
  Export is not implemented yet and now says so loudly at save time instead
  of leaving a silently unmigratable checkpoint.

## Bugs fixed en route

- **A PEFT-shaped export that PEFT silently ignores.** Megatron-Bridge writes
  bare module paths; `PeftModel.from_pretrained` matches `base_model.model.`,
  so it warns, loads **zero** tensors, and returns the base model — a silent
  zero-delta resume. corr **0.806** / gap **0.986 nats** before normalizing
  keys, **0.99964 / 0.0033** after.
- nemo_rl create-from-checkpoint handed `Policy(weights_path=)` the raw
  `tinker://` URI instead of the resolved `<root>/weights` dir, so resume via
  `create_training_client_from_state` could never have worked there.
- verl passed the same URI straight to its FSDP checkpoint manager, which
  would mkdir it verbatim.
- miles' adapter registry step is its own training-loop counter and nothing
  advances it under Tinker (the client owns the loop), so no adapter was ever
  due to save; publish our weight version as the step instead.
- `TinkerAdapterConfig.save` is annotated `str | Path | None` but only `Path`
  works (miles does `config.save / "checkpoints"`).

## Gate

`scripts/gates/g9_adapter_interchange.py` — `export` checks the published
adapter against an offline fp32 HF+peft oracle (independently covering rank
slicing, alpha scaling, target-module coverage and key naming); `import`
measures seam continuity between two backends on the same frozen batch. It
probes through `forward()` rather than `forward_backward`, which is not a
read-only observable on buffering backends, and compares per datum, reporting
the one length disagreement it found rather than absorbing it (miles
`forward()` returns L-1 per-datum logprobs where its `forward_backward`
returns L — unfixed, tracked).

Plus 11 unit tests for the interchange contract.
