### PR TITLE
miles: publish the interchange adapter on single-tenant saves too

### DIFF
--- a/tests/test_checkpoint_interchange.py
+++ b/tests/test_checkpoint_interchange.py
@@ -103,6 +103,93 @@ class TestPublishAndStage:
         assert ci.read_adapter_config(root) is None
 
 
+class TestTorchBinFallback:
+    """Miles' native export is `adapter_model.bin` (its fused-QKV lora_A is
+    aliased across q/k/v and safetensors refuses shared storage). The publish
+    path must convert it, cloning the aliased storages en route — regression
+    for the conv_mig_main relay failure (2026-08-17)."""
+
+    def _write_bin_adapter(self, d, aliased=True):
+        os.makedirs(d, exist_ok=True)
+        shared = torch.full((2, 2), 3.0)
+        state = {
+            "model.layers.0.self_attn.q_proj.lora_A.weight": shared,
+            "model.layers.0.self_attn.k_proj.lora_A.weight": shared if aliased else shared.clone(),
+            "model.layers.0.self_attn.q_proj.lora_B.weight": torch.full((2, 2), 4.0),
+        }
+        torch.save(state, os.path.join(d, ci.ADAPTER_WEIGHTS_TORCH_FILE))
+        with open(os.path.join(d, ci.ADAPTER_CONFIG_FILE), "w") as f:
+            json.dump({"peft_type": "LORA", "r": 32, "lora_alpha": 32}, f)
+        return d
+
+    def test_bin_with_aliased_tensors_publishes_as_safetensors(self, tmp_path):
+        src = self._write_bin_adapter(str(tmp_path / "iter" / "adapter"))
+        root = str(tmp_path / "ckpt")
+        os.makedirs(root)
+        published = ci.export_hf_adapter(src, root)
+        assert published == os.path.join(root, ci.HF_ADAPTER_DIRNAME)
+        out = load_file(os.path.join(published, ci.ADAPTER_WEIGHTS_FILE))
+        assert sorted(out) == [
+            ci.PEFT_PREFIX + "model.layers.0.self_attn.k_proj.lora_A.weight",
+            ci.PEFT_PREFIX + "model.layers.0.self_attn.q_proj.lora_A.weight",
+            ci.PEFT_PREFIX + "model.layers.0.self_attn.q_proj.lora_B.weight",
+        ]
+        assert float(out[ci.PEFT_PREFIX + "model.layers.0.self_attn.q_proj.lora_A.weight"][0, 0]) == 3.0
+        # the interchange copy is now loadable by find/stage like any other
+        assert ci.find_hf_adapter(root) == published
+
+    def test_safetensors_still_wins_when_both_exist(self, tmp_path):
+        src = self._write_bin_adapter(str(tmp_path / "src"))
+        save_file(
+            {BARE_KEY: torch.full((2, 2), 9.0)},
+            os.path.join(src, ci.ADAPTER_WEIGHTS_FILE),
+            metadata={"format": "pt"},
+        )
+        root = str(tmp_path / "ckpt")
+        os.makedirs(root)
+        ci.export_hf_adapter(src, root)
+        out = load_file(os.path.join(root, ci.HF_ADAPTER_DIRNAME, ci.ADAPTER_WEIGHTS_FILE))
+        assert list(out) == [ci.PEFT_PREFIX + BARE_KEY]
+        assert float(out[ci.PEFT_PREFIX + BARE_KEY][0, 0]) == 9.0
+
+
+class TestSingleTenantNativePublish:
+    """save_checkpoint must publish the interchange adapter in single-tenant
+    mode too — the hook rode the pool-only adapter_save_dir since the
+    multi-LoRA merge, silently breaking the miles->X interchange edge."""
+
+    def test_newest_iter_adapter_is_published(self, tmp_path):
+        from tinkercloud.training.backends.miles.backend import _publish_native_adapter
+
+        save_root = tmp_path / "save"
+        for i, val in ((1, 1.0), (2, 2.0)):
+            d = save_root / f"iter_{i:07d}" / "adapter"
+            os.makedirs(d)
+            torch.save(
+                {"model.layers.0.self_attn.q_proj.lora_A.weight": torch.full((2, 2), val)},
+                os.path.join(d, ci.ADAPTER_WEIGHTS_TORCH_FILE),
+            )
+            os.utime(d, (i * 1000, i * 1000))
+
+        class Args:
+            save = str(save_root)
+
+        root = str(tmp_path / "ckpt")
+        _publish_native_adapter(Args(), root)
+        out = load_file(os.path.join(root, ci.HF_ADAPTER_DIRNAME, ci.ADAPTER_WEIGHTS_FILE))
+        assert float(next(iter(out.values()))[0, 0]) == 2.0
+
+    def test_missing_save_root_is_a_warning_not_a_crash(self, tmp_path):
+        from tinkercloud.training.backends.miles.backend import _publish_native_adapter
+
+        class Args:
+            save = str(tmp_path / "nonexistent")
+
+        _publish_native_adapter(Args(), str(tmp_path / "ckpt"))
+        _publish_native_adapter(None, str(tmp_path / "ckpt"))
+        assert not os.path.exists(os.path.join(tmp_path / "ckpt", ci.HF_ADAPTER_DIRNAME))
+
+
 class TestPeftKeyNormalization:
     def test_bare_megatron_keys_gain_the_peft_prefix(self, tmp_path):
         """Miles/Bridge exports bare module paths; PeftModel.from_pretrained

--- a/training/backends/checkpoint_interchange.py
+++ b/training/backends/checkpoint_interchange.py
@@ -22,6 +22,7 @@ logger = logging.getLogger(__name__)
 CHECKPOINT_BASE = "/data/checkpoints"
 HF_ADAPTER_DIRNAME = "hf_adapter"
 ADAPTER_WEIGHTS_FILE = "adapter_model.safetensors"
+ADAPTER_WEIGHTS_TORCH_FILE = "adapter_model.bin"
 ADAPTER_CONFIG_FILE = "adapter_config.json"
 
 
@@ -87,6 +88,30 @@ def _write_peft_keyed(weights_src: str, weights_dst: str) -> None:
     )
 
 
+def _write_peft_keyed_from_torch(weights_src: str, weights_dst: str) -> None:
+    """Convert a torch-serialized adapter (`adapter_model.bin`) to the
+    interchange safetensors, normalizing keys as `_write_peft_keyed` does.
+
+    Miles falls back to `.bin` because its fused-QKV export aliases the
+    shared lora_A across q/k/v and safetensors refuses shared storage;
+    tensors are cloned here so the file is loadable everywhere downstream.
+    """
+    import torch
+    from safetensors.torch import save_file
+
+    state = torch.load(weights_src, map_location="cpu", weights_only=True)
+    logger.info("Converting %d torch-serialized adapter tensors to safetensors", len(state))
+    save_file(
+        {
+            (k if k.startswith(PEFT_PREFIX) else f"{PEFT_PREFIX}{k}"):
+                v.detach().clone().contiguous()
+            for k, v in state.items()
+        },
+        weights_dst,
+        metadata={"format": "pt"},
+    )
+
+
 def export_hf_adapter(src_dir: str, checkpoint_root: str) -> Optional[str]:
     """Publish an adapter a backend just wrote into the interchange dir.
 
@@ -95,8 +120,12 @@ def export_hf_adapter(src_dir: str, checkpoint_root: str) -> Optional[str]:
     fine-tune, or a save that predates the first optimizer step).
     """
     weights_src = os.path.join(src_dir, ADAPTER_WEIGHTS_FILE)
-    if not os.path.isfile(weights_src):
-        logger.info("No %s under %s; skipping interchange export", ADAPTER_WEIGHTS_FILE, src_dir)
+    weights_torch_src = os.path.join(src_dir, ADAPTER_WEIGHTS_TORCH_FILE)
+    if not os.path.isfile(weights_src) and not os.path.isfile(weights_torch_src):
+        logger.info(
+            "No %s or %s under %s; skipping interchange export",
+            ADAPTER_WEIGHTS_FILE, ADAPTER_WEIGHTS_TORCH_FILE, src_dir,
+        )
         return None
 
     dest = hf_adapter_dir(checkpoint_root)
@@ -104,7 +133,10 @@ def export_hf_adapter(src_dir: str, checkpoint_root: str) -> Optional[str]:
     tmp = dest + ".tmp"
     shutil.rmtree(tmp, ignore_errors=True)
     os.makedirs(tmp, exist_ok=True)
-    _write_peft_keyed(weights_src, os.path.join(tmp, ADAPTER_WEIGHTS_FILE))
+    if os.path.isfile(weights_src):
+        _write_peft_keyed(weights_src, os.path.join(tmp, ADAPTER_WEIGHTS_FILE))
+    else:
+        _write_peft_keyed_from_torch(weights_torch_src, os.path.join(tmp, ADAPTER_WEIGHTS_FILE))
 
     config_src = os.path.join(src_dir, ADAPTER_CONFIG_FILE)
     if os.path.isfile(config_src):

--- a/training/backends/miles/backend.py
+++ b/training/backends/miles/backend.py
@@ -61,6 +61,32 @@ def _publish_adapter(adapter_save_dir: Path, checkpoint_path: str, adapter_name:
     )
 
 
+def _publish_native_adapter(args, checkpoint_path: str) -> None:
+    """Single-tenant publish: miles' save_model writes the PEFT pair only into
+    its native `<args.save>/iter_*/adapter` dir (as `adapter_model.bin` — the
+    fused-QKV lora_A aliasing makes safetensors refuse), and nothing exported
+    the interchange copy since the publish hook moved onto the pool-mode
+    `adapter_save_dir`. Pick the adapter dir the save just wrote (newest
+    mtime; the numeric iter suffix is miles' own counter, monotone per save)
+    and export it. Runs under the handle's lock right after save_model, so
+    newest-mtime is the one this save produced."""
+    save_root = getattr(args, "save", None) if args else None
+    if not save_root or not os.path.isdir(save_root):
+        logger.warning("No miles save root at %r; skipping interchange publish", save_root)
+        return
+    candidates = [
+        os.path.join(save_root, d, "adapter")
+        for d in os.listdir(save_root)
+        if d.startswith("iter_")
+    ]
+    candidates = [c for c in candidates if os.path.isdir(c)]
+    if not candidates:
+        logger.warning("No iter_*/adapter under %s; nothing to publish", save_root)
+        return
+    latest = max(candidates, key=os.path.getmtime)
+    export_hf_adapter(latest, resolve_checkpoint_root(checkpoint_path, create=True))
+
+
 def _model_input_lens(data: List[Any]) -> List[int]:
     """Per-datum model_input token lengths (the observation-contract unit:
     fb logprobs are datum-aligned to these, NOT to rollout tokens which
@@ -1107,6 +1133,8 @@ class MilesBackend(TrainingBackend):
                 await asyncio.to_thread(
                     _publish_adapter, h.adapter_save_dir, checkpoint_path, h.adapter_name,
                 )
+            else:
+                await asyncio.to_thread(_publish_native_adapter, h.args, checkpoint_path)
             return checkpoint_path
 
         try:


### PR DESCRIPTION
## The gap

Since the multi-LoRA merge, `save_checkpoint`'s interchange publish rides `adapter_save_dir`, which **only pool mode sets**. A single-tenant miles save writes its native `<save>/iter_*/adapter` pair and nothing exports the `hf_adapter/` interchange copy — `/data/checkpoints/<model_id>/<name>/` never materializes, and every cross-backend resume from a miles checkpoint silently loses its source.

Found live: the `conv_mig_main` relay (re-baseline ruling (a)) failed at the miles→nemo_rl stage with nothing to stage. The Aug-6 banked relay worked because it ran on a pre-merge revision whose save still exported the adapter.

## The fix, two halves

- **`miles/backend.py`** — `save_checkpoint` publishes the newest native `iter_*/adapter` into the interchange dir when `adapter_save_dir` is unset; pool mode unchanged. Runs under the handle's lock right after `save_model`, so newest-mtime is the dir this save wrote.
- **`checkpoint_interchange.py`** — `export_hf_adapter` learns the `adapter_model.bin` fallback. Miles exports `.bin` because its fused-QKV `lora_A` is storage-aliased across q/k/v and safetensors refuses shared storage; the converter clones each tensor and normalizes to PEFT keys so `find_hf_adapter`/`stage_hf_adapter` work downstream unchanged. safetensors still wins when both exist.

## Verification

- 4 new tests: aliased-bin publish, safetensors precedence, newest-iter selection, missing-root no-crash.
- The conversion encoded here was first done by hand on the live artifact (336 tensors, 72 aliased storage groups) and verified **roundtrip max|diff| exactly 0.0**; the relay's leg b then resumed from it correctly (step-74 NLL 2.268 vs 2.464 base — the resume is real, not a silent BASE start).
- 15/15 interchange + 46 backend tests pass on the miles pod; ruff clean.
