### PR TITLE
Q4 probes + pod ops helpers + optim_step grad_norm seam fix

### DIFF
--- a/scripts/gates/README.md
+++ b/scripts/gates/README.md
@@ -17,6 +17,8 @@ rotate the server between runs (models are not auto-reaped).
 | `g5_pinned_v0.py` | G5 pinned-v0 + sampler routing | v0 sampler == base, bit-stable across training; live != base; per-tenant routing (B live == base while A live differs) |
 | `g6_batch_invariance.py` | G6 batch-invariance (M3, AC1) | same tenant data solo vs co-batched with different co-tenant mixes ⇒ bit-identical per-tenant grad_norm + logprobs (needs `TINKERCLOUD_MILES_COBATCH_MAX_SAMPLES>=16`) |
 
+| `g6b_cobatch_token_bucket.py` | G6b generalised co-batching E0 gate (the repair's gate) | sweeps `n` ACROSS the predicted band instead of sampling one point. Asserts BOTH that every arm is bit-identical AND that the arms the law calls safe still merge — either alone is trivially satisfiable. `--expect-band` is the control: with `TINKERCLOUD_MILES_COBATCH_E0_TOKENS=0` the band must REAPPEAR. Needs `COBATCH_MAX_SAMPLES>=2048`. |
+
 | `g9_adapter_interchange.py` | G9a adapter round-trip / G9b seam continuity | `export`: exported `hf_adapter/` reproduces the training engine's logprobs under fp32 HF+peft (corr > 0.999, gap < 0.03 nats). `import`: a model created FROM that checkpoint on another backend matches the source's logprobs on the same frozen probe batch |
 
 G9 is the Q5 migration seam gate (specs/007-q5-migration). Run `export` on

--- a/scripts/gates/g6b_cobatch_token_bucket.py
+++ b/scripts/gates/g6b_cobatch_token_bucket.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""G6b — generalised co-batching E0 gate (the repair's gate).
+
+G6 asserts that a tenant's batch is bit-identical run solo vs merged with
+another tenant's, but tests exactly ONE size. The 2026-08-21 attribution showed
+that size sits on the safe side of a threshold G6 does not know exists:
+
+  a tenant's gradient is bit-identical solo vs co-batched IFF both calls'
+  per-rank token totals fall on the same side of T ~ 512 tokens/rank.
+
+Co-batching adds the co-tenant's tokens to the rank, so a merge can move the
+call across T. The repair refuses exactly those merges
+(``TINKERCLOUD_MILES_COBATCH_E0_TOKENS``, default 512;
+``converter.cobatch_preserves_token_bucket``).
+
+This gate sweeps n ACROSS the predicted band instead of sampling one point,
+and asserts two things, because either alone is trivially satisfiable:
+
+  (A) every arm is bit-identical  -- a guard that refuses everything passes A
+  (B) the arms the law says are SAFE still merge -- a guard that is switched
+      off passes B
+
+PASS requires both. Run against a pool-mode server with merging on:
+  TINKERCLOUD_MILES_MULTILORA_SLOTS>0, COBATCH_MAX_SAMPLES>=2048.
+
+  python3 g6b_cobatch_token_bucket.py                 # guard on (expect PASS)
+  python3 g6b_cobatch_token_bucket.py --expect-band   # guard OFF: assert the
+                                                      # band REAPPEARS (control)
+"""
+import argparse
+import os
+import sys
+import time
+
+os.environ.setdefault("TINKER_BASE_URL", "http://localhost:8000")
+os.environ.setdefault("TINKER_API_KEY", "tml-dev-key")
+BASE = os.environ["TINKER_BASE_URL"]
+KEY = os.environ["TINKER_API_KEY"]
+
+import requests
+import torch
+
+import tinker
+from tinker import types
+
+BASE_MODEL = os.environ.get("G6B_MODEL", "Qwen/Qwen2.5-0.5B")
+RANK = int(os.environ.get("G6B_RANK", "32"))
+SEQ = 64                 # -> 63 tokens per datum
+THRESHOLD = 512
+HDRS = {"X-API-Key": KEY, "Content-Type": "application/json"}
+
+
+def make_datums(n, salt, seq=SEQ):
+    out = []
+    for i in range(n):
+        toks = [(1000 + (salt * 31 + i) * 7919 + j * 104729) % 50000 for j in range(seq)]
+        inp, tgt = toks[:-1], toks[1:]
+        out.append(types.Datum(
+            model_input=types.ModelInput.from_ints(inp),
+            loss_fn_inputs={
+                "weights": types.TensorData.from_torch(torch.ones(len(inp), dtype=torch.float32)),
+                "target_tokens": types.TensorData.from_torch(torch.tensor(tgt, dtype=torch.long)),
+            },
+        ))
+    return out
+
+
+def step_lr0(model_id):
+    r = requests.post(f"{BASE}/api/v1/optim_step", headers=HDRS,
+                      json={"model_id": model_id, "adam_params": {"learning_rate": 0.0}})
+    r.raise_for_status()
+    rid = r.json()["request_id"]
+    deadline = time.time() + 600
+    while time.time() < deadline:
+        fr = requests.post(f"{BASE}/api/v1/retrieve_future/{rid}", headers=HDRS)
+        if fr.status_code == 200:
+            return fr.json()
+        if fr.status_code == 408:
+            time.sleep(2)
+            continue
+        print(f"STEP FAILED ({fr.status_code}): {fr.text[:400]}")
+        sys.exit(2)
+    sys.exit(2)
+
+
+def per_rank(n, dp, tok):
+    """Same arithmetic the server guard uses: pad to a dp multiple, then stride."""
+    lengths = [tok] * n
+    if dp > 1 and n % dp:
+        lengths += [tok] * (dp - n % dp)
+    return sum(lengths[0::dp])
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dp", type=int, default=2)
+    ap.add_argument("--ns", default="6,8,9,10,12,16,20,24")
+    ap.add_argument("--expect-band", action="store_true",
+                    help="guard OFF control: require the predicted band to FAIL")
+    cli = ap.parse_args()
+    tok = SEQ - 1
+    ns = [int(x) for x in cli.ns.split(",")]
+
+    sc = tinker.ServiceClient()
+    tc_a = sc.create_lora_training_client(base_model=BASE_MODEL, rank=RANK)
+    tc_b = sc.create_lora_training_client(base_model=BASE_MODEL, rank=RANK)
+    print(f"A={tc_a.model_id} B={tc_b.model_id}", flush=True)
+    blocker = make_datums(int(os.environ.get("G6B_BLOCKER", "2")), salt=9)
+    rows, fails = [], []
+
+    try:
+        make_datums(8, salt=99)  # warm-up shapes below
+        for idx, n in enumerate(ns):
+            a_ds, b_ds = make_datums(n, salt=1), make_datums(n, salt=2)
+            solo_t, co_t = per_rank(n, cli.dp, tok), per_rank(2 * n, cli.dp, tok)
+            safe = (solo_t <= THRESHOLD) == (co_t <= THRESHOLD)
+
+            r_solo = tc_a.forward_backward(a_ds, "cross_entropy").result()
+            gn_solo = step_lr0(tc_a.model_id).get("grad_norm")
+
+            fut_blk = tc_a.forward(blocker, "cross_entropy")
+            time.sleep(float(os.environ.get("G6B_SETTLE", "0.2")))
+            fut_a = tc_a.forward_backward(a_ds, "cross_entropy")
+            fut_b = tc_b.forward_backward(b_ds, "cross_entropy")
+            fut_blk.result()
+            r_co = fut_a.result(); fut_b.result()
+            merged = any("co_batched_fb" in k for k in (r_co.metrics or {}))
+            gn_co = step_lr0(tc_a.model_id).get("grad_norm")
+            step_lr0(tc_b.model_id)
+
+            identical = repr(gn_solo) == repr(gn_co)
+            rows.append((n, solo_t, co_t, safe, merged, identical, gn_solo, gn_co))
+            if idx == 0:
+                continue                        # arm 0 absorbs kernel warm-up
+            if cli.expect_band:
+                if safe and not identical:
+                    fails.append(f"n={n} is SAFE by the law but diverged")
+                if not safe and identical and merged:
+                    fails.append(f"n={n} should straddle and diverge, but was identical")
+            else:
+                if not identical:
+                    fails.append(f"n={n} NOT bit-identical ({gn_solo!r} vs {gn_co!r})")
+                if safe and not merged:
+                    fails.append(f"n={n} is safe but did NOT merge (guard too strict / merging off)")
+    finally:
+        for m in (tc_b.model_id, tc_a.model_id):
+            try:
+                requests.post(f"{BASE}/api/v1/delete_model", headers=HDRS,
+                              json={"model_id": m}, timeout=120)
+            except Exception as e:  # noqa: BLE001
+                print(f"DELETE FAILED {m}: {e}")
+
+    print(f"\n{'n':>4} {'solo/rk':>8} {'co/rk':>7} {'law':>7} {'merged':>7} {'bit-id':>7}")
+    for n, s, c, safe, merged, identical, _, _ in rows:
+        print(f"{n:>4} {s:>8} {c:>7} {'safe' if safe else 'STRADDLE':>8} "
+              f"{str(merged):>7} {str(identical):>7}")
+
+    merged_any = any(r[4] for r in rows[1:])
+    print(f"\n(A) all bit-identical : {all(r[5] for r in rows[1:])}")
+    print(f"(B) safe arms merged  : {all(r[4] for r in rows[1:] if r[3])}  "
+          f"(any merge at all: {merged_any})")
+    if not cli.expect_band and not merged_any:
+        fails.append("no arm merged at all — the gate would pass vacuously")
+
+    if fails:
+        print("\nG6b: FAIL")
+        for f in fails:
+            print(f"  {f}")
+        return 1
+    print("\nG6b: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/gates/q4b_tenant.py
+++ b/scripts/gates/q4b_tenant.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Q4-B probe tenant: parameterized sl_basic (NoRobots, Qwen2.5-0.5B r32).
+
+One tenant of the merge-pricing probe: the overhead-fraction axis is set by Q4B_BATCH x Q4B_MAXLEN (per-call tokens).
+The dp2 E0-guard bucket boundary is batch*(maxlen-1) <= 1024 tokens/call
+(<=512/rank): batch 8 x maxlen 128 = 1016 sits deterministically in the low
+bucket, so under the guard every cross-tenant merge is refused; batch 128 x
+maxlen 2048 sits far above it, so every merge is admitted.
+"""
+
+import asyncio
+import os
+
+os.environ.setdefault("TINKER_BASE_URL", "http://localhost:8000")
+os.environ.setdefault("TINKER_API_KEY", "tml-dev-key")
+
+from tinker_cookbook.recipes.chat_sl import chat_datasets
+from tinker_cookbook.renderers import TrainOnWhat
+from tinker_cookbook.supervised import train
+from tinker_cookbook.supervised.types import ChatDatasetBuilderCommonConfig
+
+MODEL = os.environ.get("Q4B_MODEL", "Qwen/Qwen2.5-0.5B")
+BATCH = int(os.environ.get("Q4B_BATCH", "8"))
+MAXLEN = int(os.environ.get("Q4B_MAXLEN", "128"))
+STEPS = int(os.environ.get("Q4B_STEPS", "30"))
+LOG_PATH = os.environ["Q4B_LOG_PATH"]
+
+config = train.Config(
+    log_path=LOG_PATH,
+    model_name=MODEL,
+    renderer_name="qwen3",
+    dataset_builder=chat_datasets.NoRobotsBuilder(
+        common_config=ChatDatasetBuilderCommonConfig(
+            model_name_for_tokenizer=MODEL,
+            renderer_name="qwen3",
+            max_length=MAXLEN,
+            batch_size=BATCH,
+            train_on_what=TrainOnWhat.ALL_ASSISTANT_MESSAGES,
+        )
+    ),
+    learning_rate=2e-4,
+    lr_schedule="linear",
+    num_epochs=1,
+    max_steps=STEPS,
+    lora_rank=32,
+    eval_every=0,
+    save_every=0,
+)
+
+if __name__ == "__main__":
+    asyncio.run(train.main(config))

--- a/scripts/gates/q4w_width.py
+++ b/scripts/gates/q4w_width.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Q4-W: price merge WIDTH directly (closed-loop clients expose a merge
+frontier of ~2; this measures what width w in {1,2,4,8} would buy if a scheduler exposed it).
+
+Server must be pool mode, merging on, guard OFF (we price the move itself):
+  TINKERCLOUD_MILES_MULTILORA_SLOTS=8  TINKERCLOUD_MILES_TRAIN_GPUS=2
+  TINKERCLOUD_MILES_COBATCH_MAX_SAMPLES=2048
+  TINKERCLOUD_MILES_COBATCH_REORDER=1  TINKERCLOUD_MILES_COBATCH_E0_TOKENS=0
+
+Method (G7's blocker pattern, all SDK-submitted): per round, submit a fat
+forward as a queue blocker, then w fb's (8 datums x seq 128 each — the Q4-B
+S workload, ~1016 tok/call) from w distinct tenants back-to-back; they queue
+behind the blocker and the drain merges all w into one call. T(w) = wall
+from blocker completion to all fb results. The blocker term cancels because
+w=1 is measured the same way. Rounds that fail to reach the target width
+are discarded (achieved width read from the co_batched_fb result metric).
+
+Emits one JSON line per arm and a summary.
+"""
+
+import json
+import os
+import sys
+import time
+
+os.environ.setdefault("TINKER_BASE_URL", "http://localhost:8000")
+os.environ.setdefault("TINKER_API_KEY", "tml-dev-key")
+BASE = os.environ["TINKER_BASE_URL"]
+KEY = os.environ["TINKER_API_KEY"]
+
+import requests
+import torch
+import tinker
+from tinker import types
+
+BASE_MODEL = os.environ.get("Q4W_MODEL", "Qwen/Qwen2.5-0.5B")
+RANK = int(os.environ.get("Q4W_RANK", "32"))
+SEQ = 128          # datum length; input len SEQ-1 -> 8x127 = 1016 tok/call
+N_DATUMS = 8
+N_TENANTS = 8
+WIDTHS = [int(w) for w in os.environ.get("Q4W_WIDTHS", "1,2,4,8").split(",")]
+ROUNDS = int(os.environ.get("Q4W_ROUNDS", "14"))
+WARM = 2
+HDRS = {"X-API-Key": KEY, "Content-Type": "application/json"}
+LR0 = types.AdamParams(learning_rate=0.0)
+
+
+def make_datums(n, salt, seq=SEQ):
+    out = []
+    for i in range(n):
+        toks = [(1000 + (salt * 31 + i) * 7919 + j * 104729) % 50000 for j in range(seq)]
+        inp, tgt = toks[:-1], toks[1:]
+        out.append(types.Datum(
+            model_input=types.ModelInput.from_ints(inp),
+            loss_fn_inputs={
+                "weights": types.TensorData.from_torch(
+                    torch.ones(len(inp), dtype=torch.float32)),
+                "target_tokens": types.TensorData.from_torch(
+                    torch.tensor(tgt, dtype=torch.long)),
+            },
+        ))
+    return out
+
+
+def achieved_width(results):
+    return sum(1 for r in results if any("co_batched_fb" in k for k in (r.metrics or {})))
+
+
+def main():
+    sc = tinker.ServiceClient()
+    print(f"creating {N_TENANTS} tenants", flush=True)
+    tcs = [sc.create_lora_training_client(base_model=BASE_MODEL, rank=RANK)
+           for _ in range(N_TENANTS)]
+    for i, tc in enumerate(tcs):
+        print(f"  t{i}={tc.model_id}", flush=True)
+
+    probes = [make_datums(N_DATUMS, salt=10 + i) for i in range(N_TENANTS)]
+    blocker = make_datums(256, salt=99)
+
+    summary = {}
+    for w in WIDTHS:
+        walls, widths_seen, discarded = [], [], 0
+        for rnd in range(ROUNDS):
+            fut_blk = tcs[0].forward(blocker, "cross_entropy")
+            time.sleep(0.05)  # let the blocker reach the drain head
+            futs = [tcs[i].forward_backward(probes[i], "cross_entropy")
+                    for i in range(w)]
+            t_submitted = time.time()
+            fut_blk.result()
+            t_blk = time.time()
+            results = [f.result() for f in futs]
+            t_end = time.time()
+            aw = achieved_width(results) if w > 1 else 1
+            widths_seen.append(aw)
+            # grads must not accumulate across rounds; await so no step
+            # bleeds into the next round's timing window
+            for f in [tcs[i].optim_step(LR0) for i in range(w)]:
+                f.result()
+            ok = (w == 1 or aw == w) and t_submitted < t_blk
+            if rnd < WARM or not ok:
+                discarded += int(rnd >= WARM)
+                continue
+            walls.append(t_end - t_blk)
+        walls.sort()
+        med = walls[len(walls) // 2] if walls else None
+        summary[w] = {
+            "median_s": med, "n": len(walls), "discarded": discarded,
+            "min_s": walls[0] if walls else None,
+            "widths_seen": widths_seen,
+        }
+        print(json.dumps({"width": w, **summary[w]}), flush=True)
+
+    t1 = summary.get(1, {}).get("median_s")
+    print("\nwidth  T(w) med    per-call    vs w x T(1)")
+    for w in WIDTHS:
+        med = summary[w]["median_s"]
+        if med is None:
+            print(f"{w:>5}  (no valid rounds)")
+            continue
+        line = f"{w:>5}  {med*1000:8.1f}ms  {med/w*1000:8.1f}ms"
+        if t1 and w > 1:
+            line += f"  {med/(w*t1):8.3f}x"
+        print(line)
+
+    for tc in tcs:
+        requests.post(f"{BASE}/api/v1/delete_model", headers=HDRS,
+                      json={"model_id": tc.model_id})
+    print("MODELS_DELETED", flush=True)
+    print("Q4W_SUMMARY " + json.dumps(summary), flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/patch_bridge_hide_adapters.py
+++ b/scripts/patch_bridge_hide_adapters.py
@@ -1,0 +1,93 @@
+"""Re-apply the Megatron-Bridge `hide_adapters` guard on a miles pod.
+
+UPSTREAM BUG: `hide_adapters()` pops the `adapters` submodule while the base
+checkpoint loads, but `MultiLoRALinear.state_dict` and `.sharded_state_dict`
+reach for `self.adapters` unguarded. So *any* torch_dist / megatron-path
+base load of a multi-LoRA model dies with
+
+    AttributeError: 'MultiLoRALinear' object has no attribute 'adapters'
+
+Upstream never hits it because their driver loads the base via bridge-HF.
+`MultiLoRAGroupedExpertLinear` subclasses `MultiLoRALinear`, so guarding the
+base class covers both.
+
+The fix lands in pod site-packages and is lost on every pod rebuild or
+image re-pull — re-apply it after either, before pool-mode `create_model`
+(pod_ready_miles.sh does this automatically).
+
+    python3 patch_bridge_hide_adapters.py            # apply (idempotent)
+    python3 patch_bridge_hide_adapters.py --check    # report only, rc=1 if unpatched
+    python3 patch_bridge_hide_adapters.py --revert
+
+Durable fix is a Megatron-Bridge PR + re-bake with a new pin; until then
+this script is the record.
+"""
+
+
+import argparse
+import sys
+
+TARGET = "/usr/local/lib/python3.12/dist-packages/megatron/bridge/peft/multi_lora_layers.py"
+MARKER = "# tinkercloud-patch: hide_adapters guard"
+
+BEFORE_SD = """        self.to_wrap.state_dict(destination=destination, prefix=prefix, keep_vars=keep_vars)
+        self.adapters.state_dict(destination=destination, prefix=f"{prefix}adapters.", keep_vars=keep_vars)
+        return destination"""
+
+AFTER_SD = """        self.to_wrap.state_dict(destination=destination, prefix=prefix, keep_vars=keep_vars)
+        _adapters = getattr(self, "adapters", None)  # tinkercloud-patch: hide_adapters guard
+        if _adapters is not None:
+            _adapters.state_dict(destination=destination, prefix=f"{prefix}adapters.", keep_vars=keep_vars)
+        return destination"""
+
+BEFORE_SSD = """        for i, adapter in enumerate(self.adapters):
+            sharded_sd.update(adapter.sharded_state_dict(f"{prefix}adapters.{i}.", sharded_offsets, metadata))"""
+
+AFTER_SSD = """        for i, adapter in enumerate(getattr(self, "adapters", None) or []):  # tinkercloud-patch: hide_adapters guard
+            sharded_sd.update(adapter.sharded_state_dict(f"{prefix}adapters.{i}.", sharded_offsets, metadata))"""
+
+PAIRS = ((BEFORE_SD, AFTER_SD), (BEFORE_SSD, AFTER_SSD))
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--check", action="store_true")
+    ap.add_argument("--revert", action="store_true")
+    ap.add_argument("--file", default=TARGET)
+    a = ap.parse_args()
+
+    src = open(a.file).read()
+    patched = MARKER in src
+
+    if a.check:
+        print(f"{'PATCHED' if patched else 'UNPATCHED'}  {a.file}")
+        return 0 if patched else 1
+
+    if a.revert:
+        if not patched:
+            print("already unpatched; nothing to do")
+            return 0
+        for before, after in PAIRS:
+            if after not in src:
+                print(f"REFUSING: patched text not found, file diverged:\n{after[:80]}")
+                return 2
+            src = src.replace(after, before)
+        open(a.file, "w").write(src)
+        print(f"reverted {a.file}")
+        return 0
+
+    if patched:
+        print("already patched; nothing to do")
+        return 0
+    for before, after in PAIRS:
+        if before not in src:
+            print(f"REFUSING: expected upstream text not found, file diverged:\n{before[:80]}")
+            return 2
+        src = src.replace(before, after)
+    open(a.file, "w").write(src)
+    print(f"patched {a.file} (2 sites)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/pod_ready_miles.sh
+++ b/scripts/pod_ready_miles.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Idempotent readiness check + repair for the tinkercloud-miles pod.
+# Run after deploy_tinkercloud.sh --profile miles (or at the start of any
+# session): every step verifies before it acts, so a healthy pod passes in
+# seconds and a fresh pod is fully staged.
+#
+#   pod_ready_miles.sh [model-basename]     # default Qwen2.5-0.5B
+#
+# Covers what deploy_tinkercloud.sh does not:
+#   - HF weights staged + miles' FLAT model dir (not hub layout)
+#   - torch_dist conversion (/data is an emptyDir — dies with the pod)
+#   - Megatron-Bridge hide_adapters patch (lands in pod site-packages,
+#     lost on every rebuild/re-pull — see scripts/patch_bridge_hide_adapters.py)
+#   - /data service dirs
+#   - code-hash spot-check of the deployed code vs the local source trees
+set -euo pipefail
+
+MODEL="${1:-Qwen2.5-0.5B}"
+HF_ID="${HF_ID:-Qwen/$MODEL}"
+export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/ns.config}"
+NS="${NS:-tinkercloud-nemorl}"
+POD="${POD:-tinkercloud-miles}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# deploy_tinkercloud.sh --source dev bundles the sibling checkouts of
+# tinker-cookbook and tinker_gmi next to this repo; the hash check below
+# compares the deployed copies against the same siblings.
+SRC_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+EX() { kubectl -n "$NS" exec "$POD" -- bash -c "$1"; }
+
+echo "==> [1/6] pod alive + GPUs visible"
+EX "nvidia-smi --query-gpu=index,memory.used --format=csv,noheader"
+
+echo "==> [2/6] /data service dirs"
+EX "mkdir -p /data/metadata /data/checkpoints /data/conv /data/trajectories"
+
+echo "==> [3/6] HF weights + flat dir ($MODEL)"
+if ! EX "test -f /data/.cache/huggingface/$MODEL/config.json"; then
+  EX "export HF_HOME=/data/.cache/huggingface HF_TOKEN=\$(cat /tmp/hf_token.txt)
+      python3 -c \"from huggingface_hub import snapshot_download; print(snapshot_download('$HF_ID'))\" > /tmp/snap_path.txt
+      ln -sfn \$(cat /tmp/snap_path.txt) /data/.cache/huggingface/$MODEL
+      test -f /data/.cache/huggingface/$MODEL/config.json"
+  echo "    staged + flat-linked"
+else
+  echo "    present"
+fi
+
+echo "==> [4/6] torch_dist conversion"
+if ! EX "ls /data/.cache/huggingface/${MODEL}_torch_dist/iter_* >/dev/null 2>&1 || test -f /data/.cache/huggingface/${MODEL}_torch_dist/latest_checkpointed_iteration.txt"; then
+  MODEL_SH=$(echo "$MODEL" | tr '[:upper:]' '[:lower:]' | sed 's/^qwen/qwen/')
+  EX "set -u; export HF_HOME=/data/.cache/huggingface PYTHONDONTWRITEBYTECODE=1
+      cd /root/miles && source scripts/models/${MODEL_SH}.sh
+      PYTHONPATH=/root/Megatron-LM torchrun --nproc-per-node 1 \
+        tools/convert_hf_to_torch_dist.py \"\${MODEL_ARGS[@]}\" \
+        --hf-checkpoint /data/.cache/huggingface/$MODEL \
+        --save /data/.cache/huggingface/${MODEL}_torch_dist"
+  echo "    converted"
+else
+  echo "    present"
+fi
+
+echo "==> [5/6] hide_adapters patch"
+kubectl -n "$NS" cp "$SCRIPT_DIR/patch_bridge_hide_adapters.py" "$POD:/data/patch_bridge_hide_adapters.py"
+EX "python3 /data/patch_bridge_hide_adapters.py"
+
+echo "==> [6/6] code-hash spot-check vs local source trees"
+FAIL=0
+for pair in \
+  "tinker-cloud/training/backends/miles/backend.py /app/training/backends/miles/backend.py" \
+  "tinker-cookbook/tinker_cookbook/supervised/train.py /work/tinker-cookbook/tinker_cookbook/supervised/train.py" \
+  "tinker_gmi/src/tinker/__init__.py /work/tinker_gmi/src/tinker/__init__.py"; do
+  L=$(echo "$pair" | cut -d' ' -f1); R=$(echo "$pair" | cut -d' ' -f2)
+  LH=$(md5sum "$SRC_ROOT/$L" | cut -d' ' -f1)
+  RH=$(EX "md5sum $R" | cut -d' ' -f1)
+  if [ "$LH" != "$RH" ]; then echo "    DRIFT: $R != local $L"; FAIL=1; fi
+done
+if [ "$FAIL" = 1 ]; then
+  echo "    pod code drifted — rerun: deploy_tinkercloud.sh --profile miles --code-only"
+  exit 1
+fi
+echo "==> READY: $POD staged for $MODEL"

--- a/scripts/pod_rotate_server.sh
+++ b/scripts/pod_rotate_server.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Rotate the TinkerCloud API server on a pod: kill server -> drain GPUs ->
+# boot with the given env -> verify bind in the NEW server's own log.
+#
+#   pod_rotate_server.sh <server-log-basename> [KEY=VAL ...]
+#
+# e.g. pod_rotate_server.sh q4b_S_guard_server \
+#        TINKERCLOUD_MILES_MULTILORA_SLOTS=8 TINKERCLOUD_MILES_COBATCH_MAX_SAMPLES=2048
+#
+# Hard-won rotation rules encoded: bracketed launch-flag-agnostic pkill in
+# its own exec, server killed before Ray is touched, sglang stragglers
+# killed explicitly, bind verified in the NEW server's own log (never by
+# curl alone). Env: KUBECONFIG, NS, POD, GPUS overridable.
+set -euo pipefail
+
+LOG_NAME="${1:?usage: pod_rotate_server.sh <server-log-basename> [KEY=VAL ...]}"
+shift
+EXTRA_ENV=("$@")
+
+export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/ns.config}"
+NS="${NS:-tinkercloud-nemorl}"
+POD="${POD:-tinkercloud-miles}"
+GPUS="${GPUS:-4}"
+BACKEND="${BACKEND:-miles}"
+SERVER_LOG="/data/${LOG_NAME}.log"
+
+EX() { kubectl -n "$NS" exec "$POD" -- bash -c "$1"; }
+EX_TIMEOUT() { timeout "$1" kubectl -n "$NS" exec "$POD" -- bash -c "$2" || true; }
+
+# 1. kill the server (own exec; launch-flag-agnostic bracketed pattern)
+echo "==> killing server"
+EX "pkill -f 'm trainin[g]' || true; sleep 8"
+
+# 2. drain GPUs; after 60s kill sglang stragglers (they survive server death
+#    holding ~24GB and wedge the next create_model)
+echo "==> draining GPUs"
+DRAINED=0
+for i in $(seq 1 24); do
+  USED=$(EX "nvidia-smi --query-gpu=memory.used --format=csv,noheader,nounits | awk '{s+=\$1} END {print s}'")
+  if [ "${USED:-99999}" -lt 500 ]; then DRAINED=1; break; fi
+  [ "$i" = 12 ] && EX "pkill -9 -f 'sglan[g]::' || true"
+  sleep 5
+done
+if [ "$DRAINED" != 1 ]; then
+  echo "ERROR: GPUs did not drain:"; EX "nvidia-smi --query-gpu=index,memory.used --format=csv"
+  exit 1
+fi
+
+# 3. Ray head must show 0 GPU in use (leaked PGs = footgun 12) — else recycle it
+RAY_OK=$(EX "ray status 2>/dev/null | grep -Eo '[0-9.]+/[0-9.]+ GPU' | head -1" || true)
+case "$RAY_OK" in
+  0.0/*) : ;;
+  *)
+    echo "==> Ray head unhealthy ($RAY_OK); recycling"
+    EX "ray stop --force >/dev/null 2>&1 || true; rm -rf /tmp/ray; ray start --head --num-gpus $GPUS --disable-usage-stats > /tmp/ray_start.log 2>&1 < /dev/null; sleep 5" ;;
+esac
+
+# 4. boot the new server (detached; all fds redirected; timeout-wrapped exec)
+echo "==> booting server ($SERVER_LOG)"
+ENV_LINES=""
+for kv in "${EXTRA_ENV[@]:-}"; do
+  [ -n "$kv" ] && ENV_LINES+="export $kv"$'\n'
+done
+EX "rm -f $SERVER_LOG"
+EX_TIMEOUT 30 "
+export PYTHONPATH=/app NUM_GPUS=$GPUS RAY_ADDRESS=ray://localhost:10001
+export HF_TOKEN=\$(cat /tmp/hf_token.txt) HF_HOME=/data/.cache/huggingface
+export TINKER_API_KEY=tml-dev-key TINKERCLOUD_BACKEND=$BACKEND ALLOW_PARTIAL_BATCHES=true
+$ENV_LINES
+cd /app && setsid nohup python3 -m training > $SERVER_LOG 2>&1 < /dev/null &
+sleep 2; echo LAUNCHED"
+
+# 5. verify in the NEW log (a curl-200 alone can be a zombie on :8000)
+echo "==> verifying bind"
+for _ in $(seq 1 20); do
+  if EX "grep -q 'error while attempting to bind' $SERVER_LOG 2>/dev/null"; then
+    echo "ERROR: bind failed — a zombie server still owns :8000"; EX "tail -5 $SERVER_LOG"; exit 1
+  fi
+  if EX "grep -q 'Uvicorn running' $SERVER_LOG 2>/dev/null"; then
+    CODE=$(EX "curl -s -o /dev/null -w '%{http_code}' --max-time 3 http://localhost:8000/health" || echo 000)
+    if [ "$CODE" = 200 ]; then echo "==> server healthy ($SERVER_LOG)"; exit 0; fi
+  fi
+  sleep 5
+done
+echo "ERROR: server did not become healthy; last log lines:"; EX "tail -20 $SERVER_LOG"
+exit 1

--- a/tests/test_optim_metrics_seam.py
+++ b/tests/test_optim_metrics_seam.py
@@ -1,0 +1,52 @@
+"""grad_norm must reach SDK clients via the metrics dict.
+
+The SDK's OptimStepResponse carries only `metrics` (upstream shape), so a
+grad_norm left at the top level of the optim_step payload is silently
+dropped at the client seam — probe clients reading per-cycle grad norms
+got null on every cycle. The service now mirrors it
+into metrics; these tests keep that seam checked.
+"""
+
+import asyncio
+
+import pytest
+
+try:
+    from training.services.training_service import TrainingService
+except ImportError:  # pragma: no cover
+    TrainingService = None
+
+
+pytestmark = pytest.mark.skipif(
+    TrainingService is None, reason="training package not importable"
+)
+
+
+class _StubBackend:
+    def __init__(self, result):
+        self._result = result
+
+    async def apply_optimizer_step(self, handle, learning_rate=None, adam_params=None):
+        return dict(self._result)
+
+
+def _step(result):
+    svc = TrainingService(backend=_StubBackend(result))
+    return asyncio.run(svc.apply_optimizer_step("m1", {"backend_handle": object()}))
+
+
+def test_grad_norm_mirrored_into_metrics():
+    result = _step({"grad_norm": 2.5, "success": True})
+    assert result["metrics"]["grad_norm"] == 2.5
+    assert result["grad_norm"] == 2.5  # top level kept for raw-HTTP clients
+
+
+def test_existing_metrics_not_clobbered():
+    result = _step({"grad_norm": 2.5, "metrics": {"grad_norm": 7.0, "total_loss": 0.1}})
+    assert result["metrics"]["grad_norm"] == 7.0  # backend's own value wins
+    assert result["metrics"]["total_loss"] == 0.1
+
+
+def test_absent_grad_norm_leaves_metrics_alone():
+    result = _step({"success": True})
+    assert "grad_norm" not in (result.get("metrics") or {})

--- a/training/backends/miles/backend.py
+++ b/training/backends/miles/backend.py
@@ -191,6 +191,10 @@ class MilesPool:
     # (cross-tenant order is not contractual; per-tenant FIFO is preserved
     # via the blocked-tenant rule). Off by default.
     cobatch_reorder: bool = False
+    # E0 admission guard: refuse a merge that would move the call's per-rank
+    # token total across this boundary. 0 disables. See
+    # converter.cobatch_preserves_token_bucket.
+    cobatch_e0_tokens: int = 512
 
 
 class MilesBackend(TrainingBackend):
@@ -584,6 +588,9 @@ class MilesBackend(TrainingBackend):
                 pool.cobatch_reorder = bool(int(
                     os.environ.get("TINKERCLOUD_MILES_COBATCH_REORDER", "0") or 0
                 ))
+                pool.cobatch_e0_tokens = int(
+                    os.environ.get("TINKERCLOUD_MILES_COBATCH_E0_TOKENS", "512") or 0
+                )
                 pool.dispatcher = asyncio.create_task(self._pool_dispatcher_loop(pool))
                 if pool.cobatch_max_samples > 0:
                     logger.info(
@@ -591,6 +598,11 @@ class MilesBackend(TrainingBackend):
                         " (reorder drain %s)",
                         pool.cobatch_max_samples,
                         "ON" if pool.cobatch_reorder else "off",
+                    )
+                    logger.info(
+                        "Pool co-batch E0 guard: %s",
+                        f"refuse merges crossing {pool.cobatch_e0_tokens} tokens/rank"
+                        if pool.cobatch_e0_tokens > 0 else "OFF (merges may break E0)",
                     )
                 self._pool = pool
 
@@ -715,6 +727,11 @@ class MilesBackend(TrainingBackend):
                     and nxt.loss_fn == op.loss_fn
                     and nxt.tenant not in blocked
                     and total + nxt.num_samples <= pool.cobatch_max_samples
+                    and self.converter.cobatch_preserves_token_bucket(
+                        [o.rollout_data for o in batch] + [nxt.rollout_data],
+                        _dp_size(pool.args),
+                        pool.cobatch_e0_tokens,
+                    )
                 ):
                     batch.append(nxt)
                     total += nxt.num_samples

--- a/training/backends/miles/converter.py
+++ b/training/backends/miles/converter.py
@@ -129,6 +129,57 @@ class MilesDataConverter(DataConverter):
         return n_pad
 
     @staticmethod
+    def per_rank_token_totals(batches: List[Any], dp_size: int) -> List[int]:
+        """Per-rank packed-token totals for the call that would dispatch `batches`.
+
+        Mirrors the engine's own split so the guard below reasons about the
+        shape actually handed to the kernels: samples concatenate in request
+        order, the batch is padded to a multiple of ``dp_size`` (pads copy the
+        tail sample, so they carry its length — see
+        :meth:`pad_rollout_data_to_dp`), and rank *i* takes the strided slice
+        ``range(i, N, dp_size)`` (miles
+        ``ray/rollout/train_data_conversion.py:211``). The per-slot sort that
+        follows it reorders within a rank but does not move samples between
+        ranks, so it cannot change these totals.
+        """
+        dp = max(int(dp_size), 1)
+        lengths = [len(t) for b in batches for t in b.get("tokens", ())]
+        if not lengths:
+            return [0] * dp
+        if dp > 1 and len(lengths) % dp:
+            lengths = lengths + [lengths[-1]] * (dp - len(lengths) % dp)
+        return [sum(lengths[i::dp]) for i in range(dp)]
+
+    @staticmethod
+    def cobatch_preserves_token_bucket(
+        batches: List[Any], dp_size: int, threshold: int
+    ) -> bool:
+        """Whether merging `batches` keeps every constituent's per-rank token
+        bucket — the E0 admission test for co-batching.
+
+        Measured 2026-08-21 (23/23 pairs, 7/7 out-of-sample): a tenant's
+        gradient is bit-identical between solo and co-batched execution **iff
+        both calls' per-rank token totals fall on the same side of a threshold
+        near 512**. Merging adds the co-tenant's tokens to the rank, so it can
+        move the call across that boundary; refusing exactly those merges is
+        what keeps co-batching E0-exact. Everything else still merges.
+
+        Conservative by construction: a merge is admitted only when *every*
+        rank of *every* constituent, and every rank of the merged call, land in
+        the same bucket. ``threshold <= 0`` disables the guard.
+        """
+        if threshold <= 0 or len(batches) < 2:
+            return True
+        buckets = {t <= threshold
+                   for t in MilesDataConverter.per_rank_token_totals(batches, dp_size)}
+        for b in batches:
+            buckets |= {t <= threshold
+                        for t in MilesDataConverter.per_rank_token_totals([b], dp_size)}
+            if len(buckets) > 1:
+                return False
+        return len(buckets) == 1
+
+    @staticmethod
     def merge_forward_backward_batches(batches: List[Any]) -> Any:
         """Concatenate per-request rollout_data dicts into one mixed-slot
         batch (M3 co-batching). Per-sample list keys concatenate in request

--- a/training/services/training_service.py
+++ b/training/services/training_service.py
@@ -93,6 +93,14 @@ class TrainingService:
             handle, learning_rate=learning_rate, adam_params=adam_params_dict,
         )
 
+        # Mirror top-level grad_norm into the metrics dict: the SDK's
+        # OptimStepResponse carries only `metrics` (upstream shape), so a
+        # value left at top level is silently dropped at the client seam.
+        if result.get("grad_norm") is not None:
+            metrics = dict(result.get("metrics") or {})
+            metrics.setdefault("grad_norm", float(result["grad_norm"]))
+            result["metrics"] = metrics
+
         logger.info(
             "Optimizer step completed for %s: grad_norm=%s, success=%s",
             model_id,


### PR DESCRIPTION
Three commits:

- **miles pool E0 guard + G6b gate**: refuse co-batch merges that cross the per-rank token bucket boundary (`TINKERCLOUD_MILES_COBATCH_E0_TOKENS`, default 512; 0 disables). G6b sweeps the band and asserts both that every arm is bit-identical and that law-safe arms still merge; `--expect-band` is the guard-off control; env overrides (`G6B_MODEL/RANK/BLOCKER/SETTLE`) support cross-model calibration.
- **Q4 probe harnesses + pod ops helpers**: parameterized sl_basic tenant runner; merge-width pricing harness (forced single merged calls of width 1/2/4/8); idempotent miles pod staging; scripted server rotation; vendored hide_adapters pod patch.
- **optim_step grad_norm seam fix**: the server declares `grad_norm` required at the payload top level, but the SDK's `OptimStepResponse` (upstream shape) silently drops unknown fields — mirror it into the `metrics` dict so every unmodified client sees it; regression tests included.
