### PR TITLE
E2/RESID experiment plumbing: NeMo RL Megatron-path lowering + attribution knobs (env-gated, defaults unchanged)

### DIFF
--- a/training/backends/nemo_rl/builder.py
+++ b/training/backends/nemo_rl/builder.py
@@ -337,7 +337,8 @@ class NemoRLArgumentBuilder(ArgumentBuilder):
                     "alpha": lora_config.get("alpha") or lora_config.get("rank", 8),
                     "dropout": lora_config.get("dropout", 0.0),
                     "dropout_position": "post",
-                    "lora_A_init_method": "xavier",
+                    "lora_A_init_method": os.environ.get(
+                        "NEMORL_MEGATRON_A_INIT", "xavier"),
                     "lora_B_init_method": "zero",
                     "a2a_experimental": False,
                     "lora_dtype": None,
@@ -385,7 +386,9 @@ class NemoRLArgumentBuilder(ArgumentBuilder):
                     "adam_eps": 1.0e-8,
                     "sgd_momentum": 0.9,
                     "use_distributed_optimizer": True,
-                    "use_precision_aware_optimizer": True,
+                    "use_precision_aware_optimizer": (
+                        os.environ.get("NEMORL_MEGATRON_PRECISION_AWARE", "1")
+                        == "1"),
                     # Read unconditionally by the pod's nemo-rl rev
                     # (validate_and_set_config), absent from the older
                     # RL submodule checkout — supply both.

--- a/training/backends/nemo_rl/builder.py
+++ b/training/backends/nemo_rl/builder.py
@@ -317,6 +317,14 @@ class NemoRLArgumentBuilder(ArgumentBuilder):
             meg_lr = float(os.environ.get("NEMORL_MEGATRON_LR", "2e-4"))
             meg_iters = int(os.environ.get("NEMORL_MEGATRON_LR_DECAY_ITERS", "222"))
             policy_config["dtensor_cfg"] = {"enabled": False}
+            # The bridge scheduler converts lr_decay_iters to SAMPLE units by
+            # multiplying with config train_global_batch_size at init, while
+            # the worker steps it by the ACTUAL per-call batch. Pin the config
+            # gbs to the actual per-step batch so decay is exact (measured:
+            # 4096 vs 128 slowed decay 32x — delivered lr 1.99972e-4 vs
+            # declared 1.99099e-4 at step 1).
+            policy_config["train_global_batch_size"] = int(
+                os.environ.get("NEMORL_MEGATRON_GBS", "128"))
             if lora_config and lora_config.get("rank", 0) > 0:
                 meg_peft = {
                     "enabled": True,

--- a/training/backends/nemo_rl/builder.py
+++ b/training/backends/nemo_rl/builder.py
@@ -306,6 +306,98 @@ class NemoRLArgumentBuilder(ArgumentBuilder):
         else:
             policy_config["dtensor_cfg"]["lora_cfg"] = {"enabled": False}
 
+        # E2 arm (specs/013 round-6): lower the same declaration onto NeMo RL's
+        # Megatron path — LoRA attaches to the FUSED linear_qkv/linear_fc1
+        # modules, the other side of the lowering partition. Explicit opt-in
+        # (NEMORL_MEGATRON=1); default path is unchanged. The Megatron worker
+        # has no set_learning_rate, so the client's per-step LR is reproduced
+        # server-side by the scheduler (linear lr0*(1-t/T), matching
+        # q5_conv_migration.lr_at); verify delivered lr in train metrics.
+        if os.environ.get("NEMORL_MEGATRON") == "1":
+            meg_lr = float(os.environ.get("NEMORL_MEGATRON_LR", "2e-4"))
+            meg_iters = int(os.environ.get("NEMORL_MEGATRON_LR_DECAY_ITERS", "222"))
+            policy_config["dtensor_cfg"] = {"enabled": False}
+            if lora_config and lora_config.get("rank", 0) > 0:
+                meg_peft = {
+                    "enabled": True,
+                    # Megatron module names: qkv and gate/up are fused — the
+                    # lowering under test. Coverage mirrors all-linear.
+                    "target_modules": ["linear_qkv", "linear_proj",
+                                       "linear_fc1", "linear_fc2"],
+                    "exclude_modules": [],
+                    "dim": lora_config.get("rank", 8),
+                    "alpha": lora_config.get("alpha") or lora_config.get("rank", 8),
+                    "dropout": lora_config.get("dropout", 0.0),
+                    "dropout_position": "post",
+                    "lora_A_init_method": "xavier",
+                    "lora_B_init_method": "zero",
+                    "a2a_experimental": False,
+                    "lora_dtype": None,
+                }
+            else:
+                meg_peft = {"enabled": False}
+            policy_config["megatron_cfg"] = {
+                "enabled": True,
+                "empty_unused_memory_level": 1,
+                "activation_checkpointing": False,
+                "converter_type": "Qwen2ForCausalLM",
+                "tensor_model_parallel_size": tp_size,
+                "expert_tensor_parallel_size": 1,
+                "expert_model_parallel_size": 1,
+                "pipeline_model_parallel_size": pp_size,
+                "num_layers_in_first_pipeline_stage": None,
+                "num_layers_in_last_pipeline_stage": None,
+                "context_parallel_size": cp_size,
+                "pipeline_dtype": "bfloat16",
+                "sequence_parallel": False,
+                "freeze_moe_router": False,  # ValueError with PEFT; model is dense
+                "moe_router_dtype": "fp64",
+                "moe_router_load_balancing_type": "none",
+                "moe_router_bias_update_rate": 0.0,
+                "moe_permute_fusion": False,
+                "moe_enable_deepep": False,
+                "moe_token_dispatcher_type": "allgather",
+                "moe_shared_expert_overlap": False,
+                "moe_per_layer_logging": False,
+                "apply_rope_fusion": True,
+                "bias_activation_fusion": True,
+                "defer_fp32_logits": False,
+                "train_iters": meg_iters,
+                "peft": meg_peft,
+                "optimizer": {
+                    "optimizer": "adam",
+                    "lr": meg_lr,
+                    "min_lr": 0.0,
+                    "weight_decay": 0.0,
+                    "bf16": True,
+                    "fp16": False,
+                    "params_dtype": "float32",
+                    "adam_beta1": 0.9,
+                    "adam_beta2": 0.95,
+                    "adam_eps": 1.0e-8,
+                    "sgd_momentum": 0.9,
+                    "use_distributed_optimizer": True,
+                    "use_precision_aware_optimizer": True,
+                    "clip_grad": 1.0,
+                },
+                "scheduler": {
+                    "start_weight_decay": 0.0,
+                    "end_weight_decay": 0.0,
+                    "weight_decay_incr_style": "constant",
+                    "lr_decay_style": "linear",
+                    "lr_decay_iters": meg_iters,
+                    "lr_warmup_iters": 0,
+                    "lr_warmup_init": 0.0,
+                },
+                "distributed_data_parallel_config": {
+                    "grad_reduce_in_fp32": False,
+                    "overlap_grad_reduce": True,
+                    "overlap_param_gather": True,
+                    "use_custom_fsdp": False,
+                    "data_parallel_sharding_strategy": "optim_grads_params",
+                },
+            }
+
         # Loss function config (ClippedPGLossConfig for GRPO/PPO)
         loss_fn_config = {
             "reference_policy_kl_penalty": 0.001,

--- a/training/backends/nemo_rl/builder.py
+++ b/training/backends/nemo_rl/builder.py
@@ -378,6 +378,11 @@ class NemoRLArgumentBuilder(ArgumentBuilder):
                     "sgd_momentum": 0.9,
                     "use_distributed_optimizer": True,
                     "use_precision_aware_optimizer": True,
+                    # Read unconditionally by the pod's nemo-rl rev
+                    # (validate_and_set_config), absent from the older
+                    # RL submodule checkout — supply both.
+                    "optimizer_cpu_offload": False,
+                    "optimizer_offload_fraction": 0.0,
                     "clip_grad": 1.0,
                 },
                 "scheduler": {

--- a/training/core/slime_builder.py
+++ b/training/core/slime_builder.py
@@ -116,6 +116,10 @@ class SlimeArgumentBuilder:
         tp_size = parallel['tp']
         pp_size = parallel['pp']
         cp_size = parallel['cp']
+        # Attribution-arm override (specs/013 stack-residual): explicit env,
+        # default = auto-detect.
+        if os.environ.get('SLIME_TP'):
+            tp_size = int(os.environ['SLIME_TP'])
 
         # Build parallel_config dict for compatibility
         parallel_config = {
@@ -394,6 +398,12 @@ class SlimeArgumentBuilder:
         if not lora_config or lora_config.get("train_mlp", True):
             target_modules += ["linear_fc1", "linear_fc2"]
         args.target_modules = target_modules
+        # Attribution-arm override (specs/013 stack-residual): miles' bridge
+        # fork defaults lora_A_init_method="xavier" (multi_lora_utils/
+        # lora_utils getattr fallback); expose it so the init term measured on
+        # the NeMo megatron path (0.076) can be tested on this stack.
+        if os.environ.get('SLIME_LORA_A_INIT'):
+            args.lora_A_init_method = os.environ['SLIME_LORA_A_INIT']
         # Upstream only injects megatron-side LoRA adapters on the bridge path
         # (model.py: is_lora_enabled and megatron_to_hf_mode == "bridge");
         # without this the model silently builds as full-finetune and LoRA

--- a/training/core/slime_builder.py
+++ b/training/core/slime_builder.py
@@ -266,10 +266,13 @@ class SlimeArgumentBuilder:
         else:
             # Memory management: colocate SGLang with Megatron, enable offload
             # These MUST be set here because parse_args() sets defaults based on them
-            minimal_args.extend([
-                '--colocate',
-                '--offload',  # Equivalent to --offload-train + --offload-rollout
-            ])
+            # Attribution-arm override (specs/013 stack-residual): SLIME_NO_OFFLOAD=1
+            # drops both flags; default unchanged.
+            if os.environ.get('SLIME_NO_OFFLOAD') != '1':
+                minimal_args.extend([
+                    '--colocate',
+                    '--offload',  # Equivalent to --offload-train + --offload-rollout
+                ])
 
         # Add kv-channels if model has explicit head_dim (e.g., Qwen3)
         if model_config.get('kv_channels'):


### PR DESCRIPTION
## What

Experiment plumbing behind the specs/013 E2 (fused-lowering) and RESID (stack-residual attribution) arms. Every knob is env-gated; **default behavior is byte-identical to shipped** on both backends.

### nemo_rl builder
- `NEMORL_MEGATRON=1`: lower the declared LoRA onto NeMo RL's Megatron path — full `megatron_cfg` (Megatron-Bridge PEFT on the fused `linear_qkv`/`linear_fc1`/`linear_proj`/`linear_fc2` modules), optimizer matched to the Tinker AdamParams contract (0.9/0.95, eps 1e-8, wd 0, clip 1.0), server-side scheduler reproducing the client's linear LR (this worker has no `set_learning_rate`).
- **Real fix inside the gated path**: the bridge scheduler converts `lr_decay_iters` to sample units via config `train_global_batch_size` while the worker steps by the actual per-call batch — with config gbs 4096 vs actual 128 the decay ran 32x slow (measured: delivered lr 1.99972e-4 vs declared 1.99099e-4 at step 1). Pinned config gbs to the actual per-step batch in megatron mode; delivered LR now matches the declared schedule to all digits.
- `NEMORL_MEGATRON_LR / _LR_DECAY_ITERS / _GBS / _A_INIT / _PRECISION_AWARE`: arm parameters.

### slime_builder (miles)
- `SLIME_TP`: explicit TP override (default auto-detect).
- `SLIME_LORA_A_INIT`: expose the bridge fork's `lora_A_init_method` (fork default xavier).
- `SLIME_NO_OFFLOAD=1`: drop `--colocate --offload` (default keeps both).

## Why

These arms produced the 013 RESID-FINAL ledger: fused-class term +0.0024, A-init default term 0.076/0.027 (E0-invisible; step-0 bit-identical), TP and offload excluded at <=3e-4, remainder = Megatron-revision/kernel bundle. Now woven into the paper's Q1-E2/Q2.

## Measurements backing the LR fix
smoke r1: delivered lr near-flat (decrement lr0/7104 per step); smoke r2 after fix: delivered = 2e-4*(1-t/222) exactly (specs/013 E2 addendum).
