### PR TITLE
miles: two DP/kernel correctness defects — pack length and the grad reduction

### DIFF
--- a/tests/test_miles_dp_reduction.py
+++ b/tests/test_miles_dp_reduction.py
@@ -1,0 +1,95 @@
+"""The DP gradient reduction must match the optimizer that consumes it.
+
+miles builds the DDP config's `use_distributed_optimizer` from its own
+predicate (`bridge_lora_helpers.py`: `"muon" not in args.optimizer`) while the
+optimizer CLASS is chosen from `args.use_distributed_optimizer`. The builder
+used to pin the latter to False, so for adam+LoRA the two disagreed:
+
+    ddp_config.use_distributed_optimizer = True   -> DDP REDUCE-SCATTERs grads
+    args.use_distributed_optimizer      = False   -> Float16OptimizerWithFloat16Params,
+                                                     which needs a full ALL-REDUCE
+
+After finalization each rank then held the summed gradient only on its own
+1/dp shard of the buffer and its own *unreduced local* gradient everywhere
+else -- and stepped the whole parameter set with it. The ranks ended up with
+different gradients, different norms, different clip factors (clip_grad=1.0
+scales every step by 1/||g||) and different weights.
+
+Measured on the cluster at dp=2, Qwen2.5-0.5B, 8 datums, lr=0
+(specs/014-gate-suite/INVESTIGATION-miles-split.md §DEFECT 2):
+
+    rank0 local 131.530 | rank1 local 139.310 | true ||sum|| = 123.481
+    post-finalize: rank0 102.787, rank1 96.936   <- the ranks DISAGREE
+
+and the reported grad_norm ran 122.690 / 102.435 / 82.564 at dp = 1 / 2 / 4,
+16.5% and 32.7% apart on identical data with a bit-identical forward. Removing
+the override puts every width at 123.4814 +/- 4.2e-07 and makes a permuted
+round bit-identical.
+
+The regression this guards is narrow and source-level on purpose: the bug was
+never a wrong VALUE, it was the service owning a flag the engine also derives.
+A second derivation is exactly what must not come back.
+"""
+import importlib.util
+import inspect
+import os
+import re
+import sys
+import types
+
+import pytest
+
+
+def _load_builder_module():
+    """Import slime_builder.py without dragging FastAPI in via the package init."""
+    try:  # in-container / installed layout
+        from tinkercloud.training.core import slime_builder as m
+        return m
+    except ImportError:
+        pass
+    root = os.path.join(os.path.dirname(__file__), os.pardir, "training")
+
+    def _pkg(name):
+        p = types.ModuleType(name)
+        p.__path__ = []
+        sys.modules[name] = p
+        return p
+
+    def _load(dotted, path):
+        spec = importlib.util.spec_from_file_location(dotted, path)
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules[dotted] = mod
+        spec.loader.exec_module(mod)
+        return mod
+
+    _pkg("_tcbdp")
+    _pkg("_tcbdp.core")
+    _pkg("_tcbdp.utils")
+    _load("_tcbdp.utils.model_config", os.path.join(root, "utils", "model_config.py"))
+    return _load("_tcbdp.core.slime_builder",
+                 os.path.join(root, "core", "slime_builder.py"))
+
+
+@pytest.fixture(scope="module")
+def builder_src():
+    return inspect.getsource(_load_builder_module())
+
+
+def test_builder_does_not_pin_use_distributed_optimizer(builder_src):
+    hits = re.findall(r"^\s*args\.use_distributed_optimizer\s*=.*$",
+                      builder_src, flags=re.MULTILINE)
+    assert not hits, (
+        "the builder assigns use_distributed_optimizer:\n  "
+        + "\n  ".join(h.strip() for h in hits)
+        + "\nThe engine derives this flag for the DDP config separately, so a "
+          "second derivation here can disagree with it -- and when it does, DDP "
+          "reduce-scatters gradients for an optimizer that needs an all-reduce "
+          "and every rank steps with a partly unreduced gradient."
+    )
+
+
+def test_builder_does_not_pass_the_flag_on_the_cli(builder_src):
+    # The CLI is the other way the service could pin it, and it reaches the
+    # actors (unlike post-parse args.X), so it would be just as wrong.
+    assert "--use-distributed-optimizer" not in builder_src
+    assert "--no-use-distributed-optimizer" not in builder_src

--- a/tests/test_miles_pack_length.py
+++ b/tests/test_miles_pack_length.py
@@ -1,0 +1,131 @@
+"""The miles pack length must clear the kernel's batch-invariance threshold.
+
+`get_batch` rounds each microbatch's packed token stream up to a multiple of
+`tp_size * data_pad_size_multiplier`, so that multiplier decides the M handed
+to every GEMM in the round. `linear_fc2` (K=4864 -> N=896, the model's only
+large-K GEMM) selects a different cuBLAS K-reduction below M=352, which makes
+the client's own segmentation pick the kernel: at the stock 128, fb(3) packs
+to 256 and fb(5) to 384, and a datum's returned logprobs move by up to 0.38
+nats with how the client chunked its round.
+
+Measured on the cluster (specs/014-gate-suite/INVESTIGATION-miles-split.md):
+SPLIT_INV goes 5.169e-02 -> 2.882e-07 and the forward becomes bit-identical
+once every pack clears the threshold.
+
+Two things are asserted, and the second is the one that has bitten before:
+the value must clear 352, and it must ride the CLI list — post-parse
+namespace mutations never reach the actors (the same root cause as the
+dropped AdamParams and the ignored checkpoint_path).
+"""
+import importlib.util
+import os
+import sys
+import types
+
+import pytest
+
+# The measured switch point for linear_fc2 on H200 / TE 2.17 / Qwen2.5-0.5B.
+# Not a constant of nature — re-measure with probes/bi_fc2_bisect.py when the
+# model shape, GPU or cuBLAS changes.
+FC2_BATCH_INVARIANCE_THRESHOLD = 352
+
+
+def _load_builder_module():
+    """Import slime_builder.py without dragging FastAPI in via the package init."""
+    try:  # in-container / installed layout
+        from tinkercloud.training.core import slime_builder as m
+        return m
+    except ImportError:
+        pass
+    root = os.path.join(os.path.dirname(__file__), os.pardir, "training")
+
+    def _pkg(name):
+        p = types.ModuleType(name)
+        p.__path__ = []
+        sys.modules[name] = p
+        return p
+
+    def _load(dotted, path):
+        spec = importlib.util.spec_from_file_location(dotted, path)
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules[dotted] = mod
+        spec.loader.exec_module(mod)
+        return mod
+
+    _pkg("_tcb")
+    _pkg("_tcb.core")
+    _pkg("_tcb.utils")
+    # slime_builder does `from ..utils.model_config import ...`, so that leaf
+    # has to exist under the alias package before the builder is executed.
+    _load("_tcb.utils.model_config", os.path.join(root, "utils", "model_config.py"))
+    return _load("_tcb.core.slime_builder",
+                 os.path.join(root, "core", "slime_builder.py"))
+
+
+# Qwen2.5-0.5B, the shape every number in the investigation was measured on.
+MODEL_CONFIG = {
+    "num_layers": 24,
+    "hidden_size": 896,
+    "ffn_hidden_size": 4864,
+    "num_attention_heads": 14,
+    "num_query_groups": 2,
+    "kv_channels": 64,
+    "vocab_size": 151936,
+    "norm_epsilon": 1e-6,
+    "rotary_base": 1000000,
+    "tie_word_embeddings": True,
+}
+
+
+def _build(builder_mod):
+    """The CLI list the builder hands miles' parse_args, for a small model."""
+    return builder_mod.SlimeArgumentBuilder(
+        default_save_dir="/tmp/ckpt"
+    )._build_minimal_args(
+        hf_model_path="/tmp/model",
+        model_config=MODEL_CONFIG,
+        tp_size=1,
+        pp_size=1,
+        cp_size=1,
+        megatron_checkpoint_path="/tmp/mcore",
+    )
+
+
+@pytest.fixture(scope="module")
+def cli():
+    return _build(_load_builder_module())
+
+
+def _flag_value(cli, name):
+    """The value following `name`, or None if the flag is absent."""
+    return cli[cli.index(name) + 1] if name in cli else None
+
+
+def test_pad_multiplier_is_on_the_cli(cli):
+    # Not a post-parse args.X assignment: those never reach the Ray actors,
+    # which is how the AdamParams and checkpoint_path defects happened.
+    assert "--data-pad-size-multiplier" in cli
+
+
+def test_pad_multiplier_clears_the_fc2_threshold(cli):
+    value = int(_flag_value(cli, "--data-pad-size-multiplier"))
+    assert value > FC2_BATCH_INVARIANCE_THRESHOLD, (
+        f"pack lengths are multiples of {value}, so a call can pack to {value} "
+        f"-- at or below the {FC2_BATCH_INVARIANCE_THRESHOLD}-token switch "
+        f"point of linear_fc2, which makes the gradient depend on how the "
+        f"client segmented its round"
+    )
+
+
+def test_pad_multiplier_divides_the_dynamic_budget(cli):
+    # max_tokens_per_gpu floors at 8192. A multiplier that divides it adds no
+    # padding at all to production-sized packs; one that does not taxes every
+    # full microbatch.
+    value = int(_flag_value(cli, "--data-pad-size-multiplier"))
+    assert 8192 % value == 0, f"{value} does not divide the 8192-token budget"
+
+
+def test_pad_multiplier_is_overridable(monkeypatch):
+    monkeypatch.setenv("SLIME_DATA_PAD_MULT", "1024")
+    cli = _build(_load_builder_module())
+    assert _flag_value(cli, "--data-pad-size-multiplier") == "1024"

--- a/training/core/slime_builder.py
+++ b/training/core/slime_builder.py
@@ -442,7 +442,17 @@ class SlimeArgumentBuilder:
         args.context_parallel_size = cp_size
         args.virtual_pipeline_model_parallel_size = None
         args.sequence_parallel = cp_size > 1  # Enable sequence parallel with CP>1
-        args.use_distributed_optimizer = False
+        # use_distributed_optimizer is deliberately NOT set here. miles derives
+        # the DDP config's copy of it independently (bridge_lora_helpers.py:
+        # "muon" not in args.optimizer), so pinning it False made the two
+        # disagree: DDP reduce-scattered the grad buffer while the optimizer was
+        # the non-distributed one, which needs a full all-reduce. Each rank then
+        # held the summed gradient only on its own 1/dp shard and its own
+        # UNREDUCED gradient everywhere else, and stepped the whole parameter set
+        # with it -- so the ranks diverged and the gradient depended on which
+        # rank a datum landed on and on the DP width. Letting the engine own the
+        # flag keeps its derivations from drifting apart.
+        # specs/014-gate-suite/INVESTIGATION-miles-split.md §DEFECT 2.
         args.num_gpus_per_node = num_gpus
         args.actor_num_gpus_per_node = num_gpus
         args.actor_num_nodes = 1

--- a/training/core/slime_builder.py
+++ b/training/core/slime_builder.py
@@ -215,6 +215,22 @@ class SlimeArgumentBuilder:
             # Training config
             '--seq-length', '512',
             '--micro-batch-size', '1',
+            # Pack length must clear the kernel's batch-invariance threshold.
+            # get_batch rounds each microbatch's packed stream up to a multiple
+            # of tp_size * this value. linear_fc2 (K=4864 -> N=896, the only
+            # large-K GEMM) picks a different cuBLAS K-reduction below M=352,
+            # so at the stock 128 a client's segmentation selects the kernel:
+            # fb(3) packs to 256 (one kernel), fb(5) to 384 (another), and a
+            # datum's own returned logprobs move up to 0.38 nats with how the
+            # client chunked its round. 512 is the smallest power of two above
+            # the threshold and divides the 8192-token dynamic budget exactly,
+            # so production-sized packs gain no padding at all. Measured:
+            # 5.169e-02 -> 2.882e-07 on SPLIT_INV (specs/014-gate-suite
+            # INVESTIGATION-miles-split.md). 352 is a property of this GEMM on
+            # this GPU and cuBLAS, not a constant — re-measure with
+            # probes/bi_fc2_bisect.py on a new model shape or GPU.
+            '--data-pad-size-multiplier',
+            os.environ.get('SLIME_DATA_PAD_MULT', '512'),
             '--global-batch-size', str(global_batch_size),
             # RL algorithm
             '--advantage-estimator', os.environ.get('SLIME_ADVANTAGE_ESTIMATOR', 'grpo'),


### PR DESCRIPTION
Two correctness defects in the miles backend, both found by the gate suite's
invariance probes, both root-caused to a measured mechanism and repaired.
Full measurement log: `specs/014-gate-suite/INVESTIGATION-miles-split.md`.

## Defect 1 — pack length selects the kernel (`d69e86d`)

`get_batch` rounds each microbatch's packed stream up to a multiple of
`tp_size * data_pad_size_multiplier`, so that multiplier decides the `M`
handed to every GEMM in the round. `linear_fc2` (K=4864 → N=896, the model's
only large-K GEMM) picks a different cuBLAS K-reduction below **M=352**, so at
the stock 128 the client's own segmentation selects the kernel: `fb(3)` packs
to 256, `fb(5)` to 384, and a datum's returned logprobs move by up to **0.38
nats** with how the client chunked its round.

Set to **512** on the CLI — the smallest power of two above the threshold that
also divides the 8192-token dynamic budget exactly, so production-sized packs
gain no padding at all and the 5.1× dynamic-batching speedup is kept. The CLI
placement is load-bearing: post-parse `args.X` assignments never reach the Ray
actors (the same root cause as the dropped AdamParams and the ignored
`checkpoint_path`).

| | before | after |
|---|---|---|
| dp=1 `SPLIT_INV` worst arm | 7.357e-04 | **2.882e-07** |
| dp=1 forward, every datum | up to 0.38 nats apart | **bit-identical** |
| dp=2 aligned `[4,4]` | 3.258e-03 | **9.243e-08** |

`SLIME_DATA_PAD_MULT` overrides it. 352 is a property of this GEMM/GPU/cuBLAS,
not a constant — re-measure with `probes/bi_fc2_bisect.py` when the shape, GPU
or cuBLAS changes. The real fix is batch-invariant kernels on the TE path
(slime #2262's approach); this is a measured, tested stopgap that costs nothing
at production pack sizes.

## Defect 2 — the DP reduction and the optimizer disagreed (`f6101a5`)

The reduction and the optimizer that consumes it were built from **two
independent derivations of the same flag**:

- miles `bridge_lora_helpers.py`: `"muon" not in args.optimizer` → **True** →
  the finalization **reduce-scatters** the grad buffer.
- the builder pinned `args.use_distributed_optimizer` → **False** →
  `Float16OptimizerWithFloat16Params`, the *non-distributed* optimizer, which
  needs a full **all-reduce** and reduces its grad norm over the model-parallel
  group alone (one rank at TP=1).

So after finalization each rank held the summed gradient **only on its own
1/dp shard** and its own *unreduced local* gradient everywhere else — then
stepped the whole parameter set with it. The ranks came out with different
gradients, different norms, different clip factors (`clip_grad=1.0`, so every
step is scaled by 1/‖g‖) and different weights. The client was shown rank 0's.

Measured at dp=2 (Qwen2.5-0.5B, 8 datums, lr=0, TP=1, forward bit-identical):

```
rank0 local 131.530   rank1 local 139.310   true ||sum|| 123.481
post-finalize         rank0 102.787         rank1  96.936   <- the ranks DISAGREE
```

Neither symptom needs the client to segment its round. Datum order is something
any client varies; DP width is a service-side allocation decision no client
declares.

| | before | after |
|---|---|---|
| `grad_norm` at dp = 1 / 2 / 4 | 122.690 / 102.435 / 82.564 (16.5 %, 32.7 % apart) | 123.48142 / 123.48146 / 123.48148 (**≤ 4.2e-07**) |
| permuting one 8-datum call, dp=2 | rel 5.1e-03 | **bit-identical** |
| permuting one 8-datum call, dp=4 | rel 6.3e-02 | **bit-identical** |

The reduced buffer now equals the probe's own all-reduced ground truth to the
digit, on both ranks.

**Why this repair.** Three were measured and all three give a bit-identical
result: pinning the flag `True` here, making miles read `args` instead of
re-deriving, and this one — dropping the override so the engine owns it. This
one is preferred because it *removes* a derivation rather than adding a third,
and it needs no engine change.

**One honest caveat.** After one real optimizer step the widths are not
bit-identical: post-step Σlogprobs land 0.10 apart, against 15.25 before. That
residual is Adam's first step, which is nearly `lr·sign(g)` and so flips
coordinates whose gradient sits within the fp floor of zero. The gradient
itself agrees to 3e-07.

## Testing

- `tests/test_miles_pack_length.py` (4) — the flag rides the CLI, its value
  clears 352, it divides the budget, the env override works.
- `tests/test_miles_dp_reduction.py` (2, new) — the builder must not own
  `use_distributed_optimizer`, on the namespace or the CLI. The regression is
  guarded at source level on purpose: the bug was never a wrong *value*, it was
  a second derivation of a flag the engine already derives.

Both files pass; `ruff check` clean. The rest of `tests/` needs the container
(several modules `sys.exit(1)` at import without the server deps) and fails
identically on unmodified `main`.

Verified live on ns.config (4×H200, `tinkercloud-miles`) with shipped defaults
— dynamic batching on, no env overrides — at NUM_GPUS 1, 2 and 4. All
instrumentation reverted; the pod is back on shipped defaults.
