### PR TITLE
miles: fetch SGLang router address on single-tenant create

### DIFF
--- a/training/backends/miles/backend.py
+++ b/training/backends/miles/backend.py
@@ -503,7 +503,18 @@ class MilesBackend(TrainingBackend):
                 router_ip = getattr(args, "sglang_router_ip", None)
                 router_port = getattr(args, "sglang_router_port", None)
                 if not router_ip:
-                    logger.error("[%s] SGLang router address missing from args", request_id)
+                    # Upstream create_rollout_manager does not publish the
+                    # router address into args on the single-tenant path
+                    # (pool mode fetches it explicitly); ask the manager.
+                    try:
+                        router_ip, router_port = (
+                            await rollout_manager.get_router_address.remote()
+                        )
+                    except Exception:
+                        logger.error(
+                            "[%s] SGLang router address missing from args",
+                            request_id,
+                        )
 
             handle = MilesHandle(
                 model_id=model_id,


### PR DESCRIPTION
## What

Single-tenant `create_model` on miles booted the rollout manager but never fetched the SGLang router address — it read `args.sglang_router_ip`, which upstream `create_rollout_manager` never populates — so every single-tenant `sample()` failed with a 400 `SGLang router not available`. The pool branch (M1) already fetches the address from the rollout manager explicitly; this applies the same derivation to the single-tenant path (args read first, explicit fetch as fallback, error log last).

## Why it survived a month

Regression from the tinker-seam rewrite (`32d6980`): the original dual-backend code had the explicit fetch; the rewrite replaced it with the args read; M1 restored it pool-side only. No standing gate exercises single-tenant sampling on miles (SFT parity and E₀ gates never sample; every sampling arm ran pool mode), so the first single-tenant RL workload — specs/013's miles-pair probe — found it on contact. Follow-up (suite TODO, specs/013): a per-backend single-tenant create→sample→delete smoke gate.

## Validation

Cluster (tinkercloud-miles, Qwen3-8B, NUM_GPUS=4 auto TP2/DP2): 30-step GSM8K RL run, rc=0, all 30 steps sampled through the router; chronicle in `specs/013-a1-8b-spine/HANDOFF.md` §miles-pair.
