### PR TITLE
miles: fix sub-DP forward_backward deadlock (reject, then pad)

### DIFF
--- a/tests/test_miles_padding.py
+++ b/tests/test_miles_padding.py
@@ -1,0 +1,162 @@
+"""Unit tests for DP alignment padding on the miles path.
+
+Padding is what restores ADMISSION for a batch whose sample count is not
+divisible by the data-parallel width. Without it those calls deadlock: miles
+derives num_steps_per_rollout per rank from that rank's local sample count,
+the ranks disagree, and they block on the gradient collective
+(specs/008-q3-abstraction-tax/HANDOFF.md).
+
+Padding is only legitimate if it is invisible in two senses, and both are
+tested here:
+  * semantically — gradients are pure-sum (_loss_norm_total=1), so a pad whose
+    loss mask and advantages are zero contributes exactly zero;
+  * observationally — a pad has no observation key, so it must sit at the TAIL
+    and be truncated off before any client-visible output.
+"""
+import importlib.util
+import os
+import sys
+import types
+
+import pytest
+
+
+def _load_converter_module():
+    """Import converter.py without dragging FastAPI in via the package init."""
+    try:  # in-container / installed layout
+        from tinkercloud.training.backends.miles import converter as m
+        return m
+    except ImportError:
+        pass
+    root = os.path.join(os.path.dirname(__file__), os.pardir, "training")
+
+    def _pkg(name):
+        p = types.ModuleType(name)
+        p.__path__ = []
+        sys.modules[name] = p
+        return p
+
+    _pkg("_tcp")
+    _pkg("_tcp.backends")
+    _pkg("_tcp.core")
+    _pkg("_tcp.backends.miles")
+    base = types.ModuleType("_tcp.backends.base")
+    base.DataConverter = object
+    sys.modules["_tcp.backends.base"] = base
+    dc = types.ModuleType("_tcp.core.data_converter")
+    dc.TinkerDataConverter = object
+    sys.modules["_tcp.core.data_converter"] = dc
+
+    path = os.path.join(root, "backends", "miles", "converter.py")
+    spec = importlib.util.spec_from_file_location("_tcp.backends.miles.converter", path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+CONV = _load_converter_module()
+pad = CONV.MilesDataConverter.pad_rollout_data_to_dp
+
+
+def _rollout(n, tok_len=4, slot=None):
+    """A rollout_data shaped like the miles SFT path produces."""
+    d = {
+        "tokens": [[10 + i] * tok_len for i in range(n)],
+        "loss_masks": [[1] * tok_len for _ in range(n)],
+        "advantages": [[0.5] * tok_len for _ in range(n)],
+        "log_probs": [[-0.1] * tok_len for _ in range(n)],
+        "response_lengths": [tok_len for _ in range(n)],
+        "dynamic_global_batch_size": n,
+        "_loss_norm_total": 1,
+        "_loss_type_override": "sft_loss",
+    }
+    if slot is not None:
+        d["adapter_slots"] = [slot] * n
+    return d
+
+
+@pytest.mark.parametrize("n,dp,want", [(8, 2, 0), (4, 2, 0), (3, 2, 1), (1, 2, 1),
+                                       (5, 4, 3), (100, 8, 4), (7, 1, 0), (6, 3, 0)])
+def test_pad_count(n, dp, want):
+    d = _rollout(n)
+    assert pad(d, dp) == want
+    assert d["dynamic_global_batch_size"] == n + want
+    assert (n + want) % dp == 0 or dp <= 1
+
+
+def test_pads_are_inert():
+    """The whole justification: a pad must add exactly zero to the gradient."""
+    d = _rollout(3)
+    before_mask = sum(sum(m) for m in d["loss_masks"])
+    before_adv = sum(sum(a) for a in d["advantages"])
+    pad(d, 2)
+    assert sum(sum(m) for m in d["loss_masks"]) == before_mask, "pad changed loss mass"
+    assert sum(sum(a) for a in d["advantages"]) == before_adv, "pad changed advantage mass"
+    assert all(v == 0 for v in d["loss_masks"][-1])
+    assert all(v == 0 for v in d["advantages"][-1])
+
+
+def test_pads_are_at_the_tail_and_reals_untouched():
+    """Truncation by slice is only valid if pads never land mid-batch."""
+    d = _rollout(3)
+    reals = [list(t) for t in d["tokens"]]
+    pad(d, 2)
+    assert d["tokens"][:3] == reals
+    assert len(d["tokens"]) == 4
+
+
+def test_pad_is_well_formed_not_empty():
+    """A pad still has to be a valid sample: real token ids, matching lengths."""
+    d = _rollout(3, tok_len=5)
+    pad(d, 2)
+    for key in ("tokens", "loss_masks", "advantages", "log_probs"):
+        assert len(d[key]) == 4
+        assert len(d[key][-1]) == 5, f"{key} pad has wrong token length"
+    assert d["response_lengths"][-1] == 5
+
+
+def test_pad_does_not_alias_source_sample():
+    d = _rollout(3)
+    pad(d, 2)
+    d["tokens"][-1][0] = 999
+    assert d["tokens"][2][0] != 999, "pad aliases the last real sample's storage"
+
+
+def test_scalars_and_non_per_sample_keys_untouched():
+    d = _rollout(3)
+    pad(d, 2)
+    assert d["_loss_norm_total"] == 1
+    assert d["_loss_type_override"] == "sft_loss"
+
+
+def test_adapter_slots_extended_for_pool_routing():
+    """Pool mode routes by slot; a pad with no slot would be unroutable."""
+    d = _rollout(3, slot=7)
+    pad(d, 2)
+    assert len(d["adapter_slots"]) == 4
+    assert d["adapter_slots"][-1] == 7
+
+
+def test_idempotent_once_aligned():
+    d = _rollout(3)
+    assert pad(d, 2) == 1
+    assert pad(d, 2) == 0, "second pad must be a no-op"
+    assert d["dynamic_global_batch_size"] == 4
+
+
+def test_per_sample_key_rule_matches_merge():
+    """Padding and merging must agree on what a per-sample key is, or a
+    co-batched request would be sliced across a pad."""
+    d = _rollout(3)
+    n = d["dynamic_global_batch_size"]
+    per_sample = {k for k, v in d.items() if isinstance(v, list) and len(v) == n}
+    pad(d, 2)
+    for k in per_sample:
+        assert len(d[k]) == 4, f"per-sample key {k} not padded"
+
+
+def test_dp1_is_noop():
+    d = _rollout(3)
+    assert pad(d, 1) == 0
+    assert d["dynamic_global_batch_size"] == 3

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,0 +1,101 @@
+"""Unit tests for RequestValidator's DP-divisibility contract.
+
+The load-bearing case: an indivisible batch must be REJECTED, not attempted,
+and not waivable by ALLOW_PARTIAL_BATCHES. Miles derives num_steps_per_rollout
+per rank from that rank's local sample count, so an unbalanced split gives the
+ranks different micro-step counts and they deadlock on the gradient collective
+-- the future never resolves and the actors stay wedged until restart.
+Measured 2026-08-04 with 3 samples at dp=2; see
+specs/008-q3-abstraction-tax/HANDOFF.md.
+
+The flag still governs the genuinely partial cases (RL group alignment), where
+the consequence is normalization rather than liveness.
+"""
+import importlib.util
+import os
+from argparse import Namespace
+
+import pytest
+
+try:  # in-container / installed layout, as the other test modules use
+    from tinkercloud.training.core.validators import RequestValidator
+except ImportError:  # standalone: validators.py is stdlib-only, load it directly
+    _p = os.path.join(os.path.dirname(__file__), os.pardir,
+                      "training", "core", "validators.py")
+    _spec = importlib.util.spec_from_file_location("_validators", _p)
+    _mod = importlib.util.module_from_spec(_spec)
+    _spec.loader.exec_module(_mod)
+    RequestValidator = _mod.RequestValidator
+
+
+def _args(dp=2, gbs=8, balance_data=False, n_per_prompt=1):
+    return Namespace(
+        data_parallel_size=dp,
+        global_batch_size=gbs,
+        balance_data=balance_data,
+        n_samples_per_prompt=n_per_prompt,
+    )
+
+
+def _v(allow_partial=False, **kw):
+    return RequestValidator(_args(**kw), allow_partial_batches=allow_partial)
+
+
+@pytest.mark.parametrize("allow_partial", [False, True])
+@pytest.mark.parametrize("n", [3, 5, 7, 9])
+def test_indivisible_rejected_regardless_of_partial_flag(n, allow_partial):
+    """The regression this file exists for: dp-indivisible => reject, always.
+
+    Before the fix, allow_partial_batches waived this and the run deadlocked.
+    """
+    err = _v(allow_partial=allow_partial, dp=2).validate_sample_count(n)
+    assert err is not None, f"{n} samples at dp=2 must be rejected"
+    assert "divisible by 2" in err
+    assert "deadlock" in err, "the error must say WHY, since the old failure was a hang"
+
+
+@pytest.mark.parametrize("allow_partial", [False, True])
+@pytest.mark.parametrize("n", [2, 4, 6, 8, 128])
+def test_divisible_accepted(n, allow_partial):
+    assert _v(allow_partial=allow_partial, dp=2).validate_sample_count(n) is None
+
+
+def test_indivisible_at_wider_dp():
+    """dp=4: 100 samples splits 25/25/25/25 (ok) but 102 does not."""
+    assert _v(dp=4).validate_sample_count(100) is None
+    err = _v(dp=4, allow_partial=True).validate_sample_count(102)
+    assert err is not None and "divisible by 4" in err
+
+
+def test_below_dp_size_still_rejected():
+    """Check 1 was already unconditional; keep it that way."""
+    err = _v(allow_partial=True, dp=4).validate_sample_count(3)
+    assert err is not None and "At least 4 samples" in err
+
+
+def test_suggestions_are_actually_valid():
+    """A suggestion that is itself indivisible would be worse than none."""
+    err = _v(dp=4).validate_sample_count(10)
+    assert err is not None
+    line = next(s for s in err.splitlines() if s.startswith("Suggestion:"))
+    suggested = [int(t.strip(".,")) for t in line.split() if t.strip(".,").isdigit()]
+    assert suggested, f"no numeric suggestion in {line!r}"
+    for s in suggested:
+        assert s % 4 == 0, f"suggested {s} is not divisible by dp=4"
+
+
+def test_partial_flag_still_waives_rl_group_alignment():
+    """The flag must keep its legitimate purpose, or we have over-corrected.
+
+    RL group alignment is a normalization concern, not a liveness one, so it
+    stays waivable -- unlike dp divisibility.
+    """
+    kw = dict(dp=2, balance_data=True, n_per_prompt=4)
+    # 8 is divisible by dp=2 but not by (n_per_prompt * dp) = 8 -> it is, use 12
+    assert _v(allow_partial=False, **kw).validate_sample_count(12, is_rl=True) is not None
+    assert _v(allow_partial=True, **kw).validate_sample_count(12, is_rl=True) is None
+
+
+def test_global_batch_size_mismatch_is_a_warning_not_an_error():
+    """Check 3 only warns: gradient accumulation is well-defined here."""
+    assert _v(dp=2, gbs=4096).validate_sample_count(128) is None

--- a/training/backends/miles/backend.py
+++ b/training/backends/miles/backend.py
@@ -28,6 +28,11 @@ logger = logging.getLogger(__name__)
 _ADAPTER_CHECKPOINT_BASE = os.path.join(CHECKPOINT_BASE, "adapters")
 
 
+def _dp_size(args: Any) -> int:
+    """Data-parallel width the actors will split a batch across."""
+    return int(getattr(args, "data_parallel_size", 1) or 1)
+
+
 def _adapter_save_dir(adapter_name: str) -> Path:
     """Per-tenant dir miles writes adapter checkpoints into. Without it
     (config.save=None) miles skips per-adapter checkpoints entirely.
@@ -704,6 +709,15 @@ class MilesBackend(TrainingBackend):
         merged = self.converter.merge_forward_backward_batches(
             [o.rollout_data for o in batch]
         )
+        # Pad AFTER merging, never per request: pads must sit at the tail of
+        # what is actually dispatched, or the per-request offsets below would
+        # slice across them. See converter.pad_rollout_data_to_dp.
+        n_pad = self.converter.pad_rollout_data_to_dp(merged, _dp_size(pool.args))
+        if n_pad:
+            logger.info(
+                "Padded co-batched fb with %d inert sample(s) to align with dp=%d",
+                n_pad, _dp_size(pool.args),
+            )
         if len(batch) > 1:
             logger.info(
                 "Co-batched fb: %d requests / %d samples / tenants %s",
@@ -730,10 +744,16 @@ class MilesBackend(TrainingBackend):
 
         logprobs_list = merge_dp_sample_outputs(results or [], key="log_probs")
         expected = sum(o.num_samples for o in batch)
+        # Drop the alignment pads before anything client-visible: a pad has no
+        # observation key, so it must not reach a caller. Pads are at the tail
+        # by construction, so this is a slice, and the equality check below
+        # still guards the real per-request split.
+        if n_pad and len(logprobs_list) == expected + n_pad:
+            logprobs_list = logprobs_list[:expected]
         if len(logprobs_list) != expected:
             raise BackendError(
                 f"co-batched fb returned {len(logprobs_list)} per-sample "
-                f"outputs for {expected} samples",
+                f"outputs for {expected} samples (n_pad={n_pad})",
                 backend="miles", operation="forward_backward",
             )
 
@@ -832,9 +852,15 @@ class MilesBackend(TrainingBackend):
         config = get_config()
         allow_partial = getattr(config, "allow_partial_batches", False)
         validator = RequestValidator(h.args, allow_partial_batches=allow_partial)
-        validation_error = validator.validate_forward_backward_request(
-            data, is_rl=is_rl,
-        )
+        # Validate what will actually be DISPATCHED, not what arrived: the
+        # converter pads the batch up to a multiple of dp before it reaches the
+        # actors (pad_rollout_data_to_dp), so a client sending an indivisible
+        # count is legal and must not be refused. The validator's own
+        # divisibility rule stays strict as a backstop for any path that
+        # dispatches without padding.
+        dp = _dp_size(h.args)
+        padded = -(-len(data) // dp) * dp if dp > 1 else len(data)
+        validation_error = validator.validate_sample_count(padded, is_rl=is_rl)
         if validation_error:
             raise ValueError(
                 f"Request validation failed:\n{validation_error}\n\n"
@@ -880,6 +906,12 @@ class MilesBackend(TrainingBackend):
             rollout_data = self.converter.forward_backward_to_backend(
                 data, loss_fn, h.args, adapter_slot=h.adapter_slot,
             )
+            n_pad = self.converter.pad_rollout_data_to_dp(rollout_data, _dp_size(h.args))
+            if n_pad:
+                logger.info(
+                    "Padded fb with %d inert sample(s) to align with dp=%d",
+                    n_pad, _dp_size(h.args),
+                )
 
             results = await h.train_group.forward_backward_only(0, Box(ray.put(rollout_data)))
 
@@ -904,6 +936,16 @@ class MilesBackend(TrainingBackend):
             # computes NLL from these).
             from miles.ray.tinker_group import merge_dp_sample_outputs
             logprobs_list = merge_dp_sample_outputs(results or [], key="log_probs")
+            # Alignment pads carry no observation key — drop them before the
+            # client sees anything (they are at the tail by construction).
+            if n_pad:
+                if len(logprobs_list) != len(data) + n_pad:
+                    raise BackendError(
+                        f"fb returned {len(logprobs_list)} per-sample outputs for "
+                        f"{len(data)} samples + {n_pad} pads",
+                        backend="miles", operation="forward_backward",
+                    )
+                logprobs_list = logprobs_list[:len(data)]
             loss_fn_outputs = [
                 {"logprobs": {"data": lp.tolist(), "shape": [len(lp)], "dtype": "float32"}}
                 for lp in logprobs_list

--- a/training/backends/miles/converter.py
+++ b/training/backends/miles/converter.py
@@ -11,6 +11,24 @@ from ..base import DataConverter
 from ...core.data_converter import TinkerDataConverter
 
 
+def _zero_like(x: Any) -> Any:
+    """A same-shaped zero of x: torch tensor, nested list, or scalar."""
+    if hasattr(x, "new_zeros"):  # torch.Tensor without importing torch here
+        return x.new_zeros(x.shape)
+    if isinstance(x, list):
+        return [_zero_like(e) for e in x]
+    return type(x)(0) if isinstance(x, (int, float)) else 0
+
+
+def _copy_like(x: Any) -> Any:
+    """A detached copy of x, so a pad never aliases a real sample's storage."""
+    if hasattr(x, "clone"):  # torch.Tensor
+        return x.clone()
+    if isinstance(x, list):
+        return [_copy_like(e) for e in x]
+    return x
+
+
 class MilesDataConverter(DataConverter):
     """Adapter: TinkerDataConverter → DataConverter ABC."""
 
@@ -63,6 +81,52 @@ class MilesDataConverter(DataConverter):
         rollout_data["_loss_norm_total"] = 1
         if adapter_slot is not None:
             rollout_data["adapter_slots"] = [adapter_slot] * num_samples
+
+    @staticmethod
+    def pad_rollout_data_to_dp(rollout_data: Any, dp_size: int) -> int:
+        """Append inert samples so the batch divides evenly across DP ranks.
+
+        Miles derives num_steps_per_rollout per rank from that rank's local
+        sample count, so an unbalanced split makes the ranks disagree on how
+        many micro-steps to run and they deadlock on the gradient collective
+        (specs/008 §5b). Padding to a multiple of dp_size removes the
+        disagreement without changing what is trained.
+
+        The pads are semantically inert, not merely masked-out: gradients are
+        pure-sum here (``_loss_norm_total=1``), so a sample whose loss mask and
+        advantages are zero contributes exactly zero to the gradient and to the
+        loss, for both the SFT and the RL loss. Nothing is renormalized by the
+        padded count.
+
+        Per-sample keys are identified exactly as
+        :meth:`merge_forward_backward_batches` identifies them --- a list whose
+        length equals ``dynamic_global_batch_size`` --- so the two cannot drift
+        apart. Pads are appended at the TAIL, which is what lets callers
+        recover the client's observables with a single slice.
+
+        Returns the number of pads appended (0 if none were needed). Callers
+        MUST truncate per-sample outputs back to the original count: a pad has
+        no observation key (Def. 2), so it must not surface to a client.
+        """
+        n = rollout_data.get("dynamic_global_batch_size")
+        if not n or dp_size <= 1 or n % dp_size == 0:
+            return 0
+        n_pad = dp_size - (n % dp_size)
+
+        # Zeroing these is what makes a pad inert; everything else is copied so
+        # the sample stays well-formed (valid token ids, consistent lengths).
+        zero_keys = {"loss_masks", "advantages", "log_probs", "rollout_log_probs",
+                     "returns", "values", "weights"}
+
+        for key, value in list(rollout_data.items()):
+            if not (isinstance(value, list) and len(value) == n):
+                continue
+            last = value[-1]
+            for _ in range(n_pad):
+                value.append(_zero_like(last) if key in zero_keys else _copy_like(last))
+
+        rollout_data["dynamic_global_batch_size"] = n + n_pad
+        return n_pad
 
     @staticmethod
     def merge_forward_backward_batches(batches: List[Any]) -> Any:

--- a/training/core/validators.py
+++ b/training/core/validators.py
@@ -58,24 +58,35 @@ class RequestValidator:
                 f"Suggestion: Send {self.dp_size}, {self.dp_size * 2}, or {self.dp_size * 4} samples."
             )
 
-        # Check 2: DP divisibility (samples must distribute evenly across DP workers)
+        # Check 2: DP divisibility. NOT waivable by allow_partial_batches.
+        #
+        # An indivisible batch does not merely run inefficiently -- it HANGS.
+        # Miles derives num_steps_per_rollout per rank from that rank's local
+        # sample count (miles data.py, "dynamic global_batch_size"), so an
+        # unbalanced split gives the ranks different micro-step counts and they
+        # deadlock on the per-step collective: every rank enters
+        # forward_backward_only, none returns, the future polls forever, and the
+        # actors stay wedged until the server restarts. Measured 2026-08-04 with
+        # 3 samples at dp=2 (rank0 num_steps=2, rank1 num_steps=1); see
+        # specs/008-q3-abstraction-tax/HANDOFF.md.
+        #
+        # ALLOW_PARTIAL_BATCHES previously waived this and logged that Miles
+        # "will rely on dynamic global batch scaling" -- it is exactly that
+        # scaling that diverges per rank. The flag still governs the genuinely
+        # partial cases below (global-batch-size and RL group alignment), where
+        # the consequence is normalization, not liveness.
         if num_samples % self.dp_size != 0:
-            if self.allow_partial_batches:
-                logger.warning(
-                    "ALLOW_PARTIAL_BATCHES enabled: proceeding with %s samples (dp=%s). "
-                    "Miles will rely on dynamic global batch scaling.",
-                    num_samples,
-                    self.dp_size,
-                )
-            else:
-                next_valid = ((num_samples // self.dp_size) + 1) * self.dp_size
-                prev_valid = (num_samples // self.dp_size) * self.dp_size
-                return (
-                    f"Invalid sample count: Received {num_samples} samples but "
-                    f"data parallel size is {self.dp_size}.\n"
-                    f"Required: Sample count must be divisible by {self.dp_size}.\n"
-                    f"Suggestion: Use {prev_valid} or {next_valid} samples instead."
-                )
+            next_valid = ((num_samples // self.dp_size) + 1) * self.dp_size
+            prev_valid = (num_samples // self.dp_size) * self.dp_size
+            return (
+                f"Invalid sample count: Received {num_samples} samples but "
+                f"data parallel size is {self.dp_size}.\n"
+                f"Required: Sample count must be divisible by {self.dp_size} -- "
+                f"an unbalanced split makes the DP ranks derive different "
+                f"micro-step counts and deadlock on the gradient collective, "
+                f"so this is rejected rather than attempted.\n"
+                f"Suggestion: Use {prev_valid} or {next_valid} samples instead."
+            )
 
         # Check 3: Global batch size divisibility
         if num_samples % self.global_batch_size != 0:


### PR DESCRIPTION
## The bug

A `forward_backward` whose sample count is not divisible by the data-parallel width **hangs**. It does not error, and it does not run slowly — it never returns.

Miles derives `num_steps_per_rollout` per rank from that rank's local sample count, so an unbalanced split makes the ranks disagree on how many micro-steps to run and they block on the per-step gradient collective. Measured on `tinkercloud-miles` with 3 samples at dp=2:

```
validators.py:64  ALLOW_PARTIAL_BATCHES enabled: proceeding with 3 samples (dp=2).
                  Miles will rely on dynamic global batch scaling.
rank0  data.py:462  global_batch_size=3, num_local_samples=2, num_steps_per_rollout=2
rank1  data.py:462  global_batch_size=3, num_local_samples=1, num_steps_per_rollout=1
```

Both ranks enter `forward_backward_only`, both complete `compute_log_prob`, neither returns. The future polled 400+ times over ~7 minutes while the SGLang engines kept answering health checks — so the server looks healthy — and the actors stay wedged until it is restarted.

Found while probing split-invariance across engines (`specs/008-q3-abstraction-tax`).

## Two commits, deliberately separate

**1. `961254c` — reject.** Check 2 already rejected indivisible batches; `ALLOW_PARTIAL_BATCHES` waived it, and every pod runs with that flag on. The waiver is wrong in kind: DP indivisibility is a *liveness* concern, not the normalization concern the flag exists for — and the log line promising "dynamic global batch scaling" was naming the very mechanism that diverges per rank. Check 2 is now unconditional and says *why*, since the old failure mode was silence.

The flag keeps its legitimate scope: check 3 (global batch size) still warns, check 4 (RL group alignment) is still waivable — both affect normalization, not whether the call returns.

**2. `cec6e85` — pad.** Rejecting only makes the refusal polite; the client program is still legal, so refusing it is still wrong. `MilesDataConverter.pad_rollout_data_to_dp` appends inert samples up to a rank-balanced size. Inert in the strong sense, not merely masked: gradients here are pure sum (`_loss_norm_total=1`), so a sample with zero `loss_masks` and zero `advantages` contributes exactly zero to loss and gradient, for both the SFT and RL losses, and nothing is renormalized by the padded count.

`_validate_fb` then validates the **padded** count, so an indivisible request is legal again. The strict rule from commit 1 stays as a backstop for any path that dispatches without padding.

The first commit is independently shippable if you'd rather take only the safety fix.

## Three properties the callers depend on

- **pads go at the TAIL** — observables are recovered with one slice
- **per-sample keys are identified by the same rule `merge_forward_backward_batches` uses** (a list whose length equals `dynamic_global_batch_size`), so padding and merging cannot drift apart
- **pads never alias** a real sample's storage

Wiring detail that matters: the pool path pads the **merged** batch, never per request — per-request pads would land mid-batch and the per-request offsets in `_execute_fb_batch` would slice across them. Both dispatch sites truncate pads off the returned per-datum logprobs before anything client-visible.

## Cluster validation

Run on `tinkercloud-miles` (dp=2), same 8 datums, `lr=0.0` so weights never move:

| Segmentation | as found | after reject | after pad |
|---|---|---|---|
| `fb(3) fb(5)` | deadlock | HTTP 400 | **bit-identical to `fb(8)`** |
| `fb(1) fb(7)` | deadlock | HTTP 400 | **bit-identical** |
| `fb(3) fb(5)` rerun | — | — | **bit-identical** |
| `fb(4) fb(4)` | exact | exact | exact |
| `fb(8)` rerun | exact | exact | exact |

Server log confirms the mechanism fired and the deadlock condition is gone: `Padded co-batched fb with 1 inert sample(s) to align with dp=2`, and the ranks now agree (`num_local_samples` 3/3, 4/4) where they previously derived 2 vs 1.

Valid batches are unaffected: `fb(8)` returns `grad_norm=124.59701055427654`, bit-identical to runs from before either change.

One expectation I got wrong, reported as measured: I predicted admission would return at E1, since padding changes the sample-to-rank assignment. It came back **bit-identical** on every arm, reproducibly. No mechanism is claimed for the bitwise agreement.

## Tests

+40 unit tests, runnable without a cluster (`tests/test_validators.py` 23, `tests/test_miles_padding.py` 17):

- rejection holds with `allow_partial_batches` **both on and off**
- suggested sample counts are themselves divisible by dp
- RL group alignment stays waivable — so the fix is not an over-correction
- pads are inert (loss/advantage mass unchanged), tail-placed, non-aliasing, idempotent
- `adapter_slots` extended so pool-mode routing still works
- padding's per-sample-key rule matches merge's

Both files import standalone, so they run outside the container.
