### PR TITLE
miles: enable slime native dynamic batching by default (5.1x at 8B, bit-level clean)

### DIFF
--- a/training/core/slime_builder.py
+++ b/training/core/slime_builder.py
@@ -153,6 +153,7 @@ class SlimeArgumentBuilder:
             wandb_config=wandb_config,
             multi_lora_slots=multi_lora_slots,
             rollout_gpus=rollout_gpus,
+            max_seq_len=max_seq_len,
         )
 
         return args, hf_model_path
@@ -354,6 +355,7 @@ class SlimeArgumentBuilder:
         wandb_config: Optional[Dict[str, Any]] = None,
         multi_lora_slots: int = 0,
         rollout_gpus: int = 0,
+        max_seq_len: int = 2048,
     ) -> Namespace:
         """Configure model-specific argument overrides."""
         # Check if RLVE mode is enabled
@@ -455,9 +457,20 @@ class SlimeArgumentBuilder:
         args.tokenizer_type = "HuggingFaceTokenizer"
         args.model_name = "qwen2.5"
 
-        # Dynamic batch size - disabled for simplicity to avoid reordering complexity
-        args.use_dynamic_batch_size = False
-        args.max_tokens_per_gpu = 4096
+        # Dynamic batch size: ON by default. miles' regrouping is order-safe
+        # (gather_log_data un-permutes by micro_batch_indices; DP merge keys on
+        # partition_indices), verified bit-level in specs/013 M-fix: per-token
+        # logprobs identical across groupings, 30-step endpoint within 2x the
+        # rerun envelope, 27.3 -> 5.3 s/step at 8B/TP2DP2. Budget is the
+        # client-declared max_seq_len (floor 8192): packed peak activation ==
+        # the old mbs=1 worst case (one full-length sample), so no new OOM
+        # surface; not the model's native context (specs/013 A5 lesson).
+        args.use_dynamic_batch_size = (
+            os.environ.get("SLIME_DYN_BATCH", "1") == "1"
+        )
+        args.max_tokens_per_gpu = int(
+            os.environ.get("SLIME_MAX_TOKENS_PER_GPU", str(max(8192, max_seq_len)))
+        )
 
         # Features
         args.colocate = multi_lora_slots == 0


### PR DESCRIPTION
## Summary
- `slime_builder.py` hardcoded `--micro-batch-size 1` and disabled slime's native dynamic batching ("for simplicity to avoid reordering complexity") — each 128-seq round ran as sequential single-sequence fwd/bwds at padded width: **27.3 s/step (109.3 GPU·s/step) at 8B/TP2DP2**, 4.6× worse per GPU than eager FSDP on identical work. Same defect class as the NeMo RL default fixed in #33.
- The feared reordering is handled inside miles itself: `gather_log_data` un-permutes by `micro_batch_indices` (rank-local), `merge_dp_sample_outputs` reassembles by `partition_indices` (DP).
- Fix: dynamic batching ON by default; budget = client-declared `max_seq_len` (floor 8192) — packed peak activation ≡ the old mbs=1 worst case (one full-length sample), so no new OOM surface; deliberately NOT the model's native context (the #33 lesson). Env escape hatches: `SLIME_DYN_BATCH=0`, `SLIME_MAX_TOKENS_PER_GPU`.

## Measurements (specs/013 M-fix, miles pod, frozen A1-b stream, Qwen3-8B TP2/DP2)
| check | result |
|---|---|
| Permutation audit (per-sample, per-token, shipped vs dyn at fixed weights) | **BIT-IDENTICAL** — 128/128 lengths align, max \|Δlogprob\| = 0.0 |
| Step-0 aggregate NLL | 1.9858311574821521 — bit-equal to banked |
| 30-step endpoint | Δ **4.1e-4** vs banked (2.0× the measured miles rerun envelope 2.1e-4) |
| Step time | 27.3 → **5.32 s/step (5.1×)**; 109.3 → **21.3 GPU·s/step** |

Artifacts: monorepo `specs/013-a1-8b-spine/probes/results/mfix/` (probe JSONs + 30-step metrics + logs).
