### PR TITLE
seed: the client's declared seed must reach the initializer

### DIFF
--- a/tests/test_miles_dp_reduction.py
+++ b/tests/test_miles_dp_reduction.py
@@ -93,3 +93,13 @@ def test_builder_does_not_pass_the_flag_on_the_cli(builder_src):
     # actors (unlike post-parse args.X), so it would be just as wrong.
     assert "--use-distributed-optimizer" not in builder_src
     assert "--no-use-distributed-optimizer" not in builder_src
+
+
+def test_client_seed_rides_the_cli(builder_src):
+    # LoraConfig.seed was accepted by the API and read by nobody. Megatron's own
+    # default is 1234, so miles was reproducible by accident while ignoring
+    # whatever the client declared. specs/014-gate-suite §THE nemo_rl PEER PROBE.
+    assert "'--seed'" in builder_src, "the client's seed must reach the engine"
+    assert "lora_config or {}).get('seed')" in builder_src, (
+        "--seed must carry the client's declared value, not a constant"
+    )

--- a/training/backends/nemo_rl/builder.py
+++ b/training/backends/nemo_rl/builder.py
@@ -278,6 +278,17 @@ class NemoRLArgumentBuilder(ArgumentBuilder):
             },
         }
 
+        # The client's declared seed. The DTensor worker builds the model and
+        # applies LoRA under torch's process-global RNG and never seeds it, so
+        # without this two creations at the same seed start from different
+        # weights -- measured: pre-step sum-logprobs -887.7514 / -887.3088 /
+        # -887.2706 for one seed (specs/014-gate-suite §THE nemo_rl PEER PROBE).
+        # Carried as config rather than an env var so it is per-model and does
+        # not race between concurrent creates. The worker must read it; see
+        # probes/fix_nemorl_seed.py for the engine-side half.
+        if lora_config and lora_config.get("seed") is not None:
+            policy_config["seed"] = int(lora_config["seed"])
+
         if lora_config and lora_config.get("rank", 0) > 0:
             # All-linear coverage (attention + MLP) to match hosted Tinker
             # semantics — per the Tinker LoRA primer, attention-only LoRA

--- a/training/core/slime_builder.py
+++ b/training/core/slime_builder.py
@@ -231,6 +231,12 @@ class SlimeArgumentBuilder:
             # probes/bi_fc2_bisect.py on a new model shape or GPU.
             '--data-pad-size-multiplier',
             os.environ.get('SLIME_DATA_PAD_MULT', '512'),
+            # The client's declared seed, which decides the LoRA initializer.
+            # Megatron's own default is 1234, so omitting this was reproducible
+            # by accident while silently ignoring whatever the client asked for
+            # -- the API accepted the field and nothing read it. On the CLI, not
+            # the post-parse namespace: that never reaches the Ray actors.
+            '--seed', str((lora_config or {}).get('seed') or 1234),
             '--global-batch-size', str(global_batch_size),
             # RL algorithm
             '--advantage-estimator', os.environ.get('SLIME_ADVANTAGE_ESTIMATOR', 'grpo'),


### PR DESCRIPTION
`LoraConfig.seed` is declared in `training/models/requests.py` and carried
through `model_service` into every backend's `create_model` as part of
`lora_config`. **No training backend read it.** Grepping for a consumer finds
only the verl *sampling* path, which is a different field.

The two backends fail differently when nobody sets a seed:

- **miles was reproducible by accident.** Megatron seeds from `--seed`, whose
  default is 1234, so every run started from the same weights — while silently
  ignoring whatever the client declared. Two clients asking for different seeds
  got the same model, with no error.
- **nemo_rl was not reproducible at all.** Its DTensor worker builds the model
  and applies LoRA under torch's process-global RNG and never seeds it
  (`grep -c seed` on `dtensor_policy_worker_v2.py` and `base_policy_worker.py`:
  zero, both). Only the *Megatron* worker computes a seed, and that one is for
  the inference engine and derived from rank, not from the client. Two creations
  at one seed gave `grad_norm` 3194.760009765625 and 3270.383544921875.

## What this PR changes

Service-side only:

- **miles** — `--seed` on the **CLI list**, defaulting to Megatron's own 1234 so
  the shipped default is byte-identical. On the CLI, not the post-parse
  namespace: that never reaches the Ray actors, which is the lesson the
  pack-length defect already paid for.
- **nemo_rl** — into the policy config as `seed`. Carried as config rather than
  an env var so it is per-model and cannot race between concurrent creates.

## The other half

nemo_rl's worker has to read the key. That patch is
`specs/014-gate-suite/probes/fix_nemorl_seed.py` in the monorepo — four lines
calling nemo_rl's own `set_seed(config["seed"])` at the top of the DTensor
worker's `__init__`, before any model construction. Upstream it belongs in
`base_policy_worker.py` so every worker inherits it. Absent seed leaves
behaviour exactly as it was.

## Measured with both halves applied (dp=4, Qwen2.5-0.5B r=32)

| | seed 7, run A | seed 7, run B | seed 99 |
|---|---|---|---|
| `grad_norm` | 3141.80859375 | **3141.80859375** | 3208.8779296875 |
| post-step Σlogprobs | −791.7306575775146 | **−791.7306575775146** | −790.7908353805542 |
| datum-0 move | 6.33528995513916 | **6.33528995513916** | 6.366323471069336 |
| total absolute move | 756.73961186409 | **756.73961186409** | 758.8928556442261 |

Same seed reproduces on every digit; a different seed moves every one of them.
`[TINKER-SEED]` appears once per policy worker in the server log, which is how
we know the value arrived.

One thing the table deliberately does not show: the **pre-step** logprobs are
−887.2705669403076 for all three, seed 7 and seed 99 alike. LoRA's `B` is
zero-initialized, so the adapter contributes nothing at step 0 and the forward
is the base model regardless of `A`. Pre-step logprobs are a comparability
check, not a seed check.

## Testing

`tests/test_miles_dp_reduction.py` gains a third test: the seed must ride the
CLI and must carry the client's declared value rather than a constant. Three
tests pass, `ruff` clean. The rest of `tests/` needs the container and fails
identically on unmodified `main`.

Found by `dp_width_probe` refusing to compare across widths whose pre-step
states disagreed — the instrument's own guard. Detail in
`specs/014-gate-suite/INVESTIGATION-miles-split.md` §THE SEED FIX.
