### PR TITLE
gates: README — how to read a verdict, not just how to run one

### DIFF
--- a/gates/README.md
+++ b/gates/README.md
@@ -4,6 +4,10 @@ The checking layer for the TinkerCloud API as a shippable artifact.
 Design, phasing (P1/P2/P3), and SOTA positioning:
 `specs/014-gate-suite/design.md` in the monorepo.
 
+**Status: P1 merged** (#39) — registry, trace/driver/oracle/comparator
+split, runner + verdict schema, and three gates. Remaining P1 migrations
+and P2/P3 are in the map below.
+
 A gate is one composition — **invariant × trace × arm → verdict** —
 instead of a 300-line script:
 
@@ -34,8 +38,8 @@ python -m gates.runner seg_sweep --tag nemo_rl_tp2 --model Qwen/Qwen3-8B-Base \
 # reordered_gpu_ids[gpu_index] at NUM_GPUS=2)
 python -m gates.runner order_perm --tag miles_dp4 --seed 7 --debug-train-only \
     --expect INVARIANT
-python -m gates.runner order_perm --tag nemo_rl_dp4 --seed 7 --debug-train-only \
-    --expect PARTITION_INVARIANT_ORDER_SENSITIVE
+python -m gates.runner order_perm --tag nemo_rl_dp2 --seed 7 --debug-train-only \
+    --expect PARTITION_INVARIANT_ORDER_SENSITIVE   # dp=4 is INVARIANT
 
 # SEED_REPRO: does the backend read LoraConfig.seed at all
 python -m gates.runner seed_repro --tag nemo_rl_dp4 --debug-train-only \
@@ -51,6 +55,89 @@ all — LoRA `B` is zero-initialized, so no step-0 observable can see `A`.
 Exit code 0 iff `passed` (strict invariant at its claimed level) or, when
 `--expect` is given, the outcome matches the prediction. Verdict JSONs
 conform to `verdicts/schema.json`.
+
+## Invariants
+
+`invariants.py` is the registry. Each entry carries a statement, the
+**claimed** equivalence level, the comparator that discharges it, where its
+tolerance comes from, and the label it answers to in the manuscript.
+
+| id | level | asks |
+|---|---|---|
+| `SPLIT_INV` | E0 | is a round's result independent of how the client segmented it |
+| `PARTITION_INV` | E0 | is the gradient independent of which datums share a DP rank |
+| `SEED_REPRO` | E0 | is the client's seed read, or defaulted behind its back |
+| `DEFER_OBS` | E0 | is deferring `fb` to `optim_step` the identity on observables |
+| `ISOLATION` | E0 | do co-located tenants observe what they would serialized |
+| `PIN_DRIFT` | E0 | does a pinned sampler stay bit-stable as training moves |
+| `ADAPTER_ORACLE` | E1 | do engine logprobs match an offline fp32 HF(+PEFT) oracle |
+| `ENDPOINT_NLL` | E2 | does endpoint NLL land inside the measured rerun envelope |
+
+`PARTITION_INV` is **strictly stronger than `SPLIT_INV`**: the DP-reduction
+defect (`39add0a`) was invisible at `SPLIT_INV`'s aligned arm yet caught by
+a single permuted call.
+
+## Outcomes
+
+Each trace owns a vocabulary; the runner records it verbatim and
+`--expect` grades against it.
+
+| trace | outcomes |
+|---|---|
+| `seg_sweep` | `E0_ARBITRARY` · `E0_ALIGNED_ONLY` · `E0_BROKEN` · `NO_NONALIGNED_ARM`⁰ · `INCONCLUSIVE`⁰ |
+| `order_perm` | `INVARIANT` · `PARTITION_INVARIANT_ORDER_SENSITIVE` · `PARTITION_SENSITIVE` · `ORDER_SENSITIVE_UNCLASSIFIED`⁰ · `NO_PARTITION_ARM`⁰ · `NO_DETERMINISM_CONTROL`⁰ · `INCONCLUSIVE`⁰ |
+| `seed_repro` | `SEED_HONORED` · `SEED_IGNORED` · `NOT_REPRODUCIBLE` · `NO_CONTRAST_ARM`⁰ · `NO_REPEAT_ARM`⁰ |
+
+⁰ = `passed: null`. **"Could not decide" is a first-class outcome**, distinct
+from False: a failed determinism control, an arm set that never asked the
+question, or — for `order_perm` — arms that match neither known signature.
+A gate that cannot answer must say so rather than guess.
+
+Two outcomes are worth reading twice:
+
+- `PARTITION_INVARIANT_ORDER_SENSITIVE` **passes**. The rank-flipping
+  permutation is bit-identical, so the partition does not reach the
+  gradient, which is what `PARTITION_INV` claims; the residual is
+  concatenation order (fp addition is commutative but not associative) and
+  is reported in `detail`, not treated as a failure.
+- `SEED_IGNORED` needs the third arm to exist at all. An engine that
+  ignores the client's seed and falls back to a fixed internal default
+  reproduces perfectly across a same-seed pair — so `seed_repro` runs
+  `SEED_A`/`SEED_A_R` at one seed **and `SEED_B` at another**.
+
+## Contracts the runner enforces
+
+- **A gate deletes the models it creates.** miles never reaps them, and one
+  leftover wedges the next gate's `create_model` in Ray placement (four
+  runs were lost to this before it was fixed). Cleanup is best-effort and
+  never masks a verdict — losing a result that cost a cluster run is worse
+  than leaking a model. `seed_repro` goes further and releases each arm's
+  model *before* creating the next: three live models do not fit a 4-GPU
+  pod.
+- **A trace's verdict logic is a module-level pure function**, so recorded
+  JSONs replay offline. SDK/torch imports stay inside `execute()`; the
+  verdict layer loads without a GPU stack.
+- **Recorded results stay comparable.** Migrated gates preserve datum
+  generators, arm naming and verdict semantics token-for-token. The datum
+  generator in `traces/common.py` is byte-identical to the probes' — do not
+  "improve" it.
+
+## What the suite has caught
+
+Live runs and full numbers: `specs/014-gate-suite/RESULTS-P1-SMOKE.md` and
+`RESULTS-P1-PARTITION-SEED.md` (monorepo).
+
+- **A split-invariance failure on miles** contradicting this repo's own
+  recorded artifacts — first live run of the migrated `seg_sweep`. Two
+  engine defects behind it, both since fixed (`e37b8a2`, `39add0a`).
+- **A merged-but-not-deployed backend.** `seed_repro`'s first run found the
+  miles pod serving pre-`995945e` code: seeds 7 and 99 gave a bit-identical
+  gradient. The pod was perfectly reproducible the whole time on Megatron's
+  own default of 1234 — a same-seed pair alone would have passed.
+- **An init-dependent residual.** `PARTITION_INV` is bitwise on both
+  backends at dp=4 at seed 7, but at the engine default init `SWAP_PAIRS`
+  sits 6.405e-08 off `IDENT`, reproducibly. Post-fix partition invariance
+  is bitwise at the inits measured, not structurally.
 
 ## Layout
 


### PR DESCRIPTION
Docs only. Follows #39, which put `gates/` on main.

The README explained **how to invoke** a gate but not **how to read one**. A reader who ran `order_perm` and got `ORDER_SENSITIVE_UNCLASSIFIED`, or ran `seed_repro` and got `SEED_IGNORED`, had to go to the source to learn whether that meant "broken", "did not ask", or "fine but worth noting".

## Added

**The invariant registry as a table** — all eight entries with their claimed level and the question each one asks, plus the one relationship that matters: `PARTITION_INV` is strictly stronger than `SPLIT_INV`, because the DP-reduction defect (`39add0a`) was invisible at `SPLIT_INV`'s aligned arm yet caught by a single permuted call.

**Per-trace outcome vocabularies**, with `passed: null` marked on every outcome that carries it. "Could not decide" is a first-class outcome here, distinct from False — a failed determinism control, an arm set that never asked the question, or arms matching neither known signature. That distinction is load-bearing and was invisible in the docs.

**The two outcomes that read wrong at first glance:**

- `PARTITION_INVARIANT_ORDER_SENSITIVE` **passes**. The rank-flip is bit-identical, so the partition does not reach the gradient — which is precisely what the invariant claims. The residual is concatenation order and is reported in `detail`, not treated as failure.
- `SEED_IGNORED` only exists because `seed_repro` runs a **third** arm at a different seed. An engine that ignores the client's seed and falls back to a fixed internal default reproduces perfectly across a same-seed pair.

**The contracts the runner enforces** — a gate reaps the models it creates (and `seed_repro` releases each arm's model before creating the next, since three live models do not fit a 4-GPU pod); verdict logic is a module-level pure function so recorded JSONs replay offline; datum generators are byte-frozen so recorded results stay comparable.

**What the suite has caught** — the split-invariance failure, the merged-but-not-deployed backend, and the init-dependent 6.405e-08 residual, with pointers to the two results docs. Those three findings are the argument for the suite existing, and the README made none of it.

## Fixed

The nemo_rl `order_perm` example expected `PARTITION_INVARIANT_ORDER_SENSITIVE` at **dp=4**, where the measurement is `INVARIANT` — that signature is dp=1/dp=2. Copy-pasting the example as written would have produced a spurious `expect NOT MET`.

## Checked

The invariant ids and every outcome name in the README are asserted against `invariants.REGISTRY` and each trace's `OUTCOME_VERDICTS` — no drift between the doc and the code at time of writing. 71 gate tests still pass; no code changed.
