### PR TITLE
nemo_rl: default to dynamic batching on the policy.train path (A5 perf fix)

### DIFF
--- a/training/backends/nemo_rl/backend.py
+++ b/training/backends/nemo_rl/backend.py
@@ -64,6 +64,7 @@ class NemoRLHandle(BackendHandle):
     ref_logprob_accumulator: Any = None  # Lazy _RefLogprobAccumulator (BUG-015)
     staleness_k: int = 0                 # Declared max sampler staleness (A4, specs/012)
     generation_synced_version: int = 0   # ver(S): weight version the inference engine holds
+    dyn_mb_base: int = 0                 # Base dynamic-batching token budget (A5, specs/013)
 
 
 class NemoRLBackend(TrainingBackend):
@@ -241,6 +242,7 @@ class NemoRLBackend(TrainingBackend):
             # in pipelined SFT. train vs eval mode gives identical logprobs (no dropout).
             await asyncio.to_thread(h.policy.prepare_for_training)
 
+            _ensure_dyn_mb_budget(h, batched_data)
             result = await asyncio.to_thread(h.policy.get_logprobs, batched_data)
 
             # No refit after forward(): read-only pass, inference weights already in
@@ -517,6 +519,7 @@ class NemoRLBackend(TrainingBackend):
                     if h.loss_fn_name != "cross_entropy" and "prev_logprobs" in all_data:
                         if h.staleness_k == 0:
                             logger.info("Computing prev_logprobs via DTensor forward pass (BUG-011)")
+                            _ensure_dyn_mb_budget(h, all_data)
                             logprob_result = await asyncio.to_thread(
                                 h.policy.get_logprobs, all_data,
                             )
@@ -542,6 +545,7 @@ class NemoRLBackend(TrainingBackend):
 
                     # Pass gbs=actual size so NeMo RL shards correctly instead of
                     # defaulting to config train_global_batch_size.
+                    _ensure_dyn_mb_budget(h, all_data)
                     train_result = await asyncio.to_thread(
                         h.policy.train,
                         data=all_data,
@@ -906,6 +910,7 @@ class NemoRLBackend(TrainingBackend):
             if h.policy_generation is not None and h.colocated_inference:
                 await asyncio.to_thread(h.policy_generation.finish_generation)
             await asyncio.to_thread(h.policy.prepare_for_training)
+            _ensure_dyn_mb_budget(h, data)
             out = await asyncio.to_thread(h.policy.get_reference_policy_logprobs, data)
 
         ref = out["reference_logprobs"]  # [B_padded, S]; row t = logprob(token_t | <t)
@@ -1264,6 +1269,37 @@ class _RefLogprobAccumulator:
             async with self._lock:
                 if not self._pending:
                     return
+
+
+def _ensure_dyn_mb_budget(h: "NemoRLHandle", data) -> None:
+    """Raise the dynamic-batching token budgets to admit this batch (A5).
+
+    The builder sets a memory-sized base budget (default 8192 tokens);
+    NeMo RL asserts every sample fits its micro-batch budget after
+    sequence_length_round padding. Setting max(base, longest sample)
+    before each train/logprob call keeps short-sequence packing bounded
+    while a long sample degrades to its own micro-batch — the old MBS=1
+    worst case — instead of a hard assert. Non-ratcheting: a long batch
+    does not inflate the budget for later short batches.
+    """
+    policy = h.policy
+    dyn = getattr(policy, "cfg", {}).get("dynamic_batching") if policy else None
+    if not dyn or not dyn.get("enabled"):
+        return
+    lengths = data.get("input_lengths") if hasattr(data, "get") else None
+    if lengths is None or len(lengths) == 0:
+        return
+    if h.dyn_mb_base <= 0:
+        h.dyn_mb_base = int(dyn.get("train_mb_tokens", 0))
+    rounded = -(-int(lengths.max()) // 64) * 64  # sequence_length_round
+    budget = max(h.dyn_mb_base, rounded)
+    for key in ("train_mb_tokens", "logprob_mb_tokens"):
+        if dyn.get(key) != budget:
+            logger.info(
+                "dynamic batching %s: %s -> %d (longest sample %d, base %d)",
+                key, dyn.get(key), budget, int(lengths.max()), h.dyn_mb_base,
+            )
+            dyn[key] = budget
 
 
 def _maybe_pad_batch(batch, dp_size: int, mbs: int, image_preprocessor=None):

--- a/training/backends/nemo_rl/builder.py
+++ b/training/backends/nemo_rl/builder.py
@@ -164,10 +164,40 @@ class NemoRLArgumentBuilder(ArgumentBuilder):
             model_parallel = tp_size * pp_size * cp_size
             dp_size = max(1, num_gpus // model_parallel)
 
-        # GBS = samples per train() call; MBS=1 minimizes activation memory
-        # (NeMo RL convention); grad-accum steps = GBS / (MBS * DP) bridge the gap.
+        # GBS = samples per train() call; grad-accum steps = GBS / (MBS * DP)
+        # bridge the gap. MBS=1 (the old default) is a measured perf bug at
+        # scale (specs/013 A5: 128 sequential single-sequence micro-batches
+        # at global-pad width, 5.6x padding inflation, 103 s/step at 8B/TP2).
+        # Default is NeMo RL dynamic batching (length-sorted, token-budgeted,
+        # per-micro-batch length trim). The budget is a MEMORY constant, not
+        # max_seq_len: activations run ~9 MB/token at 8B/TP2 without
+        # checkpointing, so a budget that tracks a 32k context packs 32k-token
+        # micro-batches and OOMs an H200 (measured, A5 sweep). 8192 tokens
+        # (~74 GB at 8B/TP2) is the validated default; the backend raises it
+        # per-batch to the longest actual sample before each train/logprob
+        # call (backend._ensure_dyn_mb_budget), so a long sample degrades to
+        # exactly the old MBS=1 worst case instead of tripping NeMo RL's
+        # sample-exceeds-budget assert.
+        # NEMORL_TRAIN_MB_TOKENS: override base budget; 0 disables dynamic
+        # batching; NEMORL_TRAIN_MBS then sets the static micro-batch size.
         train_global_batch_size = max_batch_size
-        train_micro_batch_size = 1
+        train_micro_batch_size = int(os.environ.get("NEMORL_TRAIN_MBS", "1"))
+        dyn_env = os.environ.get("NEMORL_TRAIN_MB_TOKENS")
+        # VLMs keep the static path: dynamic batching's slice/truncate is
+        # unvalidated against multimodal kwargs (same conservatism as the
+        # sequence_packing/cp guards above).
+        dyn_default = 0 if is_vlm else min(max_seq_len, 8192)
+        dyn_mb_tokens = int(dyn_env) if dyn_env is not None else dyn_default
+        dynamic_batching_cfg = (
+            {
+                "enabled": True,
+                "train_mb_tokens": dyn_mb_tokens,
+                "logprob_mb_tokens": dyn_mb_tokens,
+                "sequence_length_round": 64,
+            }
+            if dyn_mb_tokens > 0
+            else {"enabled": False}
+        )
 
         # Policy config (maps to NeMo RL PolicyConfig TypedDict)
         policy_config = {
@@ -197,9 +227,7 @@ class NemoRLArgumentBuilder(ArgumentBuilder):
             "megatron_cfg": {
                 "enabled": False,
             },
-            "dynamic_batching": {
-                "enabled": False,
-            },
+            "dynamic_batching": dynamic_batching_cfg,
             "sequence_packing": {
                 "enabled": False,
             },


### PR DESCRIPTION
## What

The nemo_rl backend ran every buffered sample as its own micro-batch (`train_micro_batch_size=1`, dynamic batching and sequence packing both disabled) at global-pad width. On the specs/013 frozen 8B/TP2 stream that is 128 sequential single-sequence forward/backwards per step with 5.6× padding inflation: **103 s/step vs 23.7 (verl, 1 GPU) / 27.3 (miles, 4 GPU)** — review objection A5. dmon signature: TP ranks alternating 100%/17% SM at ~5% memory bandwidth (spin-wait, not math).

## Fix

- Enable NeMo RL **dynamic batching** by default (length-sorted, token-budgeted micro-batches, per-micro-batch length trim).
- The budget is a **memory constant** (default 8192 tokens), not `max_seq_len`: the builder raises `max_seq_len` to the model's native context (32k for Qwen3-8B), and a budget tied to it packs 32k-token micro-batches → measured OOM at 136 GiB on H200 (~9 MB activations/token at 8B/TP2 without checkpointing).
- `_ensure_dyn_mb_budget` (backend) raises the budget **per call** to the longest actual sample (round-64, non-ratcheting), so a long sample degrades to its own micro-batch — exactly the old MBS=1 worst case — instead of tripping NeMo RL's sample-exceeds-budget assert. Long-context recipes keep working unchanged.
- VLMs keep the static path (dynamic slice/truncate unvalidated against multimodal kwargs).
- Overrides: `NEMORL_TRAIN_MB_TOKENS` (base budget; 0 disables), `NEMORL_TRAIN_MBS` (static mbs when disabled).

## Measurements (specs/013 probes/results/a5/, Qwen3-8B-Base r32 TP2 DP1, frozen 008 stream)

| config | s/step | step-0 NLL |
|---|---|---|
| mbs=1 (shipped) | 103.3 | 1.9857325975819264 |
| mbs=8 (sweep arm) | 14.3 | bit-identical raw total_loss |
| **dynamic 8192 (this PR)** | **6.74** | 1.9857327 (Δrel 7e-8, regrouped-micro-batch fp noise) |

Full 30-step endpoint 1.74461 vs 1.74393 on the shipped config — Δ 6.8e-4, inside the ±0.016 same-engine rerun envelope. Three-engine endpoint spread tightens 0.00346 → 0.00306 nats.
