### PR TITLE
gates: the P1 checking layer, with the two invariants that caught defect 2 and the seed gap

### DIFF
--- a/gates/README.md
+++ b/gates/README.md
@@ -1,0 +1,81 @@
+# Gate Suite
+
+The checking layer for the TinkerCloud API as a shippable artifact.
+Design, phasing (P1/P2/P3), and SOTA positioning:
+`specs/014-gate-suite/design.md` in the monorepo.
+
+A gate is one composition — **invariant × trace × arm → verdict** —
+instead of a 300-line script:
+
+```python
+from gates import invariants, runner
+from gates.traces import SegSweep
+
+runner.run(
+    invariants.get("SPLIT_INV"),
+    SegSweep(model="Qwen/Qwen3-8B-Base", max_seq_len=8192, debug_train_only=True),
+    tag="nemo_rl_tp2",
+    out_dir="results",
+)
+```
+
+0.5B and 8B are two parameter points of one gate, not two files.
+
+```bash
+# on the server pod (TINKER_BASE_URL=http://localhost:8000)
+python -m gates.runner seg_sweep --tag nemo_rl --expect E0_ARBITRARY
+python -m gates.runner seg_sweep --tag miles --segmentations '8;4,4;2,6;6,2;2,6;8' \
+    --expect E0_ALIGNED_ONLY   # miles deadlocks on rank-imbalanced splits at dp>1
+python -m gates.runner seg_sweep --tag nemo_rl_tp2 --model Qwen/Qwen3-8B-Base \
+    --max-seq-len 8192 --debug-train-only --expect E0_ARBITRARY
+```
+
+Exit code 0 iff `passed` (strict invariant at its claimed level) or, when
+`--expect` is given, the outcome matches the prediction. Verdict JSONs
+conform to `verdicts/schema.json`.
+
+## Layout
+
+| Path | Role |
+|---|---|
+| `invariants.py` | registry: the paper's §3 contract as first-class objects |
+| `traces/` | canonical trace generators (the admission clause made executable) |
+| `drivers/` | run a trace through the public SDK/HTTP surface only |
+| `oracles/` | fp32 HF(+PEFT) oracle, rerun-envelope estimator (P1: pointers) |
+| `comparators.py` | E0 bitwise / E1 calibrated bar / E2 measured envelope |
+| `runner.py` | composition + uniform verdict JSON + CLI |
+| `verdicts/schema.json` | verdict schema (history in, certificate out) |
+| `calibration.json` | (P3) the two measured populations per scale |
+| `fixtures/` | (P3) frozen streams, content-addressed |
+
+## Migration map
+
+Standing gates and their source probes. Migrated gates preserve datum
+generators, arm naming, and verdict semantics token-for-token, so recorded
+results JSONs under `specs/*/probes/results/` remain comparable.
+
+| Gate | Invariant | Source | Status |
+|---|---|---|---|
+| G1b segmentation sweep (0.5B + 8B) | SPLIT_INV | `specs/008 probes/g1b_segmentation.py`, `specs/013 probes/g1b_8b.py` | **migrated** → `traces/seg_sweep.py` |
+| G1 grad-accum split | SPLIT_INV | `scripts/gates/g1_seam_parity.py` | pending (subsumed by seg_sweep default arms) |
+| G1c admission sweep | SPLIT_INV (admission clause) | `specs/008 probes/g1c_admission_sweep.py` | pending |
+| G2 client-order / pipelined | DEFER_OBS | `scripts/gates/g2_client_order.py`, `g2_pipelined.py` | pending |
+| G3 30-step SFT e2e | ENDPOINT_NLL | `scripts/gates/g3_sl_basic.py` | pending |
+| G4 pool isolation | ISOLATION | `scripts/gates/g4_pool_isolation.py` | pending |
+| G5 pinned-v0 + routing | PIN_DRIFT | `scripts/gates/g5_pinned_v0.py` | pending |
+| G6 batch-invariance | ISOLATION | `scripts/gates/g6_batch_invariance.py` | pending |
+| G7 reorder-drain | ISOLATION | `scripts/gates/g7_reorder_merge.py` | pending |
+| G8/G8e sampling + overlap | DEFER_OBS | `scripts/gates/g8_verl_sampling.py`, `g8e_overlap_check.py` | pending |
+| G9 adapter interchange | ADAPTER_ORACLE | `scripts/gates/g9_adapter_interchange.py` | pending |
+| G10 staleness-k | PIN_DRIFT (ver(S)) | `scripts/gates/g10_staleness.py` | pending |
+| logprob HF parity | ADAPTER_ORACLE | `scripts/gates/g_lp_hf_parity.py` | pending |
+
+One-off attribution probes (E2/RESID arms, `q4_rl_tenant.py`, analyze
+scripts) stay in their spec directories as historical record, per
+design.md §6 Q2.
+
+## CI tiers (P3)
+
+Smoke (0.5B, minutes) on every PR touching translation/backend code; full
+parity nightly; 8B weekly/manual; mandatory admission run before any
+engine-submodule bump.

--- a/gates/README.md
+++ b/gates/README.md
@@ -28,7 +28,25 @@ python -m gates.runner seg_sweep --tag miles --segmentations '8;4,4;2,6;6,2;2,6;
     --expect E0_ALIGNED_ONLY   # miles deadlocks on rank-imbalanced splits at dp>1
 python -m gates.runner seg_sweep --tag nemo_rl_tp2 --model Qwen/Qwen3-8B-Base \
     --max-seq-len 8192 --debug-train-only --expect E0_ARBITRARY
+
+# PARTITION_INV: one call, only the submission order changes (--debug-train-only
+# is required on miles below NUM_GPUS=4 -- start_engines dies on
+# reordered_gpu_ids[gpu_index] at NUM_GPUS=2)
+python -m gates.runner order_perm --tag miles_dp4 --seed 7 --debug-train-only \
+    --expect INVARIANT
+python -m gates.runner order_perm --tag nemo_rl_dp4 --seed 7 --debug-train-only \
+    --expect PARTITION_INVARIANT_ORDER_SENSITIVE
+
+# SEED_REPRO: does the backend read LoraConfig.seed at all
+python -m gates.runner seed_repro --tag nemo_rl_dp4 --debug-train-only \
+    --expect SEED_HONORED
 ```
+
+**DP width is not an arm anywhere in this suite.** Width is fixed by the
+server's `NUM_GPUS` at launch, so one gate process cannot sweep it: run the
+gate once per server configuration and diff the verdict JSONs. On a
+buffered backend the width comparison is not certifiable through the API at
+all — LoRA `B` is zero-initialized, so no step-0 observable can see `A`.
 
 Exit code 0 iff `passed` (strict invariant at its claimed level) or, when
 `--expect` is given, the outcome matches the prediction. Verdict JSONs
@@ -57,6 +75,8 @@ results JSONs under `specs/*/probes/results/` remain comparable.
 | Gate | Invariant | Source | Status |
 |---|---|---|---|
 | G1b segmentation sweep (0.5B + 8B) | SPLIT_INV | `specs/008 probes/g1b_segmentation.py`, `specs/013 probes/g1b_8b.py` | **migrated** → `traces/seg_sweep.py` |
+| Order permutation (partition sensitivity) | PARTITION_INV | `specs/014 probes/order_perm_probe.py` | **migrated** → `traces/order_perm.py` |
+| Seed reproducibility | SEED_REPRO | (none — found by hand, tinker-cloud `995945e` + `GavinZhu-GMI/RL` `faba0bfc3`) | **new** → `traces/seed_repro.py` |
 | G1 grad-accum split | SPLIT_INV | `scripts/gates/g1_seam_parity.py` | pending (subsumed by seg_sweep default arms) |
 | G1c admission sweep | SPLIT_INV (admission clause) | `specs/008 probes/g1c_admission_sweep.py` | pending |
 | G2 client-order / pipelined | DEFER_OBS | `scripts/gates/g2_client_order.py`, `g2_pipelined.py` | pending |

--- a/gates/__init__.py
+++ b/gates/__init__.py
@@ -1,0 +1,11 @@
+"""Gate suite: specification-first checking layer for the TinkerCloud API.
+
+Design + SOTA positioning: specs/014-gate-suite/design.md (monorepo).
+A gate is one composition: invariant x trace x arm -> verdict JSON
+(schema: gates/verdicts/schema.json). Invariants encode the paper's
+S3 contract; traces make its admission clause executable; drivers
+speak only the public SDK/HTTP surface; comparators discharge the
+claimed equivalence level (E0/E1/E2).
+"""
+
+GATES_VERSION = "0.1.0"

--- a/gates/comparators.py
+++ b/gates/comparators.py
@@ -1,0 +1,49 @@
+"""Comparators discharge a claimed equivalence level on a pair of observables.
+
+E0 = bit identity (compared on repr, so float64 round-trips exactly).
+E1 = |a-b| within a calibrated bar (bar placement: specs/014 design S3.7).
+E2 = value inside a measured rerun envelope.
+All return a Comparison; rel_diff is always computed for diagnosis, even
+when the verdict is bitwise.
+"""
+
+import math
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Comparison:
+    passed: bool
+    delta: float | None  # observed deviation (relative for E0/E1)
+    threshold: float | None  # bar / envelope half-width; None for E0
+
+
+def rel_diff(a: float, b: float) -> float:
+    if a == b:
+        return 0.0
+    if not (math.isfinite(a) and math.isfinite(b)) or a == 0:
+        return float("inf")
+    return abs(b - a) / abs(a)
+
+
+def e0_bitwise(a: float, b: float) -> Comparison:
+    return Comparison(passed=repr(a) == repr(b), delta=rel_diff(a, b), threshold=None)
+
+
+def e1_threshold(a: float, b: float, bar: float) -> Comparison:
+    d = abs(b - a)
+    return Comparison(passed=d <= bar, delta=d, threshold=bar)
+
+
+def e2_envelope(value: float, lo: float, hi: float) -> Comparison:
+    mid = (lo + hi) / 2
+    return Comparison(
+        passed=lo <= value <= hi, delta=abs(value - mid), threshold=(hi - lo) / 2
+    )
+
+
+REGISTRY = {
+    "e0_bitwise": e0_bitwise,
+    "e1_threshold": e1_threshold,
+    "e2_envelope": e2_envelope,
+}

--- a/gates/drivers/__init__.py
+++ b/gates/drivers/__init__.py
@@ -1,0 +1,6 @@
+"""Drivers run traces against an arm through the public surface only —
+a gate cannot reach an engine internal that a client could not
+(specs/014 design S3.3: the zero-instrumentation deployability trade).
+"""
+
+from gates.drivers.sdk import SDKDriver  # noqa: F401

--- a/gates/drivers/sdk.py
+++ b/gates/drivers/sdk.py
@@ -1,0 +1,81 @@
+"""Public-SDK driver: tinker.ServiceClient for model/fb calls, raw HTTP for
+optim_step + durable-future polling (same path the 008/013 probes used).
+"""
+
+import os
+import time
+
+
+class GateStepError(RuntimeError):
+    pass
+
+
+class SDKDriver:
+    def __init__(
+        self,
+        base_url: str | None = None,
+        api_key: str | None = None,
+        step_timeout_s: float = 1800,
+    ):
+        self.base_url = base_url or os.environ.get(
+            "TINKER_BASE_URL", "http://localhost:8000"
+        )
+        self.api_key = api_key or os.environ.get("TINKER_API_KEY", "tml-dev-key")
+        os.environ.setdefault("TINKER_BASE_URL", self.base_url)
+        os.environ.setdefault("TINKER_API_KEY", self.api_key)
+        self.step_timeout_s = step_timeout_s
+        self._sc = None
+
+    @property
+    def service_client(self):
+        if self._sc is None:
+            import tinker
+
+            self._sc = tinker.ServiceClient()
+        return self._sc
+
+    def create_training_client(
+        self,
+        base_model: str,
+        rank: int,
+        seed: int | None = None,
+        max_seq_len: int | None = None,
+        debug_train_only: bool = False,
+    ):
+        kwargs = {"base_model": base_model, "rank": rank}
+        if seed is not None:
+            kwargs["seed"] = seed
+        if max_seq_len is not None:
+            kwargs["max_seq_len"] = max_seq_len
+        if debug_train_only:
+            # no inference engine: weight-sync is guarded on it, and training
+            # observables (grad_norm) are unaffected
+            kwargs["debug_train_only"] = True
+        t0 = time.time()
+        tc = self.service_client.create_lora_training_client(**kwargs)
+        print(f"model_id: {tc.model_id} (boot {time.time() - t0:.1f}s)", flush=True)
+        return tc
+
+    def optim_step(self, model_id: str, lr: float = 0.0) -> dict:
+        import requests
+
+        hdrs = {"X-API-Key": self.api_key, "Content-Type": "application/json"}
+        r = requests.post(
+            f"{self.base_url}/api/v1/optim_step",
+            headers=hdrs,
+            json={"model_id": model_id, "adam_params": {"learning_rate": lr}},
+        )
+        r.raise_for_status()
+        rid = r.json()["request_id"]
+        deadline = time.time() + self.step_timeout_s
+        while time.time() < deadline:
+            fr = requests.post(
+                f"{self.base_url}/api/v1/retrieve_future/{rid}", headers=hdrs
+            )
+            if fr.status_code == 200:
+                return fr.json()
+            if fr.status_code == 408:
+                time.sleep(2)
+                continue
+            raise GateStepError(f"optim_step failed ({fr.status_code}): {fr.text[:1500]}")
+        raise GateStepError(f"optim_step timeout after {self.step_timeout_s}s")

--- a/gates/drivers/sdk.py
+++ b/gates/drivers/sdk.py
@@ -56,6 +56,30 @@ class SDKDriver:
         print(f"model_id: {tc.model_id} (boot {time.time() - t0:.1f}s)", flush=True)
         return tc
 
+    def delete_model(self, model_id: str) -> bool:
+        """Release the model's GPU resources. A gate MUST call this when it
+        finishes: miles does not auto-reap models, and a leftover model (plus
+        SGLang engines that outlive `ray stop`) wedges the next gate's
+        create_model in placement. Never raises — cleanup must not mask a
+        verdict."""
+        import requests
+
+        try:
+            r = requests.post(
+                f"{self.base_url}/api/v1/delete_model",
+                headers={"X-API-Key": self.api_key, "Content-Type": "application/json"},
+                json={"model_id": model_id},
+                timeout=300,
+            )
+            if r.status_code == 200:
+                print(f"deleted model {model_id}", flush=True)
+                return True
+            print(f"WARNING: delete_model {model_id} -> {r.status_code}: "
+                  f"{r.text[:300]}", flush=True)
+        except Exception as e:  # noqa: BLE001 - cleanup is best-effort
+            print(f"WARNING: delete_model {model_id} failed: {e}", flush=True)
+        return False
+
     def optim_step(self, model_id: str, lr: float = 0.0) -> dict:
         import requests
 

--- a/gates/invariants.py
+++ b/gates/invariants.py
@@ -1,0 +1,101 @@
+"""Invariant registry: the paper's S3 contract as first-class code objects.
+
+Each entry = (id, statement, claimed level, comparator, tolerance source,
+paper pointer). Gates and RequestValidator rules derive from this registry;
+verdict JSONs cite entries by id. Statements are one-line summaries — the
+normative text is the cited paper section / spec.
+"""
+
+from dataclasses import dataclass
+
+# Tolerance sources:
+#   "exact"                       E0: bit-identity, no tolerance
+#   "calibration:<key>"           E1: bar read from gates/calibration.json (P3)
+#   "measured:rerun_envelope"     E2: envelope estimated from rerun population
+
+
+@dataclass(frozen=True)
+class Invariant:
+    id: str
+    statement: str
+    level: str  # claimed equivalence level: "E0" | "E1" | "E2"
+    comparator: str  # key into comparators.REGISTRY
+    tolerance_source: str
+    paper_ref: str  # label in paper/main.tex (monorepo)
+
+
+REGISTRY: dict[str, Invariant] = {
+    inv.id: inv
+    for inv in [
+        Invariant(
+            id="SPLIT_INV",
+            statement=(
+                "fb(D1)..fb(DN) optim_step == fb(D) optim_step for every "
+                "contiguous segmentation D1..DN of a round's data"
+            ),
+            level="E0",
+            comparator="e0_bitwise",
+            tolerance_source="exact",
+            paper_ref="inv:split",
+        ),
+        Invariant(
+            id="DEFER_OBS",
+            statement=(
+                "deferring fb execution to optim_step is the identity on obs: "
+                "every eager key present, logprobs under pre-step weights W_k"
+            ),
+            level="E0",
+            comparator="e0_bitwise",
+            tolerance_source="exact",
+            paper_ref="inv:defer",
+        ),
+        Invariant(
+            id="ISOLATION",
+            statement=(
+                "co-located tenants observe what they would observe running "
+                "serialized: per-slot grad_norm + logprobs unchanged by co-tenants"
+            ),
+            level="E0",
+            comparator="e0_bitwise",
+            tolerance_source="exact",
+            paper_ref="sec:sched (multi-tenant co-location)",
+        ),
+        Invariant(
+            id="PIN_DRIFT",
+            statement=(
+                "a sampler pinned to ver(S)=v returns bit-stable outputs across "
+                "subsequent training steps; live samplers track post-step weights"
+            ),
+            level="E0",
+            comparator="e0_bitwise",
+            tolerance_source="exact",
+            paper_ref="sec:model (observation function, ver(S))",
+        ),
+        Invariant(
+            id="ADAPTER_ORACLE",
+            statement=(
+                "training-engine logprobs match an offline fp32 HF(+PEFT) oracle "
+                "on the exported adapter, within the calibrated E1 bar"
+            ),
+            level="E1",
+            comparator="e1_threshold",
+            tolerance_source="calibration:e1_bar",
+            paper_ref="sec:checking (model-derived metamorphic tests)",
+        ),
+        Invariant(
+            id="ENDPOINT_NLL",
+            statement=(
+                "endpoint NLL of a fixed recipe lands inside the measured "
+                "rerun envelope of the reference arm"
+            ),
+            level="E2",
+            comparator="e2_envelope",
+            tolerance_source="measured:rerun_envelope",
+            paper_ref="sec:model:eq (equivalence hierarchy, E2)",
+        ),
+    ]
+}
+
+
+def get(inv_id: str) -> Invariant:
+    return REGISTRY[inv_id]

--- a/gates/invariants.py
+++ b/gates/invariants.py
@@ -39,6 +39,34 @@ REGISTRY: dict[str, Invariant] = {
             paper_ref="inv:split",
         ),
         Invariant(
+            id="PARTITION_INV",
+            statement=(
+                "the round's gradient does not depend on which datums share a "
+                "data-parallel rank: permuting the submission order of a "
+                "single fb call leaves optim_step's gradient unchanged"
+            ),
+            level="E0",
+            comparator="e0_bitwise",
+            tolerance_source="exact",
+            # strictly stronger than SPLIT_INV -- the DP-reduction defect
+            # (tinker-cloud 39add0a) was invisible at SPLIT_INV's aligned arm
+            # yet caught by a single permuted call. The manuscript has no
+            # dedicated partition label yet; inv:split is the nearest.
+            paper_ref="inv:split (no dedicated partition label; see HANDOFF 0-NEXT19)",
+        ),
+        Invariant(
+            id="SEED_REPRO",
+            statement=(
+                "two models created with the same client-supplied seed give "
+                "the same gradient on the same data, and a different seed "
+                "gives a different one -- the seed is read, not defaulted"
+            ),
+            level="E0",
+            comparator="e0_bitwise",
+            tolerance_source="exact",
+            paper_ref="sec:model:obs (client-supplied seed; no dedicated label)",
+        ),
+        Invariant(
             id="DEFER_OBS",
             statement=(
                 "deferring fb execution to optim_step is the identity on obs: "

--- a/gates/oracles/__init__.py
+++ b/gates/oracles/__init__.py
@@ -1,0 +1,9 @@
+"""Oracles: external references a comparator can discharge E1/E2 against.
+
+P1 placeholder — migrates with the E1/E2 gates:
+  fp32 HF forward + HF+PEFT adapter oracle:
+      specs/009-e1-8b-calibration/probes/e1_8b_oracle.py,
+      scripts/gates/g9_adapter_interchange.py (export mode)
+  rerun-envelope estimator:
+      specs/013-a1-8b-spine/probes/ (e2_* / a5_* rerun population)
+"""

--- a/gates/runner.py
+++ b/gates/runner.py
@@ -8,6 +8,10 @@ ad hoc verdict/result formats.
              max_seq_len=8192, debug_train_only=True), tag="nemo_rl_tp2")
 
 CLI: python -m gates.runner seg_sweep --tag nemo_rl [--model ...] --out results
+
+DP width is not an arm anywhere in this suite: it is fixed by the server's
+NUM_GPUS at launch, so a width comparison means invoking the runner once per
+server configuration and diffing the verdict JSONs.
 """
 
 import argparse
@@ -131,7 +135,42 @@ def _build_seg_sweep(args) -> tuple[Invariant, object]:
     return invariants.get("SPLIT_INV"), trace
 
 
-TRACES = {"seg_sweep": _build_seg_sweep}
+def _build_order_perm(args) -> tuple[Invariant, object]:
+    from gates.traces.order_perm import OrderPerm, default_arms
+
+    trace = OrderPerm(
+        model=args.model,
+        rank=args.rank,
+        seq=args.seq,
+        n=args.n,
+        seed=args.seed,
+        max_seq_len=args.max_seq_len,
+        debug_train_only=args.debug_train_only,
+    )
+    trace.arms = default_arms(trace.n)
+    return invariants.get("PARTITION_INV"), trace
+
+
+def _build_seed_repro(args) -> tuple[Invariant, object]:
+    from gates.traces.seed_repro import DEFAULT_SEED, SeedRepro
+
+    return invariants.get("SEED_REPRO"), SeedRepro(
+        model=args.model,
+        rank=args.rank,
+        seq=args.seq,
+        n=args.n,
+        seed=args.seed if args.seed is not None else DEFAULT_SEED,
+        contrast_seed=args.contrast_seed,
+        max_seq_len=args.max_seq_len,
+        debug_train_only=args.debug_train_only,
+    )
+
+
+TRACES = {
+    "order_perm": _build_order_perm,
+    "seed_repro": _build_seed_repro,
+    "seg_sweep": _build_seg_sweep,
+}
 
 
 def main():
@@ -143,7 +182,12 @@ def main():
     ap.add_argument("--model", default="Qwen/Qwen2.5-0.5B")
     ap.add_argument("--rank", type=int, default=32)
     ap.add_argument("--seq", type=int, default=64)
-    ap.add_argument("--seed", type=int, default=None)
+    ap.add_argument("--n", type=int, default=8,
+                    help="datums per round (order_perm needs it even)")
+    ap.add_argument("--seed", type=int, default=None,
+                    help="fix LoRA init so runs at different dp are comparable")
+    ap.add_argument("--contrast-seed", type=int, default=99,
+                    help="seed_repro: the different-seed arm")
     ap.add_argument("--max-seq-len", type=int, default=None)
     ap.add_argument("--debug-train-only", action="store_true",
                     help="no inference engine (8B sweeps run this way)")

--- a/gates/runner.py
+++ b/gates/runner.py
@@ -1,0 +1,144 @@
+"""Runner: gate = invariant x trace x arm -> uniform verdict JSON
+(gates/verdicts/schema.json). Replaces the per-spec probe scripts'
+ad hoc verdict/result formats.
+
+  from gates import invariants, runner
+  from gates.traces import SegSweep
+  runner.run(invariants.get("SPLIT_INV"), SegSweep(model="Qwen/Qwen3-8B-Base",
+             max_seq_len=8192, debug_train_only=True), tag="nemo_rl_tp2")
+
+CLI: python -m gates.runner seg_sweep --tag nemo_rl [--model ...] --out results
+"""
+
+import argparse
+import hashlib
+import json
+import os
+from datetime import datetime, timezone
+
+from gates import GATES_VERSION, comparators, invariants
+from gates.drivers import SDKDriver
+from gates.invariants import Invariant
+
+
+def _sha256(obj) -> str:
+    return hashlib.sha256(
+        json.dumps(obj, sort_keys=True, default=repr).encode()
+    ).hexdigest()
+
+
+def run(
+    invariant: Invariant,
+    trace,
+    tag: str,
+    out_dir: str | None = None,
+    expect: str | None = None,
+    driver=None,
+) -> dict:
+    driver = driver or SDKDriver()
+    comparator = comparators.REGISTRY[invariant.comparator]
+
+    print(f"[{tag}] gate {invariant.id}.{trace.name} ({invariant.level})", flush=True)
+    rows = trace.execute(driver)
+    v = trace.verdict(rows, comparator)
+
+    ref = rows[0]
+    print(f"\n[{tag}] vs {ref['arm']} = {ref['grad_norm']!r}"
+          if "grad_norm" in ref else f"\n[{tag}]")
+    for r in rows[1:]:
+        if "bit_identical" in r:
+            line = ("BIT-IDENTICAL" if r["bit_identical"]
+                    else f"differs, rel={r['rel_diff']:.3e}")
+            print(f"  {r['arm']:10s} {str(r.get('segmentation', '')):8s} {line}")
+
+    verdict_doc = {
+        "gate": f"{invariant.id}.{trace.name}",
+        "invariant": invariant.id,
+        "claimed_level": invariant.level,
+        "arm": {"tag": tag, "expect": expect},
+        "trace": {"name": trace.name, "params": trace.params()},
+        "outcome": v["outcome"],
+        "verdict": v["verdict"],
+        "passed": v["passed"],
+        "expect_met": (v["outcome"] == expect) if expect else None,
+        "delta": v.get("delta"),
+        "threshold": v.get("threshold"),
+        "observations": rows,
+        "detail": {
+            k: val
+            for k, val in v.items()
+            if k not in ("outcome", "verdict", "passed", "delta", "threshold")
+        },
+        "artifacts": {
+            "observations_sha256": _sha256(rows),
+            "trace_sha256": _sha256(trace.params()),
+        },
+        "meta": {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "base_url": getattr(driver, "base_url", None),
+            "gates_version": GATES_VERSION,
+        },
+    }
+
+    print(f"\n[{tag}] {v['verdict']}")
+    if expect:
+        print(f"[{tag}] expected {expect}: "
+              f"{'MET' if verdict_doc['expect_met'] else 'NOT MET'}")
+    if out_dir:
+        os.makedirs(out_dir, exist_ok=True)
+        path = os.path.join(
+            out_dir, f"{invariant.id}.{trace.name}_{tag}.json".lower()
+        )
+        with open(path, "w") as f:
+            json.dump(verdict_doc, f, indent=2)
+        print(f"wrote {path}")
+    return verdict_doc
+
+
+def _build_seg_sweep(args) -> tuple[Invariant, object]:
+    from gates.traces.seg_sweep import SegSweep, parse_segmentations
+
+    trace = SegSweep(
+        model=args.model,
+        rank=args.rank,
+        seq=args.seq,
+        seed=args.seed,
+        max_seq_len=args.max_seq_len,
+        debug_train_only=args.debug_train_only,
+    )
+    if args.segmentations:
+        trace.arms = parse_segmentations(args.segmentations, trace.n)
+    return invariants.get("SPLIT_INV"), trace
+
+
+TRACES = {"seg_sweep": _build_seg_sweep}
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("trace", choices=sorted(TRACES))
+    ap.add_argument("--tag", required=True,
+                    help="arm label: nemo_rl | nemo_rl_tp2 | verl | miles | ...")
+    ap.add_argument("--out", default="results")
+    ap.add_argument("--model", default="Qwen/Qwen2.5-0.5B")
+    ap.add_argument("--rank", type=int, default=32)
+    ap.add_argument("--seq", type=int, default=64)
+    ap.add_argument("--seed", type=int, default=None)
+    ap.add_argument("--max-seq-len", type=int, default=None)
+    ap.add_argument("--debug-train-only", action="store_true",
+                    help="no inference engine (8B sweeps run this way)")
+    ap.add_argument("--segmentations", default=None,
+                    help="override arms, e.g. '8;4,4;2,6;6,2;2,6;8' "
+                         "(first=reference, last=determinism control)")
+    ap.add_argument("--expect", default=None,
+                    help="grade the outcome against a prediction, "
+                         "e.g. E0_ARBITRARY (buffered) / E0_ALIGNED_ONLY (eager)")
+    args = ap.parse_args()
+
+    inv, trace = TRACES[args.trace](args)
+    doc = run(inv, trace, tag=args.tag, out_dir=args.out, expect=args.expect)
+    raise SystemExit(0 if doc["passed"] or doc["expect_met"] else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/gates/runner.py
+++ b/gates/runner.py
@@ -27,6 +27,21 @@ def _sha256(obj) -> str:
     ).hexdigest()
 
 
+def _release_models(trace, driver) -> None:
+    """Delete every model the trace created. Best-effort and never raises —
+    a failed cleanup must not turn a real verdict into an exception."""
+    models = getattr(trace, "created_models", None) or []
+    delete = getattr(driver, "delete_model", None)
+    if not models or delete is None:
+        return
+    for model_id in models:
+        try:
+            delete(model_id)
+        except Exception as e:  # noqa: BLE001 - a leaked model must not eat a verdict
+            print(f"WARNING: releasing {model_id} raised {e!r}", flush=True)
+    models.clear()
+
+
 def run(
     invariant: Invariant,
     trace,
@@ -39,7 +54,12 @@ def run(
     comparator = comparators.REGISTRY[invariant.comparator]
 
     print(f"[{tag}] gate {invariant.id}.{trace.name} ({invariant.level})", flush=True)
-    rows = trace.execute(driver)
+    try:
+        rows = trace.execute(driver)
+    finally:
+        # A gate owns the models it creates. miles does not auto-reap them, so
+        # skipping this wedges the next gate's create_model in placement.
+        _release_models(trace, driver)
     v = trace.verdict(rows, comparator)
 
     ref = rows[0]

--- a/gates/traces/__init__.py
+++ b/gates/traces/__init__.py
@@ -1,0 +1,6 @@
+"""Canonical trace generators — the admission clause L(ref) ⊆ L(I) made
+executable. Each trace is pure data + an execute(driver) method; SDK/torch
+imports stay inside execute so verdict logic loads without a GPU stack.
+"""
+
+from gates.traces.seg_sweep import SegSweep  # noqa: F401

--- a/gates/traces/__init__.py
+++ b/gates/traces/__init__.py
@@ -3,4 +3,6 @@ executable. Each trace is pure data + an execute(driver) method; SDK/torch
 imports stay inside execute so verdict logic loads without a GPU stack.
 """
 
+from gates.traces.order_perm import OrderPerm  # noqa: F401
+from gates.traces.seed_repro import SeedRepro  # noqa: F401
 from gates.traces.seg_sweep import SegSweep  # noqa: F401

--- a/gates/traces/common.py
+++ b/gates/traces/common.py
@@ -1,0 +1,36 @@
+"""Shared trace ingredients.
+
+synthetic_lm_datums reproduces the generator of scripts/gates/g1_seam_parity.py
+and specs/008+013 g1b probes token-for-token, so gate results stay comparable
+with the recorded results JSONs.
+"""
+
+
+def synthetic_token_rows(n: int, seq: int, vocab: int = 50000) -> list[list[int]]:
+    return [
+        [(1000 + i * 7919 + j * 104729) % vocab for j in range(seq)]
+        for i in range(n)
+    ]
+
+
+def synthetic_lm_datums(n: int, seq: int):
+    import torch
+    from tinker import types
+
+    out = []
+    for toks in synthetic_token_rows(n, seq):
+        inp, tgt = toks[:-1], toks[1:]
+        out.append(
+            types.Datum(
+                model_input=types.ModelInput.from_ints(inp),
+                loss_fn_inputs={
+                    "weights": types.TensorData.from_torch(
+                        torch.ones(len(inp), dtype=torch.float32)
+                    ),
+                    "target_tokens": types.TensorData.from_torch(
+                        torch.tensor(tgt, dtype=torch.long)
+                    ),
+                },
+            )
+        )
+    return out

--- a/gates/traces/order_perm.py
+++ b/gates/traces/order_perm.py
@@ -1,0 +1,266 @@
+"""PARTITION_INV order-permutation probe, consolidated from
+specs/014-gate-suite/probes/order_perm_probe.py. Datum generator, arm
+naming and verdict semantics are preserved, so the 13 recorded
+`order_perm_*.json` runs replay against this logic (see
+tests/test_gates_order_perm.py).
+
+Strictly stronger than SPLIT_INV and it needs no segmentation at all:
+ONE call, all n datums, only the submission order changes. miles assigns
+sample i of a call to rank `i % dp`, so SWAP_PAIRS ([1,0,3,2,...]) moves
+every datum to the OTHER rank while changing nothing else -- same call,
+same count, no pad, same weights, lr=0. A pure-sum gradient is
+order-invariant in exact arithmetic (Thm 1), so any deviation beyond the
+fp floor is a defect.
+
+The three-way verdict keys on the fact that SWAP_PAIRS and REVERSE induce
+the SAME rank partition but different concatenation orders -- the two
+failure modes a binary order-invariance verdict confounds (they coincided
+on miles, which is why the confusion went unnoticed):
+  INVARIANT                            every permuted arm bit-identical
+  PARTITION_SENSITIVE                  SWAP_PAIRS != IDENT and == REVERSE:
+                                       the gradient is a function of which
+                                       datums share a rank (the miles
+                                       signature, pre-`39add0a`)
+  PARTITION_INVARIANT_ORDER_SENSITIVE  SWAP_PAIRS bit-identical, something
+                                       else moves: fp addition is
+                                       commutative but not associative
+                                       (the buffered/nemo_rl signature)
+  ORDER_SENSITIVE_UNCLASSIFIED         neither known signature
+  INCONCLUSIVE                         determinism control failed
+
+DP WIDTH IS NOT AN ARM AND CANNOT BE. Width is fixed by the server's
+NUM_GPUS at launch, so one gate process cannot sweep it: invoke the runner
+once per server configuration and compare the verdicts afterwards. On a
+buffered backend the width comparison is not certifiable through the API
+at all -- LoRA B is zero-initialized, so no step-0 observable can see A.
+
+WHAT THE ARMS MEAN IS ITSELF WIDTH-DEPENDENT, and the trace is blind to
+the width. Under `rank = position % dp`, the grouping an arm induces is
+the partition of datum indices by position residue, so at n=8:
+  dp=2  SWAP_PAIRS moves every datum to the other rank -- a real grouping
+        change, which is the case the three-way verdict was validated on
+  dp=4  every default arm preserves the grouping and changes only which
+        rank holds which group (and the order within it), so a residual
+        there is a reduction-order effect, not partition sensitivity
+Hence a run whose arms disagree lands in ORDER_SENSITIVE_UNCLASSIFIED
+rather than being forced into a signature: at dp=4 the gate genuinely
+cannot tell the two apart, and saying so is the honest verdict. Seen
+live -- miles dp=4 at the engine default seed puts SWAP_PAIRS 6.4e-08
+off IDENT while REVERSE is bit-identical, reproducibly.
+"""
+
+import time
+from dataclasses import dataclass, field
+
+from gates.comparators import Comparison, rel_diff
+
+# The determinism control; every other arm is a genuine permutation.
+CONTROL_ARM = "IDENT_R"
+# The partition arm: at dp>=2 it sends every datum to a different rank.
+PARTITION_ARM = "SWAP_PAIRS"
+# Same partition as PARTITION_ARM, different concatenation order.
+ORDER_ARM = "REVERSE"
+
+
+def default_arms(n: int) -> list[tuple[str, list[int]]]:
+    """(name, submission order). SWAP_PAIRS flips every datum's rank at
+    dp=2; REVERSE induces the same partition by a coarser route; the _R
+    arms are the reproducibility and determinism controls."""
+    if n % 2:
+        raise ValueError(f"n must be even for {PARTITION_ARM}, got {n}")
+    ident = list(range(n))
+    swap = [i ^ 1 for i in range(n)]
+    return [
+        ("IDENT", ident),
+        (PARTITION_ARM, swap),
+        (ORDER_ARM, list(reversed(ident))),
+        (PARTITION_ARM + "_R", list(swap)),
+        (CONTROL_ARM, list(ident)),
+    ]
+
+
+OUTCOME_VERDICTS = {
+    "INCONCLUSIVE": "INCONCLUSIVE: the repeated IDENT arm is not reproducible",
+    "NO_DETERMINISM_CONTROL": (
+        "INCONCLUSIVE: the sweep carries no repeated IDENT arm, so a moved "
+        "gradient cannot be told from run-to-run noise"
+    ),
+    "NO_PARTITION_ARM": (
+        "INCONCLUSIVE: the sweep contains no rank-flipping permutation, so it "
+        "cannot ask whether the gradient depends on the partition"
+    ),
+    "INVARIANT": (
+        "INVARIANT: permuting the round leaves the gradient bit-identical "
+        "under every arm -- neither the rank partition nor the concatenation "
+        "order reaches it"
+    ),
+    "PARTITION_SENSITIVE": (
+        "PARTITION-SENSITIVE: two different permutations inducing the SAME "
+        "rank partition agree bit-for-bit while differing from the reference "
+        "by rel={partition_rel:.3e} -- the gradient is a function of which "
+        "datums share a rank, and no segmentation is needed to reach it"
+    ),
+    "PARTITION_INVARIANT_ORDER_SENSITIVE": (
+        "PARTITION-INVARIANT, order-sensitive at rel={max_rel:.3e}: the "
+        "rank-flipping permutation is bit-identical, so the partition does "
+        "not reach the gradient; what moves is the concatenation order, and "
+        "floating-point addition is commutative but not associative -- a "
+        "within-pair swap preserves the reduction tree, a reversal regroups it"
+    ),
+    "ORDER_SENSITIVE_UNCLASSIFIED": (
+        "ORDER-SENSITIVE (unclassified): max rel={max_rel:.3e}; the "
+        "partition/order arms do not match either known signature"
+    ),
+}
+
+# Outcomes that report a deviation rather than a broken invariant: the
+# partition does not reach the gradient, which is what PARTITION_INV
+# claims. The residual order-sensitivity is carried in the detail fields.
+PASSING_OUTCOMES = ("INVARIANT", "PARTITION_INVARIANT_ORDER_SENSITIVE")
+UNDECIDED_OUTCOMES = (
+    "INCONCLUSIVE",
+    "NO_DETERMINISM_CONTROL",
+    "NO_PARTITION_ARM",
+    "ORDER_SENSITIVE_UNCLASSIFIED",
+)
+
+
+@dataclass
+class OrderPerm:
+    model: str = "Qwen/Qwen2.5-0.5B"
+    rank: int = 32
+    seq: int = 64
+    n: int = 8
+    seed: int | None = None
+    max_seq_len: int | None = None
+    debug_train_only: bool = False
+    lr: float = 0.0
+    arms: list[tuple[str, list[int]]] = field(default_factory=lambda: default_arms(8))
+    name: str = "order_perm"
+    # models this trace created; the runner deletes them when the gate ends
+    created_models: list[str] = field(default_factory=list)
+
+    def params(self) -> dict:
+        return {
+            "model": self.model,
+            "rank": self.rank,
+            "seq": self.seq,
+            "n_datums": self.n,
+            "seed": self.seed,
+            "max_seq_len": self.max_seq_len,
+            "debug_train_only": self.debug_train_only,
+            "lr": self.lr,
+            "arms": [{"arm": a, "order": o} for a, o in self.arms],
+        }
+
+    def execute(self, driver) -> list[dict]:
+        """One observation row per arm: {arm, order, grad_norm, repr, s}."""
+        from gates.traces.common import synthetic_lm_datums
+
+        ds = synthetic_lm_datums(self.n, self.seq)
+        tc = driver.create_training_client(
+            base_model=self.model,
+            rank=self.rank,
+            seed=self.seed,
+            max_seq_len=self.max_seq_len,
+            debug_train_only=self.debug_train_only,
+        )
+        self.created_models.append(tc.model_id)
+        rows = []
+        for arm, order in self.arms:
+            t0 = time.time()
+            # ONE call: no segmentation, no pad -- only the order changes
+            tc.forward_backward([ds[i] for i in order], "cross_entropy").result()
+            res = driver.optim_step(tc.model_id, lr=self.lr)
+            gn = res.get("grad_norm")
+            rows.append(
+                {
+                    "arm": arm,
+                    "order": list(order),
+                    "grad_norm": gn,
+                    "repr": repr(gn),
+                    "s": round(time.time() - t0, 1),
+                }
+            )
+            print(
+                f"  {arm:13s} grad_norm={gn!r} ({time.time() - t0:.1f}s)",
+                flush=True,
+            )
+        return rows
+
+    def verdict(self, rows: list[dict], comparator) -> dict:
+        return verdict(rows, comparator)
+
+
+def verdict(rows: list[dict], comparator) -> dict:
+    """Pure function of the observation rows; mutates rows in place with
+    per-arm bit_identical/rel_diff exactly as order_perm_probe.py did."""
+    ref = rows[0]["grad_norm"]
+    for r in rows[1:]:
+        cmp: Comparison = comparator(ref, r["grad_norm"])
+        r["bit_identical"] = cmp.passed
+        r["rel_diff"] = rel_diff(ref, r["grad_norm"]) if ref else float("nan")
+
+    by = {r["arm"]: r for r in rows[1:]}
+    control, swap, rev = by.get(CONTROL_ARM), by.get(PARTITION_ARM), by.get(ORDER_ARM)
+    # the arms that actually permute something; the control is not one
+    perms = [r for r in rows[1:] if r["arm"] != CONTROL_ARM]
+
+    det = control["bit_identical"] if control else None
+    max_rel = max((r["rel_diff"] for r in perms), default=0.0)
+    partition_rel = swap["rel_diff"] if swap else None
+    all_perm_bit = all(r["bit_identical"] for r in perms) if perms else False
+    # A repeated permutation that reproduces its own value pins the IDENT
+    # difference on the permutation, not on run-to-run noise.
+    repeat = by.get(PARTITION_ARM + "_R")
+    partition_reproducible = (
+        comparator(swap["grad_norm"], repeat["grad_norm"]).passed
+        if swap and repeat
+        else None
+    )
+    # SWAP_PAIRS and REVERSE induce the SAME partition: agreeing bit-for-bit
+    # while both differing from IDENT is the partition-sensitive signature.
+    same_partition_agree = (
+        comparator(swap["grad_norm"], rev["grad_norm"]).passed
+        if swap and rev
+        else None
+    )
+
+    if control is None:
+        outcome = "NO_DETERMINISM_CONTROL"
+    elif not det:
+        outcome = "INCONCLUSIVE"
+    elif swap is None:
+        outcome = "NO_PARTITION_ARM"
+    elif all_perm_bit:
+        outcome = "INVARIANT"
+    elif not swap["bit_identical"] and same_partition_agree:
+        outcome = "PARTITION_SENSITIVE"
+    elif swap["bit_identical"]:
+        outcome = "PARTITION_INVARIANT_ORDER_SENSITIVE"
+    else:
+        outcome = "ORDER_SENSITIVE_UNCLASSIFIED"
+
+    return {
+        "outcome": outcome,
+        "verdict": OUTCOME_VERDICTS[outcome].format(
+            partition_rel=partition_rel or 0.0, max_rel=max_rel
+        ),
+        # PARTITION_INV asks whether the partition reaches the gradient, so a
+        # bit-identical rank-flip passes even when the concatenation order
+        # still moves the last ulp; None = the sweep could not decide.
+        "passed": (
+            None
+            if outcome in UNDECIDED_OUTCOMES
+            else outcome in PASSING_OUTCOMES
+        ),
+        # the invariant's own quantity: how far the rank-flip moved the gradient
+        "delta": partition_rel,
+        "determinism_ok": det,
+        "partition_bit_identical": swap["bit_identical"] if swap else None,
+        "partition_reproducible": partition_reproducible,
+        "same_partition_arms_agree": same_partition_agree,
+        "permutation_invariant": all_perm_bit,
+        "partition_rel_diff": partition_rel,
+        "max_rel_diff": max_rel,
+    }

--- a/gates/traces/seed_repro.py
+++ b/gates/traces/seed_repro.py
@@ -1,0 +1,200 @@
+"""SEED_REPRO: is the client's `LoraConfig.seed` actually read?
+
+Guards a silent failure. The seed was declared on the API, carried into
+every backend's create_model, and read by NO training backend: miles was
+reproducible *by accident* (Megatron's --seed defaults to 1234) while
+ignoring the client's value, and nemo_rl's policy workers never seeded at
+all. Fixed on both sides (tinker-cloud `995945e` PR #38, GavinZhu-GMI/RL
+`faba0bfc3`), but nothing fails loudly the day an image is rebuilt without
+the engine half -- hence this gate.
+
+Three arms, each a fresh model given ONE identical call at lr=0:
+  SEED_A, SEED_A_R   same seed twice
+  SEED_B             a different seed
+
+The contrast arm is what separates the two failure modes, and it is why
+"two models, one seed" is not enough on its own: an engine that ignores the
+client's seed and falls back to a fixed internal default reproduces
+perfectly across SEED_A/SEED_A_R and looks healthy.
+
+  SEED_HONORED     same seed agrees bitwise, different seed disagrees
+  SEED_IGNORED     both pairs agree -- the seed value reaches nothing
+  NOT_REPRODUCIBLE same seed disagrees -- nothing is seeded (or the engine
+                   is not run-to-run deterministic)
+
+grad_norm is the right observable even though LoRA B is zero-initialized:
+B=0 makes the step-0 *forward* seed-independent, but dL/dB is a function of
+A, so the gradient sees the seed. Do not substitute a forward observable.
+"""
+
+import time
+from dataclasses import dataclass, field
+
+from gates.comparators import Comparison, rel_diff
+
+DEFAULT_SEED = 7
+DEFAULT_CONTRAST_SEED = 99
+
+REPEAT_ARM = "SEED_A_R"
+CONTRAST_ARM = "SEED_B"
+
+OUTCOME_VERDICTS = {
+    "NO_REPEAT_ARM": (
+        "INCONCLUSIVE: the sweep creates no second model at the same seed, so "
+        "it cannot ask whether the seed reproduces"
+    ),
+    "NOT_REPRODUCIBLE": (
+        "SEED NOT REPRODUCIBLE: two models created with the same seed disagree "
+        "on grad_norm by rel={repeat_rel:.3e} -- the seed reaches no RNG, so "
+        "nothing about a run at this seed is reproducible"
+    ),
+    "NO_CONTRAST_ARM": (
+        "INCONCLUSIVE: the same seed reproduces, but with no different-seed "
+        "arm this cannot be told from an engine that ignores the client's seed "
+        "and falls back to a fixed internal default"
+    ),
+    "SEED_IGNORED": (
+        "SEED IGNORED: two DIFFERENT seeds produce a bit-identical gradient -- "
+        "the client's value reaches no RNG and the reproducibility above is an "
+        "accident of the engine's own default seed"
+    ),
+    "SEED_HONORED": (
+        "SEED HONORED: the same seed reproduces bit-identically and a "
+        "different seed moves the gradient (rel={contrast_rel:.3e}) -- the "
+        "client's seed is read"
+    ),
+}
+
+
+def default_arms(
+    seed: int = DEFAULT_SEED, contrast_seed: int = DEFAULT_CONTRAST_SEED
+) -> list[tuple[str, int]]:
+    return [("SEED_A", seed), (REPEAT_ARM, seed), (CONTRAST_ARM, contrast_seed)]
+
+
+@dataclass
+class SeedRepro:
+    model: str = "Qwen/Qwen2.5-0.5B"
+    rank: int = 32
+    seq: int = 64
+    n: int = 8
+    seed: int = DEFAULT_SEED
+    contrast_seed: int = DEFAULT_CONTRAST_SEED
+    max_seq_len: int | None = None
+    debug_train_only: bool = False
+    lr: float = 0.0
+    arms: list[tuple[str, int]] | None = None
+    name: str = "seed_repro"
+    # models this trace created; the runner deletes any the trace still holds
+    created_models: list[str] = field(default_factory=list)
+
+    def __post_init__(self):
+        if self.arms is None:
+            self.arms = default_arms(self.seed, self.contrast_seed)
+
+    def params(self) -> dict:
+        return {
+            "model": self.model,
+            "rank": self.rank,
+            "seq": self.seq,
+            "n_datums": self.n,
+            "seed": self.seed,
+            "contrast_seed": self.contrast_seed,
+            "max_seq_len": self.max_seq_len,
+            "debug_train_only": self.debug_train_only,
+            "lr": self.lr,
+            "arms": [{"arm": a, "seed": s} for a, s in self.arms],
+        }
+
+    def execute(self, driver) -> list[dict]:
+        """One observation row per arm: {arm, seed, grad_norm, repr, s}.
+
+        Each arm's model is released as soon as its observation is recorded:
+        the arms are independent, and holding three models at once would ask
+        for GPUs a 4-GPU pod does not have."""
+        from gates.traces.common import synthetic_lm_datums
+
+        ds = synthetic_lm_datums(self.n, self.seq)
+        delete = getattr(driver, "delete_model", None)
+        rows = []
+        for arm, seed in self.arms:
+            t0 = time.time()
+            tc = driver.create_training_client(
+                base_model=self.model,
+                rank=self.rank,
+                seed=seed,
+                max_seq_len=self.max_seq_len,
+                debug_train_only=self.debug_train_only,
+            )
+            self.created_models.append(tc.model_id)
+            try:
+                tc.forward_backward(ds, "cross_entropy").result()
+                res = driver.optim_step(tc.model_id, lr=self.lr)
+            finally:
+                if delete and delete(tc.model_id):
+                    self.created_models.remove(tc.model_id)
+            gn = res.get("grad_norm")
+            rows.append(
+                {
+                    "arm": arm,
+                    "seed": seed,
+                    "grad_norm": gn,
+                    "repr": repr(gn),
+                    "s": round(time.time() - t0, 1),
+                }
+            )
+            print(
+                f"  {arm:10s} seed={seed:<6d} grad_norm={gn!r} "
+                f"({time.time() - t0:.1f}s)",
+                flush=True,
+            )
+        return rows
+
+    def verdict(self, rows: list[dict], comparator) -> dict:
+        return verdict(rows, comparator)
+
+
+def verdict(rows: list[dict], comparator) -> dict:
+    """Pure function of the observation rows; mutates rows in place with
+    per-arm bit_identical/rel_diff against the first arm."""
+    ref = rows[0]["grad_norm"]
+    for r in rows[1:]:
+        cmp: Comparison = comparator(ref, r["grad_norm"])
+        r["bit_identical"] = cmp.passed
+        r["rel_diff"] = rel_diff(ref, r["grad_norm"]) if ref else float("nan")
+
+    by = {r["arm"]: r for r in rows[1:]}
+    repeat, contrast = by.get(REPEAT_ARM), by.get(CONTRAST_ARM)
+    reproducible = repeat["bit_identical"] if repeat else None
+    contrast_differs = (not contrast["bit_identical"]) if contrast else None
+    repeat_rel = repeat["rel_diff"] if repeat else None
+    contrast_rel = contrast["rel_diff"] if contrast else None
+
+    if repeat is None:
+        outcome = "NO_REPEAT_ARM"
+    elif not reproducible:
+        outcome = "NOT_REPRODUCIBLE"
+    elif contrast is None:
+        outcome = "NO_CONTRAST_ARM"
+    elif not contrast_differs:
+        outcome = "SEED_IGNORED"
+    else:
+        outcome = "SEED_HONORED"
+
+    return {
+        "outcome": outcome,
+        "verdict": OUTCOME_VERDICTS[outcome].format(
+            repeat_rel=repeat_rel or 0.0, contrast_rel=contrast_rel or 0.0
+        ),
+        "passed": (
+            None
+            if outcome in ("NO_REPEAT_ARM", "NO_CONTRAST_ARM")
+            else outcome == "SEED_HONORED"
+        ),
+        # the invariant's own quantity: how far two same-seed models drifted
+        "delta": repeat_rel,
+        "same_seed_bit_identical": reproducible,
+        "different_seed_differs": contrast_differs,
+        "same_seed_rel_diff": repeat_rel,
+        "different_seed_rel_diff": contrast_rel,
+    }

--- a/gates/traces/seg_sweep.py
+++ b/gates/traces/seg_sweep.py
@@ -30,6 +30,10 @@ DEFAULT_ARMS: list[tuple[str, list[int]]] = [
 
 OUTCOME_VERDICTS = {
     "INCONCLUSIVE": "INCONCLUSIVE: backend is not run-to-run deterministic (A2 != A1)",
+    "NO_NONALIGNED_ARM": (
+        "INCONCLUSIVE: the sweep contains no non-aligned segmentation, so it "
+        "cannot distinguish E0 under arbitrary splits from E0 only when aligned"
+    ),
     "E0_ARBITRARY": (
         "E0 UNDER ARBITRARY SEGMENTATION: every arm bit-identical "
         "(consistent with a segmentation-independent reduction order)"
@@ -172,10 +176,15 @@ def verdict(rows: list[dict], comparator) -> dict:
                     base["grad_norm"], r["grad_norm"]
                 ).passed
     all_nonalign_bit = all(r["bit_identical"] for r in nonalign)
-    max_rel = max(r["rel_diff"] for r in nonalign)
+    max_rel = max((r["rel_diff"] for r in nonalign), default=0.0)
 
     if not det:
         outcome = "INCONCLUSIVE"
+    elif not nonalign:
+        # Aligned arms alone cannot separate "invariant under every
+        # segmentation" from "invariant only where the split happens to
+        # match the engine's batching" — the sweep asked nothing.
+        outcome = "NO_NONALIGNED_ARM"
     elif all_nonalign_bit:
         outcome = "E0_ARBITRARY"
     elif aligned:
@@ -186,8 +195,13 @@ def verdict(rows: list[dict], comparator) -> dict:
     return {
         "outcome": outcome,
         "verdict": OUTCOME_VERDICTS[outcome].format(max_rel=max_rel),
-        # strict SPLIT_INV@E0; None = inconclusive (determinism control failed)
-        "passed": None if outcome == "INCONCLUSIVE" else outcome == "E0_ARBITRARY",
+        # strict SPLIT_INV@E0; None = the sweep could not decide (determinism
+        # control failed, or no non-aligned arm was submitted)
+        "passed": (
+            None
+            if outcome in ("INCONCLUSIVE", "NO_NONALIGNED_ARM")
+            else outcome == "E0_ARBITRARY"
+        ),
         "delta": max_rel,
         "determinism_ok": det,
         "aligned_bit_identical": aligned,

--- a/gates/traces/seg_sweep.py
+++ b/gates/traces/seg_sweep.py
@@ -1,0 +1,194 @@
+"""SPLIT_INV segmentation sweep (G1b), consolidated from
+specs/008-q3-abstraction-tax/probes/g1b_segmentation.py and
+specs/013-a1-8b-spine/probes/g1b_8b.py — 0.5B and 8B are two parameter
+points of this one trace. Datum generator, arm naming, and verdict
+semantics are preserved token-for-token; recorded results JSONs remain
+comparable.
+
+All arms run at lr=0.0 so every arm sees identical weights. Outcomes:
+  E0_ARBITRARY    every segmentation bit-identical (buffered prediction)
+  E0_ALIGNED_ONLY aligned arm bit-identical, non-aligned differ at
+                  ~fp-noise (eager prediction: Thm 1 holds, Prop 2 fails)
+  E0_BROKEN       even the aligned arm differs
+  INCONCLUSIVE    determinism control failed (A2 != A1)
+"""
+
+import time
+from dataclasses import dataclass, field
+
+from gates.comparators import Comparison, rel_diff
+
+# (name, segmentation of the n datums); verdict logic keys on A1/A2/ALIGNED/_R
+DEFAULT_ARMS: list[tuple[str, list[int]]] = [
+    ("A1", [8]),
+    ("ALIGNED", [4, 4]),
+    ("NONALIGN", [3, 5]),
+    ("NONALIGN2", [1, 7]),
+    ("NONALIGN_R", [3, 5]),  # rerun: is the non-aligned value itself stable?
+    ("A2", [8]),
+]
+
+OUTCOME_VERDICTS = {
+    "INCONCLUSIVE": "INCONCLUSIVE: backend is not run-to-run deterministic (A2 != A1)",
+    "E0_ARBITRARY": (
+        "E0 UNDER ARBITRARY SEGMENTATION: every arm bit-identical "
+        "(consistent with a segmentation-independent reduction order)"
+    ),
+    "E0_ALIGNED_ONLY": (
+        "E0 ONLY WHEN ALIGNED: aligned arm bit-identical, non-aligned "
+        "arms differ (max rel {max_rel:.3e}) -- Thm 1 holds, Prop 2 fails"
+    ),
+    "E0_BROKEN": (
+        "E0 FAILS EVEN WHEN ALIGNED -- split-invariance is broken, not just bitwise"
+    ),
+}
+
+
+def parse_segmentations(spec: str, n: int) -> list[tuple[str, list[int]]]:
+    """'8;4,4;2,6;6,2;2,6;8' -> named arms. First = reference A1, last =
+    determinism control A2. Needed on backends that DEADLOCK on
+    rank-imbalanced splits (miles at dp=2 derives a different
+    num_steps_per_rollout per rank and hangs): balanced-but-unaligned
+    splits like 2,6 still ask the bitwise question."""
+    segs = [[int(x) for x in part.split(",")] for part in spec.split(";")]
+    names, seen = [], {}
+    for i, s in enumerate(segs):
+        if i == 0:
+            names.append("A1")
+        elif i == len(segs) - 1:
+            names.append("A2")
+        elif s == [n // 2, n // 2]:
+            names.append("ALIGNED")
+        else:
+            key = tuple(s)
+            seen[key] = seen.get(key, 0) + 1
+            names.append("S" + "+".join(map(str, s)) + ("_R" if seen[key] > 1 else ""))
+    return list(zip(names, segs))
+
+
+def segments(ds: list, sizes: list[int]) -> list[list]:
+    out, i = [], 0
+    for s in sizes:
+        out.append(ds[i : i + s])
+        i += s
+    assert i == len(ds), f"segmentation {sizes} does not cover {len(ds)} datums"
+    return out
+
+
+@dataclass
+class SegSweep:
+    model: str = "Qwen/Qwen2.5-0.5B"
+    rank: int = 32
+    seq: int = 64
+    n: int = 8
+    seed: int | None = None
+    max_seq_len: int | None = None
+    debug_train_only: bool = False
+    lr: float = 0.0
+    arms: list[tuple[str, list[int]]] = field(
+        default_factory=lambda: list(DEFAULT_ARMS)
+    )
+    name: str = "seg_sweep"
+
+    def params(self) -> dict:
+        return {
+            "model": self.model,
+            "rank": self.rank,
+            "seq": self.seq,
+            "n_datums": self.n,
+            "seed": self.seed,
+            "max_seq_len": self.max_seq_len,
+            "debug_train_only": self.debug_train_only,
+            "lr": self.lr,
+            "arms": [{"arm": a, "segmentation": s} for a, s in self.arms],
+        }
+
+    def execute(self, driver) -> list[dict]:
+        """One observation row per arm: {arm, segmentation, grad_norm, repr, s}."""
+        from gates.traces.common import synthetic_lm_datums
+
+        ds = synthetic_lm_datums(self.n, self.seq)
+        tc = driver.create_training_client(
+            base_model=self.model,
+            rank=self.rank,
+            seed=self.seed,
+            max_seq_len=self.max_seq_len,
+            debug_train_only=self.debug_train_only,
+        )
+        rows = []
+        for arm, sizes in self.arms:
+            t0 = time.time()
+            for part in segments(ds, sizes):
+                tc.forward_backward(part, "cross_entropy").result()
+            res = driver.optim_step(tc.model_id, lr=self.lr)
+            gn = res.get("grad_norm")
+            rows.append(
+                {
+                    "arm": arm,
+                    "segmentation": sizes,
+                    "grad_norm": gn,
+                    "repr": repr(gn),
+                    "s": round(time.time() - t0, 1),
+                }
+            )
+            print(
+                f"  {arm:10s} {str(sizes):8s} grad_norm={gn!r} "
+                f"({time.time() - t0:.1f}s)",
+                flush=True,
+            )
+        return rows
+
+    def verdict(self, rows: list[dict], comparator) -> dict:
+        return verdict(rows, comparator)
+
+
+def verdict(rows: list[dict], comparator) -> dict:
+    """Pure function of the observation rows; mutates rows in place with
+    per-arm bit_identical/rel_diff exactly as the 008/013 probes did."""
+    ref = rows[0]["grad_norm"]
+    for r in rows[1:]:
+        cmp: Comparison = comparator(ref, r["grad_norm"])
+        r["bit_identical"] = cmp.passed
+        r["rel_diff"] = (
+            rel_diff(ref, r["grad_norm"]) if ref else float("nan")
+        )
+
+    det = next(r for r in rows if r["arm"] == "A2")["bit_identical"]
+    al = [r for r in rows if r["arm"] == "ALIGNED"]
+    aligned = al[0]["bit_identical"] if al else None
+    # "non-aligned" = every middle arm other than the aligned one
+    nonalign = [r for r in rows[1:-1] if r["arm"] != "ALIGNED"]
+    # A repeated segmentation that reproduces its own value pins the A1
+    # difference on the segmentation, not run-to-run noise.
+    nonalign_reproducible = None
+    for r in nonalign:
+        if r["arm"].endswith("_R"):
+            base = next((q for q in nonalign if q["arm"] == r["arm"][:-2]), None)
+            if base:
+                nonalign_reproducible = comparator(
+                    base["grad_norm"], r["grad_norm"]
+                ).passed
+    all_nonalign_bit = all(r["bit_identical"] for r in nonalign)
+    max_rel = max(r["rel_diff"] for r in nonalign)
+
+    if not det:
+        outcome = "INCONCLUSIVE"
+    elif all_nonalign_bit:
+        outcome = "E0_ARBITRARY"
+    elif aligned:
+        outcome = "E0_ALIGNED_ONLY"
+    else:
+        outcome = "E0_BROKEN"
+
+    return {
+        "outcome": outcome,
+        "verdict": OUTCOME_VERDICTS[outcome].format(max_rel=max_rel),
+        # strict SPLIT_INV@E0; None = inconclusive (determinism control failed)
+        "passed": None if outcome == "INCONCLUSIVE" else outcome == "E0_ARBITRARY",
+        "delta": max_rel,
+        "determinism_ok": det,
+        "aligned_bit_identical": aligned,
+        "nonaligned_reproducible": nonalign_reproducible,
+        "nonaligned_all_bit_identical": all_nonalign_bit,
+        "max_nonaligned_rel_diff": max_rel,
+    }

--- a/gates/traces/seg_sweep.py
+++ b/gates/traces/seg_sweep.py
@@ -89,6 +89,8 @@ class SegSweep:
         default_factory=lambda: list(DEFAULT_ARMS)
     )
     name: str = "seg_sweep"
+    # models this trace created; the runner deletes them when the gate ends
+    created_models: list[str] = field(default_factory=list)
 
     def params(self) -> dict:
         return {
@@ -115,6 +117,7 @@ class SegSweep:
             max_seq_len=self.max_seq_len,
             debug_train_only=self.debug_train_only,
         )
+        self.created_models.append(tc.model_id)
         rows = []
         for arm, sizes in self.arms:
             t0 = time.time()

--- a/gates/verdicts/schema.json
+++ b/gates/verdicts/schema.json
@@ -1,0 +1,102 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "tinkercloud-gates-verdict",
+  "title": "Gate verdict",
+  "description": "Uniform result of one gate = invariant x trace x arm. History in, certificate-bearing verdict out (Elle-shaped; specs/014 design S3.4).",
+  "type": "object",
+  "required": [
+    "gate",
+    "invariant",
+    "claimed_level",
+    "arm",
+    "trace",
+    "outcome",
+    "verdict",
+    "passed",
+    "delta",
+    "threshold",
+    "observations",
+    "artifacts",
+    "meta"
+  ],
+  "properties": {
+    "gate": {
+      "type": "string",
+      "description": "invariant_id.trace_name, e.g. SPLIT_INV.seg_sweep"
+    },
+    "invariant": {
+      "type": "string",
+      "description": "id in gates/invariants.py REGISTRY"
+    },
+    "claimed_level": { "enum": ["E0", "E1", "E2"] },
+    "arm": {
+      "type": "object",
+      "required": ["tag"],
+      "properties": {
+        "tag": {
+          "type": "string",
+          "description": "backend/parallelism label, e.g. nemo_rl_tp2"
+        },
+        "expect": {
+          "type": ["string", "null"],
+          "description": "predicted outcome for this arm, if graded against one"
+        }
+      }
+    },
+    "trace": {
+      "type": "object",
+      "required": ["name", "params"],
+      "properties": {
+        "name": { "type": "string" },
+        "params": { "type": "object" }
+      }
+    },
+    "outcome": {
+      "type": "string",
+      "description": "trace-specific outcome code, e.g. E0_ARBITRARY"
+    },
+    "verdict": {
+      "type": "string",
+      "description": "human-readable one-liner (probe-compatible phrasing)"
+    },
+    "passed": {
+      "type": ["boolean", "null"],
+      "description": "strict verdict at claimed_level; null = inconclusive. When arm.expect is set, pass of outcome==expect is reported in expect_met."
+    },
+    "expect_met": { "type": ["boolean", "null"] },
+    "delta": {
+      "type": ["number", "null"],
+      "description": "max observed deviation (relative for E0/E1)"
+    },
+    "threshold": {
+      "type": ["number", "null"],
+      "description": "E1 bar / E2 envelope half-width; null for E0"
+    },
+    "observations": {
+      "type": "array",
+      "items": { "type": "object" },
+      "description": "per-arm observation rows as returned by trace.execute"
+    },
+    "detail": {
+      "type": "object",
+      "description": "trace-specific verdict fields (e.g. determinism_ok)"
+    },
+    "artifacts": {
+      "type": "object",
+      "required": ["observations_sha256", "trace_sha256"],
+      "properties": {
+        "observations_sha256": { "type": "string" },
+        "trace_sha256": { "type": "string" }
+      }
+    },
+    "meta": {
+      "type": "object",
+      "required": ["timestamp", "gates_version"],
+      "properties": {
+        "timestamp": { "type": "string" },
+        "base_url": { "type": "string" },
+        "gates_version": { "type": "string" }
+      }
+    }
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,4 +16,9 @@ requires-python = ">=3.10"
 # image already provides everything. This entry only creates the import path.
 
 [tool.setuptools.packages.find]
-include = ["training*"]
+# gates ships with the service: the suite must version with the server it
+# certifies (specs/014 design S6 Q1).
+include = ["training*", "gates*"]
+
+[tool.setuptools.package-data]
+gates = ["verdicts/*.json"]

--- a/scripts/deploy_tinkercloud.sh
+++ b/scripts/deploy_tinkercloud.sh
@@ -252,7 +252,8 @@ fi
 tar -C "$SRC" -czf "$TMP/code.tar.gz" \
   --exclude='.git' --exclude='__pycache__' --exclude='*.pyc' --exclude='.pytest_cache' \
   --exclude='.venv' --exclude='tinker-cookbook/attic' \
-  tinker-cloud/training tinker-cloud/tests tinker-cloud/scripts/evo2 \
+  tinker-cloud/training tinker-cloud/tests tinker-cloud/gates tinker-cloud/pyproject.toml \
+  tinker-cloud/scripts/evo2 \
   RL/nemo_rl \
   tinker_gmi/src tinker_gmi/pyproject.toml tinker_gmi/README.md \
   tinker-cookbook/tinker_cookbook tinker-cookbook/pyproject.toml tinker-cookbook/README.md \

--- a/scripts/lib/setup_container.sh
+++ b/scripts/lib/setup_container.sh
@@ -17,9 +17,10 @@ cd /tmp && tar xzf code.tar.gz
 mkdir -p /app /work /data/metadata /data/trajectories /data/.cache/huggingface
 
 # TinkerCloud server -> /app (run via PYTHONPATH=/app python3 -m training)
-rm -rf /app/training /app/tests /app/scripts /work/tinker_gmi /work/tinker-cookbook
+rm -rf /app/training /app/tests /app/gates /app/scripts /work/tinker_gmi /work/tinker-cookbook
 mv /tmp/tinker-cloud/training /app/training
 mv /tmp/tinker-cloud/tests /app/tests
+[ -d /tmp/tinker-cloud/gates ] && mv /tmp/tinker-cloud/gates /app/gates
 [ -d /tmp/tinker-cloud/scripts/evo2 ] && { mkdir -p /app/scripts; mv /tmp/tinker-cloud/scripts/evo2 /app/scripts/evo2; }
 
 if [ "$PROFILE" = bionemo ]; then
@@ -83,6 +84,11 @@ elif [ "$PROFILE" = miles ]; then
   fi
   python3 -c 'import miles; print("miles fork overlaid OK ('"$MILES_REF"')")'
 fi
+
+# server editable install: Ray workers import training.* by module path
+# (e.g. nemo_rl losses), and PYTHONPATH=/app does not reach them (BUG-015)
+[ -f /tmp/tinker-cloud/pyproject.toml ] && cp /tmp/tinker-cloud/pyproject.toml /app/pyproject.toml
+[ -f /app/pyproject.toml ] && pip install -e /app --no-deps -q
 
 # SDK + cookbook editable installs
 mv /tmp/tinker_gmi /work/tinker_gmi

--- a/tests/test_gates_order_perm.py
+++ b/tests/test_gates_order_perm.py
@@ -1,0 +1,219 @@
+"""Offline tests for the PARTITION_INV order-permutation trace.
+
+The fidelity test replays all 13 recorded `order_perm_*.json` runs from
+specs/014-gate-suite/results/ (monorepo layout). Those JSONs were written
+by the probe's ORIGINAL binary verdict (order-invariant / not), so the
+recorded verdict STRING is not comparable; what is asserted is that the
+migrated three-way logic reproduces the recorded per-arm annotations and
+numbers exactly, agrees with the recorded binary field where they overlap,
+and lands each run in the class the investigation attributed it to.
+"""
+
+import json
+import math
+from pathlib import Path
+
+import pytest
+
+from gates import comparators, invariants, runner
+from gates.traces.order_perm import OrderPerm, default_arms, verdict
+
+MONOREPO = Path(__file__).resolve().parents[2]
+RESULTS = MONOREPO / "specs/014-gate-suite/results"
+RECORDED = sorted(RESULTS.glob("order_perm_*.json"))
+
+E0 = comparators.REGISTRY["e0_bitwise"]
+
+# tag -> the class the investigation attributed the run to
+# (INVESTIGATION-miles-split.md §DEFECT 2 / §THE nemo_rl PEER PROBE).
+EXPECTED = {
+    # miles pre-fix: the gradient is a function of the rank partition
+    "d2_dp2_instr": "PARTITION_SENSITIVE",
+    "dynON_dp2": "PARTITION_SENSITIVE",
+    "dynoff_dp2": "PARTITION_SENSITIVE",
+    "seed7_dp2": "PARTITION_SENSITIVE",
+    # dp=1 (no partition exists) and every post-fix miles run
+    "d2_dp1_instr": "INVARIANT",
+    "d2_dp2_FIXED": "INVARIANT",
+    "d2_dp4_FIXED": "INVARIANT",
+    "d2_dp2_optB": "INVARIANT",
+    "d2_dp2_optB2": "INVARIANT",
+    "seed7_dp1": "INVARIANT",
+    # nemo_rl: miles' exact inverse -- the rank-flip is bit-identical and
+    # what moves is the concatenation order, at the fp floor
+    "nemorl_dp1": "PARTITION_INVARIANT_ORDER_SENSITIVE",
+    "nemorl_dp2": "PARTITION_INVARIANT_ORDER_SENSITIVE",
+    "nemorl_dp4": "INVARIANT",
+}
+
+
+def rows_for(values, arms=None):
+    arms = arms or [a for a, _ in default_arms(8)]
+    orders = dict(default_arms(8))
+    return [
+        {"arm": a, "order": orders.get(a, list(range(8))), "grad_norm": v}
+        for a, v in zip(arms, values)
+    ]
+
+
+class TestVerdict:
+    def test_all_bit_identical(self):
+        v = verdict(rows_for([3.0] * 5), E0)
+        assert v["outcome"] == "INVARIANT"
+        assert v["passed"] is True
+        assert v["delta"] == 0.0 and v["max_rel_diff"] == 0.0
+
+    def test_partition_sensitive(self):
+        # SWAP_PAIRS and REVERSE induce the SAME partition: they agree with
+        # each other while differing from IDENT -- the miles signature
+        v = verdict(rows_for([3.0, 3.01, 3.01, 3.01, 3.0]), E0)
+        assert v["outcome"] == "PARTITION_SENSITIVE"
+        assert v["passed"] is False
+        assert v["same_partition_arms_agree"] is True
+        assert v["partition_reproducible"] is True
+        assert v["delta"] == pytest.approx(0.01 / 3.0)
+        assert "SAME rank partition" in v["verdict"]
+
+    def test_partition_invariant_but_order_sensitive(self):
+        # the rank-flip is bit-identical; only the reversal moves
+        v = verdict(rows_for([3.0, 3.0, 3.0 + 1e-6, 3.0, 3.0]), E0)
+        assert v["outcome"] == "PARTITION_INVARIANT_ORDER_SENSITIVE"
+        # the partition does not reach the gradient, which is what
+        # PARTITION_INV claims; the residual is reported, not a failure
+        assert v["passed"] is True
+        assert v["delta"] == 0.0
+        assert v["max_rel_diff"] == pytest.approx(1e-6 / 3.0)
+        assert "commutative but not associative" in v["verdict"]
+
+    def test_unclassified_when_neither_signature_matches(self):
+        # SWAP_PAIRS moves but REVERSE lands somewhere else: the partition
+        # and the order cannot be separated, so the gate must not guess
+        v = verdict(rows_for([3.0, 3.01, 3.02, 3.01, 3.0]), E0)
+        assert v["outcome"] == "ORDER_SENSITIVE_UNCLASSIFIED"
+        assert v["passed"] is None
+        assert v["same_partition_arms_agree"] is False
+
+    def test_nondeterministic_is_inconclusive(self):
+        v = verdict(rows_for([3.0, 3.0, 3.0, 3.0, 3.5]), E0)
+        assert v["outcome"] == "INCONCLUSIVE"
+        assert v["passed"] is None
+
+    def test_missing_determinism_control(self):
+        rows = rows_for([3.0, 3.0, 3.0, 3.0], arms=["IDENT", "SWAP_PAIRS",
+                                                    "REVERSE", "SWAP_PAIRS_R"])
+        v = verdict(rows, E0)
+        assert v["outcome"] == "NO_DETERMINISM_CONTROL"
+        assert v["passed"] is None
+
+    def test_no_partition_arm(self):
+        # a sweep without the rank-flipping permutation asks nothing about
+        # the partition, however bit-identical its other arms are
+        rows = rows_for([3.0, 3.0, 3.0], arms=["IDENT", "REVERSE", "IDENT_R"])
+        v = verdict(rows, E0)
+        assert v["outcome"] == "NO_PARTITION_ARM"
+        assert v["passed"] is None
+        assert "cannot ask" in v["verdict"]
+
+
+class TestDefaultArms:
+    def test_probe_compatible_orders(self):
+        assert default_arms(8) == [
+            ("IDENT", [0, 1, 2, 3, 4, 5, 6, 7]),
+            ("SWAP_PAIRS", [1, 0, 3, 2, 5, 4, 7, 6]),
+            ("REVERSE", [7, 6, 5, 4, 3, 2, 1, 0]),
+            ("SWAP_PAIRS_R", [1, 0, 3, 2, 5, 4, 7, 6]),
+            ("IDENT_R", [0, 1, 2, 3, 4, 5, 6, 7]),
+        ]
+
+    def test_odd_n_rejected(self):
+        # SWAP_PAIRS is what flips the partition; without pairs it is not
+        # the arm the verdict logic thinks it is
+        with pytest.raises(ValueError, match="even"):
+            default_arms(7)
+
+
+@pytest.mark.skipif(not RECORDED, reason="monorepo specs/014 results not present")
+class TestRecordedReplay:
+    @pytest.mark.parametrize("path", RECORDED, ids=lambda p: p.stem)
+    def test_reproduces_recorded_observations(self, path):
+        doc = json.loads(path.read_text())
+        rows = [
+            {k: v for k, v in r.items() if k not in ("bit_identical", "rel_diff")}
+            for r in doc["arms"]
+        ]
+        v = verdict(rows, E0)
+
+        assert v["determinism_ok"] == doc["determinism_ok"]
+        assert v["permutation_invariant"] == doc["order_invariant"]
+        rec = doc["max_rel_diff"]
+        assert v["max_rel_diff"] == rec or (
+            math.isnan(v["max_rel_diff"]) and math.isnan(rec)
+        )
+        for new, old in zip(rows, doc["arms"]):
+            if "bit_identical" in old:
+                assert new["bit_identical"] == old["bit_identical"]
+                assert new["rel_diff"] == pytest.approx(old["rel_diff"], rel=1e-12)
+
+    @pytest.mark.parametrize("path", RECORDED, ids=lambda p: p.stem)
+    def test_classifies_recorded_run(self, path):
+        tag = json.loads(path.read_text())["tag"]
+        assert tag in EXPECTED, f"unattributed recorded run {tag}"
+        doc = json.loads(path.read_text())
+        v = verdict([dict(r) for r in doc["arms"]], E0)
+        assert v["outcome"] == EXPECTED[tag]
+
+    def test_every_expected_tag_has_a_recording(self):
+        tags = {json.loads(p.read_text())["tag"] for p in RECORDED}
+        assert tags == set(EXPECTED)
+
+
+class StubDriver:
+    base_url = "stub://"
+
+    def __init__(self):
+        self.deleted = []
+
+    def delete_model(self, model_id):
+        self.deleted.append(model_id)
+        return True
+
+
+class StubTrace(OrderPerm):
+    """OrderPerm with execute() replaced by canned rows (no SDK/torch)."""
+
+    def __init__(self, rows, **kw):
+        super().__init__(**kw)
+        self._rows = rows
+
+    def execute(self, driver):
+        self.created_models.append("model_perm")
+        return [dict(r) for r in self._rows]
+
+
+class TestRunner:
+    def test_verdict_doc_matches_schema(self, tmp_path):
+        driver = StubDriver()
+        doc = runner.run(
+            invariants.get("PARTITION_INV"),
+            StubTrace(rows_for([3.0, 3.01, 3.01, 3.01, 3.0])),
+            tag="stub",
+            out_dir=str(tmp_path),
+            expect="PARTITION_SENSITIVE",
+            driver=driver,
+        )
+        schema = json.loads(
+            (Path(runner.__file__).parent / "verdicts" / "schema.json").read_text()
+        )
+        jsonschema = pytest.importorskip("jsonschema")
+        jsonschema.validate(doc, schema)
+        assert doc["gate"] == "PARTITION_INV.order_perm"
+        assert doc["claimed_level"] == "E0"
+        assert doc["passed"] is False and doc["expect_met"] is True
+        assert driver.deleted == ["model_perm"]
+        written = json.loads(
+            (tmp_path / "partition_inv.order_perm_stub.json").read_text()
+        )
+        assert written["artifacts"] == doc["artifacts"]
+
+    def test_registered_on_the_cli(self):
+        assert "order_perm" in runner.TRACES

--- a/tests/test_gates_seed_repro.py
+++ b/tests/test_gates_seed_repro.py
@@ -1,0 +1,202 @@
+"""Offline tests for the SEED_REPRO trace.
+
+No recorded JSONs exist to replay — the seeding gap was found by hand
+(two same-width same-seed nemo_rl runs disagreeing on grad_norm,
+3194.760 vs 3270.384) and fixed before a gate existed. The cases below
+encode that observation and the miles one it is paired with: an engine
+that ignores the client's seed and falls back to its own default (miles
+pre-`995945e`, Megatron's --seed=1234) reproduces perfectly and must
+still fail.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from gates import comparators, invariants, runner
+from gates.traces.seed_repro import SeedRepro, default_arms, verdict
+
+E0 = comparators.REGISTRY["e0_bitwise"]
+
+
+def rows_for(values, seeds=(7, 7, 99)):
+    arms = [a for a, _ in default_arms()]
+    return [
+        {"arm": a, "seed": s, "grad_norm": v}
+        for a, s, v in zip(arms, seeds, values)
+    ]
+
+
+class TestVerdict:
+    def test_seed_honored(self):
+        v = verdict(rows_for([3141.8, 3141.8, 2900.0]), E0)
+        assert v["outcome"] == "SEED_HONORED"
+        assert v["passed"] is True
+        assert v["delta"] == 0.0
+        assert v["same_seed_bit_identical"] and v["different_seed_differs"]
+
+    def test_seed_ignored_when_the_contrast_arm_agrees_too(self):
+        # the failure the same-seed pair alone cannot see: perfectly
+        # reproducible, and the client's value reaches nothing
+        v = verdict(rows_for([3141.8, 3141.8, 3141.8]), E0)
+        assert v["outcome"] == "SEED_IGNORED"
+        assert v["passed"] is False
+        assert v["same_seed_bit_identical"] is True
+        assert v["different_seed_differs"] is False
+        assert "accident of the engine's own default seed" in v["verdict"]
+
+    def test_not_reproducible(self):
+        # the recorded nemo_rl signature: same seed, two models, no seeding
+        v = verdict(rows_for([3194.760, 3270.384, 2900.0]), E0)
+        assert v["outcome"] == "NOT_REPRODUCIBLE"
+        assert v["passed"] is False
+        assert v["delta"] == pytest.approx(abs(3270.384 - 3194.760) / 3194.760)
+
+    def test_no_contrast_arm_is_inconclusive(self):
+        rows = rows_for([3141.8, 3141.8], seeds=(7, 7))[:2]
+        v = verdict(rows, E0)
+        assert v["outcome"] == "NO_CONTRAST_ARM"
+        assert v["passed"] is None
+        assert v["different_seed_rel_diff"] is None
+
+    def test_no_repeat_arm_is_inconclusive(self):
+        rows = [
+            {"arm": "SEED_A", "seed": 7, "grad_norm": 3141.8},
+            {"arm": "SEED_B", "seed": 99, "grad_norm": 2900.0},
+        ]
+        v = verdict(rows, E0)
+        assert v["outcome"] == "NO_REPEAT_ARM"
+        assert v["passed"] is None
+
+
+class TestArms:
+    def test_default_arms_pair_a_repeat_with_a_contrast(self):
+        assert default_arms(7, 99) == [
+            ("SEED_A", 7),
+            ("SEED_A_R", 7),
+            ("SEED_B", 99),
+        ]
+
+    def test_trace_params_carry_both_seeds(self):
+        p = SeedRepro(seed=11, contrast_seed=12).params()
+        assert p["seed"] == 11 and p["contrast_seed"] == 12
+        assert [a["seed"] for a in p["arms"]] == [11, 11, 12]
+
+
+class FakeClient:
+    def __init__(self, model_id, grad_norm):
+        self.model_id = model_id
+        self._gn = grad_norm
+
+    def forward_backward(self, datums, loss_fn):
+        class _F:
+            def result(self):
+                return None
+
+        return _F()
+
+
+class FakeDriver:
+    """Records the create/delete interleaving and serves canned grad_norms
+    keyed by the seed each model was created with."""
+
+    base_url = "stub://"
+
+    def __init__(self, by_seed):
+        self.by_seed = by_seed
+        self.events = []
+        self.live = set()
+        self.grad_norms = {}
+
+    def create_training_client(self, base_model, rank, seed, max_seq_len,
+                               debug_train_only):
+        mid = f"model_{len(self.grad_norms) + 1}"
+        self.events.append(("create", mid, seed))
+        self.live.add(mid)
+        self.grad_norms[mid] = self.by_seed[seed]
+        return FakeClient(mid, self.grad_norms[mid])
+
+    def optim_step(self, model_id, lr=0.0):
+        return {"grad_norm": self.grad_norms[model_id]}
+
+    def delete_model(self, model_id):
+        self.events.append(("delete", model_id, None))
+        self.live.discard(model_id)
+        return True
+
+
+class TestExecute:
+    """Three models is one more than a 4-GPU pod can hold beside a live
+    engine, so the arms must not overlap."""
+
+    def _run(self, monkeypatch, by_seed):
+        monkeypatch.setattr(
+            "gates.traces.common.synthetic_lm_datums",
+            lambda n, seq: [f"d{i}" for i in range(n)],
+        )
+        trace = SeedRepro(seed=7, contrast_seed=99)
+        driver = FakeDriver(by_seed)
+        return trace, driver, trace.execute(driver)
+
+    def test_each_model_is_released_before_the_next_is_created(
+        self, monkeypatch
+    ):
+        trace, driver, rows = self._run(monkeypatch, {7: 3141.8, 99: 2900.0})
+        kinds = [e[0] for e in driver.events]
+        assert kinds == ["create", "delete"] * 3
+        assert driver.live == set() and trace.created_models == []
+        assert [r["seed"] for r in rows] == [7, 7, 99]
+        assert [r["grad_norm"] for r in rows] == [3141.8, 3141.8, 2900.0]
+
+    def test_a_failed_arm_still_releases_its_model(self, monkeypatch):
+        monkeypatch.setattr(
+            "gates.traces.common.synthetic_lm_datums",
+            lambda n, seq: [f"d{i}" for i in range(n)],
+        )
+        trace = SeedRepro()
+        driver = FakeDriver({7: 3141.8, 99: 2900.0})
+
+        def boom(model_id, lr=0.0):
+            raise RuntimeError("step exploded")
+
+        driver.optim_step = boom
+        with pytest.raises(RuntimeError, match="exploded"):
+            trace.execute(driver)
+        assert driver.live == set() and trace.created_models == []
+
+
+class StubDriver:
+    base_url = "stub://"
+
+
+class StubTrace(SeedRepro):
+    def __init__(self, rows, **kw):
+        super().__init__(**kw)
+        self._rows = rows
+
+    def execute(self, driver):
+        return [dict(r) for r in self._rows]
+
+
+class TestRunner:
+    def test_verdict_doc_matches_schema(self, tmp_path):
+        doc = runner.run(
+            invariants.get("SEED_REPRO"),
+            StubTrace(rows_for([3141.8, 3141.8, 2900.0])),
+            tag="stub",
+            out_dir=str(tmp_path),
+            expect="SEED_HONORED",
+            driver=StubDriver(),
+        )
+        schema = json.loads(
+            (Path(runner.__file__).parent / "verdicts" / "schema.json").read_text()
+        )
+        jsonschema = pytest.importorskip("jsonschema")
+        jsonschema.validate(doc, schema)
+        assert doc["gate"] == "SEED_REPRO.seed_repro"
+        assert doc["passed"] is True and doc["expect_met"] is True
+        assert (tmp_path / "seed_repro.seed_repro_stub.json").exists()
+
+    def test_registered_on_the_cli(self):
+        assert "seed_repro" in runner.TRACES

--- a/tests/test_gates_verdicts.py
+++ b/tests/test_gates_verdicts.py
@@ -1,0 +1,179 @@
+"""Offline tests for the gate suite's pure layers: comparators, seg-sweep
+verdict logic, arm parsing, runner verdict-JSON shape. No server/GPU.
+
+Fidelity tests replay the recorded g1b results JSONs from specs/008 and
+specs/013 (monorepo layout) and assert the migrated verdict logic
+reproduces the probes' recorded verdicts byte-for-byte.
+"""
+
+import json
+import math
+from pathlib import Path
+
+import pytest
+
+from gates import comparators, invariants, runner
+from gates.traces.seg_sweep import (
+    DEFAULT_ARMS,
+    SegSweep,
+    parse_segmentations,
+    verdict,
+)
+
+MONOREPO = Path(__file__).resolve().parents[2]
+RECORDED = [
+    p
+    for pattern in (
+        "specs/008-q3-abstraction-tax/probes/results/g1b_*.json",
+        "specs/013-a1-8b-spine/probes/results/g1b_8b_*.json",
+    )
+    for p in MONOREPO.glob(pattern)
+]
+
+E0 = comparators.REGISTRY["e0_bitwise"]
+
+
+def rows_for(values, arms=None):
+    arms = arms or [a for a, _ in DEFAULT_ARMS]
+    segs = dict(DEFAULT_ARMS)
+    return [
+        {"arm": a, "segmentation": segs.get(a, [8]), "grad_norm": v}
+        for a, v in zip(arms, values)
+    ]
+
+
+class TestComparators:
+    def test_e0_bitwise(self):
+        assert E0(1.5, 1.5).passed
+        assert not E0(1.5, 1.5000001).passed
+        assert E0(1.5, 1.5000001).delta == pytest.approx(1e-7 / 1.5, rel=1e-2)
+
+    def test_e1_threshold(self):
+        c = comparators.e1_threshold(2.80, 2.83, bar=0.05)
+        assert c.passed and c.delta == pytest.approx(0.03) and c.threshold == 0.05
+        assert not comparators.e1_threshold(2.80, 2.90, bar=0.05).passed
+
+    def test_e2_envelope(self):
+        assert comparators.e2_envelope(2.30, 2.25, 2.35).passed
+        assert not comparators.e2_envelope(2.40, 2.25, 2.35).passed
+
+
+class TestSegSweepVerdict:
+    def test_all_bit_identical(self):
+        v = verdict(rows_for([3.0] * 6), E0)
+        assert v["outcome"] == "E0_ARBITRARY"
+        assert v["passed"] is True
+        assert v["determinism_ok"] and v["nonaligned_all_bit_identical"]
+        assert v["nonaligned_reproducible"] is True
+
+    def test_aligned_only(self):
+        v = verdict(rows_for([3.0, 3.0, 3.0 + 1e-6, 3.0 + 2e-6, 3.0 + 1e-6, 3.0]), E0)
+        assert v["outcome"] == "E0_ALIGNED_ONLY"
+        assert v["passed"] is False
+        assert v["aligned_bit_identical"] is True
+        # the repeated [3,5] arm reproduced its value: segmentation-caused
+        assert v["nonaligned_reproducible"] is True
+        assert v["max_nonaligned_rel_diff"] == pytest.approx(2e-6 / 3.0)
+
+    def test_broken_even_aligned(self):
+        v = verdict(rows_for([3.0, 3.1, 3.2, 3.3, 3.2, 3.0]), E0)
+        assert v["outcome"] == "E0_BROKEN"
+        assert v["passed"] is False
+
+    def test_nondeterministic_inconclusive(self):
+        v = verdict(rows_for([3.0, 3.0, 3.0, 3.0, 3.0, 3.5]), E0)
+        assert v["outcome"] == "INCONCLUSIVE"
+        assert v["passed"] is None
+
+    def test_verdict_string_formats_max_rel(self):
+        v = verdict(rows_for([3.0, 3.0, 3.0 + 3e-6, 3.0 + 3e-6, 3.0 + 3e-6, 3.0]), E0)
+        assert "max rel 1.000e-06" in v["verdict"]
+
+
+class TestParseSegmentations:
+    def test_probe_compatible_naming(self):
+        arms = parse_segmentations("8;4,4;2,6;6,2;2,6;8", n=8)
+        assert arms == [
+            ("A1", [8]),
+            ("ALIGNED", [4, 4]),
+            ("S2+6", [2, 6]),
+            ("S6+2", [6, 2]),
+            ("S2+6_R", [2, 6]),
+            ("A2", [8]),
+        ]
+
+
+@pytest.mark.skipif(not RECORDED, reason="monorepo specs/ results not present")
+class TestRecordedReplay:
+    @pytest.mark.parametrize("path", RECORDED, ids=lambda p: p.stem)
+    def test_reproduces_recorded_verdict(self, path):
+        doc = json.loads(path.read_text())
+        rows = [
+            {k: v for k, v in r.items() if k not in ("bit_identical", "rel_diff")}
+            for r in doc["arms"]
+        ]
+        v = verdict(rows, E0)
+        assert v["verdict"] == doc["verdict"]
+        assert v["determinism_ok"] == doc["determinism_ok"]
+        assert v["aligned_bit_identical"] == doc["aligned_bit_identical"]
+        assert v["nonaligned_all_bit_identical"] == doc["nonaligned_all_bit_identical"]
+        assert v["nonaligned_reproducible"] == doc.get("nonaligned_reproducible")
+        rec = doc["max_nonaligned_rel_diff"]
+        assert v["max_nonaligned_rel_diff"] == rec or (
+            math.isnan(v["max_nonaligned_rel_diff"]) and math.isnan(rec)
+        )
+        # recomputed per-arm annotations match what the probe wrote
+        for new, old in zip(rows, doc["arms"]):
+            if "bit_identical" in old:
+                assert new["bit_identical"] == old["bit_identical"]
+
+
+class StubDriver:
+    base_url = "stub://"
+
+
+class StubTrace(SegSweep):
+    """SegSweep with execute() replaced by canned rows (no SDK/torch)."""
+
+    def __init__(self, rows, **kw):
+        super().__init__(**kw)
+        self._rows = rows
+
+    def execute(self, driver):
+        return [dict(r) for r in self._rows]
+
+
+class TestRunner:
+    def make_doc(self, values, expect=None, tmp_path=None):
+        trace = StubTrace(rows_for(values))
+        return runner.run(
+            invariants.get("SPLIT_INV"),
+            trace,
+            tag="stub",
+            out_dir=str(tmp_path) if tmp_path else None,
+            expect=expect,
+            driver=StubDriver(),
+        )
+
+    def test_verdict_doc_matches_schema(self, tmp_path):
+        doc = self.make_doc([3.0] * 6, tmp_path=tmp_path)
+        schema = json.loads(
+            (Path(runner.__file__).parent / "verdicts" / "schema.json").read_text()
+        )
+        jsonschema = pytest.importorskip("jsonschema")
+        jsonschema.validate(doc, schema)
+        assert doc["gate"] == "SPLIT_INV.seg_sweep"
+        assert doc["claimed_level"] == "E0"
+        assert doc["passed"] is True
+        written = json.loads(
+            (tmp_path / "split_inv.seg_sweep_stub.json").read_text()
+        )
+        assert written["artifacts"] == doc["artifacts"]
+
+    def test_expect_grading(self):
+        doc = self.make_doc(
+            [3.0, 3.0, 3.0 + 1e-6, 3.0 + 2e-6, 3.0 + 1e-6, 3.0],
+            expect="E0_ALIGNED_ONLY",
+        )
+        assert doc["passed"] is False
+        assert doc["expect_met"] is True

--- a/tests/test_gates_verdicts.py
+++ b/tests/test_gates_verdicts.py
@@ -177,3 +177,58 @@ class TestRunner:
         )
         assert doc["passed"] is False
         assert doc["expect_met"] is True
+
+
+class RecordingDriver(StubDriver):
+    """Driver that records delete_model calls (the cleanup contract)."""
+
+    def __init__(self):
+        self.deleted = []
+
+    def delete_model(self, model_id):
+        self.deleted.append(model_id)
+        return True
+
+
+class TestModelCleanup:
+    """A gate owns the models it creates: miles does not auto-reap them, and
+    a leftover model wedges the next gate's create_model in placement."""
+
+    def _trace(self, rows, models):
+        t = StubTrace(rows)
+        t.created_models = list(models)
+        return t
+
+    def test_models_released_after_run(self):
+        driver = RecordingDriver()
+        trace = self._trace(rows_for([3.0] * 6), ["model_a"])
+        runner.run(invariants.get("SPLIT_INV"), trace, tag="stub", driver=driver)
+        assert driver.deleted == ["model_a"]
+        assert trace.created_models == []
+
+    def test_models_released_even_when_trace_raises(self):
+        driver = RecordingDriver()
+        trace = self._trace(rows_for([3.0] * 6), ["model_b"])
+
+        def boom(_driver):
+            trace.created_models.append("model_c")
+            raise RuntimeError("arm exploded mid-sweep")
+
+        trace.execute = boom
+        with pytest.raises(RuntimeError, match="exploded"):
+            runner.run(invariants.get("SPLIT_INV"), trace, tag="stub", driver=driver)
+        assert driver.deleted == ["model_b", "model_c"]
+
+    def test_cleanup_failure_does_not_mask_verdict(self):
+        """A leaked model is an operational problem; losing the verdict that
+        cost a cluster run is worse. Cleanup warns and the result stands."""
+
+        class AngryDriver(StubDriver):
+            def delete_model(self, model_id):
+                raise RuntimeError("delete endpoint down")
+
+        trace = self._trace(rows_for([3.0] * 6), ["model_d"])
+        doc = runner.run(invariants.get("SPLIT_INV"), trace, tag="stub",
+                         driver=AngryDriver())
+        assert doc["outcome"] == "E0_ARBITRARY"
+        assert doc["passed"] is True

--- a/tests/test_gates_verdicts.py
+++ b/tests/test_gates_verdicts.py
@@ -232,3 +232,30 @@ class TestModelCleanup:
                          driver=AngryDriver())
         assert doc["outcome"] == "E0_ARBITRARY"
         assert doc["passed"] is True
+
+
+class TestAlignedOnlySweep:
+    """A sweep of only aligned arms asks nothing about split-invariance and
+    must say so rather than crashing on an empty max()."""
+
+    def test_no_nonaligned_arm_is_inconclusive(self):
+        rows = [
+            {"arm": "A1", "segmentation": [8], "grad_norm": 3.0},
+            {"arm": "ALIGNED", "segmentation": [4, 4], "grad_norm": 3.0},
+            {"arm": "A2", "segmentation": [8], "grad_norm": 3.0},
+        ]
+        v = verdict(rows, E0)
+        assert v["outcome"] == "NO_NONALIGNED_ARM"
+        assert v["passed"] is None
+        assert v["delta"] == 0.0
+        assert "cannot distinguish" in v["verdict"]
+
+    def test_still_reports_a_failed_determinism_control(self):
+        rows = [
+            {"arm": "A1", "segmentation": [8], "grad_norm": 3.0},
+            {"arm": "ALIGNED", "segmentation": [4, 4], "grad_norm": 3.0},
+            {"arm": "A2", "segmentation": [8], "grad_norm": 3.5},
+        ]
+        v = verdict(rows, E0)
+        assert v["outcome"] == "INCONCLUSIVE"
+        assert v["passed"] is None


### PR DESCRIPTION
## What this is

The checking layer for the TinkerCloud API as a shippable artifact — P1 of `specs/014-gate-suite/design.md`. A gate is one composition, **invariant × trace × arm → verdict JSON**, instead of a 300-line script per question:

```python
from gates import invariants, runner
from gates.traces import SegSweep

runner.run(invariants.get("SPLIT_INV"), SegSweep(model="Qwen/Qwen3-8B-Base"),
           tag="nemo_rl_tp2", out_dir="results")
```

```
invariants.py   the S3 contract as first-class objects (id, statement, claimed
                level, comparator, tolerance source, paper pointer)
traces/         canonical trace generators — the admission clause made executable
drivers/        run a trace through the public SDK/HTTP surface ONLY; a gate
                cannot reach an engine internal a client could not
comparators.py  E0 bitwise / E1 calibrated bar / E2 measured envelope
runner.py       composition, model reaping, uniform verdict JSON, CLI
verdicts/       schema.json — history in, certificate-bearing verdict out
```

**Nothing under `training/` changes.** No request path, no backend code. Three pre-existing files move: `pyproject.toml` ships `gates/` as a package, and the two deploy scripts bundle it and editable-install `/app` (Ray workers import `training.*` by module path, so `PYTHONPATH=/app` never reaches them). Those three landed in `5307ab0` and have run on both cluster pods for a week.

## The three gates

| Gate | Invariant | Source |
|---|---|---|
| `seg_sweep` | `SPLIT_INV` | migrated from the 008 + 013 g1b probes — 0.5B and 8B are two parameter points of one trace, not two files |
| `order_perm` | `PARTITION_INV` | migrated from `specs/014 probes/order_perm_probe.py`, the instrument that root-caused defect 2 |
| `seed_repro` | `SEED_REPRO` | new — the guard the seed fix (#38) shipped without |

Migrated gates preserve datum generators, arm naming and verdict semantics token-for-token, so every recorded results JSON stays comparable. That is enforced, not asserted: **all six recorded g1b runs and all 13 recorded `order_perm_*.json` runs replay against the migrated logic** and reproduce their per-arm annotations and classifications.

### `PARTITION_INV` is strictly stronger than `SPLIT_INV`

One call, all 8 datums, no split and no pad — only the submission order changes. Defect 2 (the DDP reduction, fixed in #37) was **invisible at `SPLIT_INV`'s aligned arm yet caught by a single permuted call**.

The verdict is three-way, keyed on the fact that `SWAP_PAIRS` and `REVERSE` induce the *same* rank partition but different concatenation orders — the two failure modes a binary order-invariance check confounds, and they coincided on miles, which is why the confusion went unnoticed for so long:

- `SWAP_PAIRS != IDENT` **and** `== REVERSE` → **PARTITION-SENSITIVE** (the gradient is a function of which datums share a rank — miles pre-`39add0a`, 5.1e-03)
- `SWAP_PAIRS == IDENT`, something else moves → **PARTITION-INVARIANT, order-sensitive** (fp addition is commutative but not associative — the buffered/nemo_rl signature, ~1e-07)
- all arms bit-identical → **INVARIANT**
- neither signature → **UNCLASSIFIED** (`passed=None`; the gate declines to guess)

### `SEED_REPRO` uses three arms, and the third one is the point

`LoraConfig.seed` was declared on the API, carried into every backend's `create_model`, and read by none. An engine that ignores the client's seed and falls back to a fixed internal default (Megatron's `--seed` defaults to 1234) **reproduces perfectly across a same-seed pair and looks healthy**. So the trace runs `SEED_A / SEED_A_R` at one seed and `SEED_B` at another, and separates `SEED_HONORED` from `SEED_IGNORED` from `NOT_REPRODUCIBLE`.

It earned that on its first live run — see below.

## Live results (ns.config, both pods at `NUM_GPUS=4`, Qwen2.5-0.5B r32, lr=0)

| Gate | arm | outcome | expected | met |
|---|---|---|---|---|
| `SEED_REPRO` | `miles_dp4` **pre-deploy** | `SEED_IGNORED` | `SEED_HONORED` | **no** |
| `SEED_REPRO` | `miles_dp4` post-deploy | `SEED_HONORED` | `SEED_HONORED` | yes |
| `SEED_REPRO` | `nemorl_dp4` | `SEED_HONORED` | `SEED_HONORED` | yes |
| `PARTITION_INV` | `miles_dp4_seed7` | `INVARIANT` | `INVARIANT` | yes |
| `PARTITION_INV` | `miles_dp4_default_seed` | `ORDER_SENSITIVE_UNCLASSIFIED` | `INVARIANT` | **no** |
| `PARTITION_INV` | `nemorl_dp4_seed7` | `INVARIANT` | `INVARIANT` | yes |

**The seed gate caught a real gap on its first run.** The miles pod was serving pre-`995945e` code: `/app/training/core/slime_builder.py` was byte-identical to merged main *except* for the six `'--seed'` lines #38 added — the pod had never been re-bundled after the merge. Seeds 7 and 99 gave a **bit-identical** gradient, 123.48147159847505 for all three arms. Merged ≠ deployed, and a same-seed pair alone would have passed. After deploying the merged builder and restarting: 124.09015749647511 / 124.09015749647511 / 119.7348755780349 → `SEED_HONORED`.

**One caveat worth a reviewer's attention.** `PARTITION_INV` passes bitwise on both backends at dp=4 at seed 7 — but at the engine default init the same gate puts `SWAP_PAIRS` **6.405e-08** off `IDENT`, reproducibly across a server restart and a fresh model. miles' post-fix partition invariance is bitwise *at the inits measured*, not structurally, and the residual sits at the ~1e-07 floor. That run is classified `ORDER_SENSITIVE_UNCLASSIFIED` rather than failed, because the `SWAP_PAIRS`/`REVERSE` discriminator is a **dp=2** argument: the grouping is the partition of datum indices by position residue mod dp, so at dp=4 every default arm permutes the residue classes wholesale and preserves the grouping. The gate cannot separate partition from reduction order there and says so. Documented in the trace docstring and in `specs/014-gate-suite/RESULTS-P1-PARTITION-SEED.md`.

## Two operational contracts the runner enforces

- **A gate deletes the models it creates** (`d6d96ed`). miles never reaps them and one leftover wedges the next gate's `create_model` in Ray placement — four runs were lost to this before it was fixed. Cleanup is best-effort and never masks a verdict: losing a verdict that cost a cluster run is worse than leaking a model. `seed_repro` goes further and releases each arm's model *before* creating the next, since three live models do not fit a 4-GPU pod.
- **An aligned-only sweep is inconclusive, not a crash** (`215257a`). It reports `NO_NONALIGNED_ARM` with `passed=None`, because such a sweep asked nothing about split-invariance.

`passed=None` is a first-class outcome throughout — the runner distinguishes "could not decide" from False.

## Testing

**71 offline tests, no server and no GPU** (`pytest tests/test_gates_verdicts.py tests/test_gates_order_perm.py tests/test_gates_seed_repro.py`), ruff clean. Verdict logic is a module-level pure function per trace, so recorded JSONs replay offline; SDK/torch imports stay inside `execute()`.

The replay tests read the monorepo's `specs/*/results/`; they are `skipif`-guarded, so a standalone `tinker-cloud` checkout skips them and the other 45 still run.

## Not in this PR

Remaining P1 migrations, as follow-ups: G2 (client-order / `DEFER_OBS`), and promoting `inert_probe` / `pad_equiv_probe` as `ZERO_WEIGHT_INERT` / `PAD_EQUIV`. P2 (observable chokepoint) and P3 (`calibration.json`, content-addressed fixtures, CI tiers) per the design doc's phasing.

**DP width is deliberately not an arm anywhere.** It is fixed by the server's `NUM_GPUS` at launch, so one gate process cannot sweep it — a width comparison means invoking the runner once per server configuration and diffing the verdicts. Recorded as the design in the docstrings and README, not as a TODO.
