### PR TITLE
E0 guard threshold from a calibration registry; guard refusal ends the merge window

### DIFF
--- a/scripts/gates/g6b_cobatch_token_bucket.py
+++ b/scripts/gates/g6b_cobatch_token_bucket.py
@@ -26,8 +26,12 @@ PASS requires both. Run against a pool-mode server with merging on:
   python3 g6b_cobatch_token_bucket.py                 # guard on (expect PASS)
   python3 g6b_cobatch_token_bucket.py --expect-band   # guard OFF: assert the
                                                       # band REAPPEARS (control)
+  python3 g6b_cobatch_token_bucket.py --emit-entry --tp 1   # guard OFF:
+      # calibration mode — no PASS/FAIL, prints an e0_calibration.json entry
+      # (human-reviewed before it lands in the registry)
 """
 import argparse
+import json
 import os
 import sys
 import time
@@ -97,6 +101,13 @@ def main():
     ap.add_argument("--ns", default="6,8,9,10,12,16,20,24")
     ap.add_argument("--expect-band", action="store_true",
                     help="guard OFF control: require the predicted band to FAIL")
+    ap.add_argument("--emit-entry", action="store_true",
+                    help="calibration mode (run with the guard OFF): derive an "
+                         "e0_calibration.json entry from the sweep instead of "
+                         "asserting PASS/FAIL")
+    ap.add_argument("--tp", type=int, default=1,
+                    help="tensor-parallel width of the pool under test "
+                         "(recorded in the emitted entry)")
     cli = ap.parse_args()
     tok = SEQ - 1
     ns = [int(x) for x in cli.ns.split(",")]
@@ -132,6 +143,8 @@ def main():
             rows.append((n, solo_t, co_t, safe, merged, identical, gn_solo, gn_co))
             if idx == 0:
                 continue                        # arm 0 absorbs kernel warm-up
+            if cli.emit_entry:
+                continue                        # calibration: no gate semantics
             if cli.expect_band:
                 if safe and not identical:
                     fails.append(f"n={n} is SAFE by the law but diverged")
@@ -159,6 +172,48 @@ def main():
     print(f"\n(A) all bit-identical : {all(r[5] for r in rows[1:])}")
     print(f"(B) safe arms merged  : {all(r[4] for r in rows[1:] if r[3])}  "
           f"(any merge at all: {merged_any})")
+
+    if cli.emit_entry:
+        # Calibration derivation over arms that actually merged (unmerged
+        # arms are vacuous: their "co" run executed solo). A divergent arm's
+        # boundary lies in (solo_t, co_t); emit the conservative lower edge
+        # and record the bracket for human review.
+        merged_rows = [r for r in rows[1:] if r[4]]
+        if not merged_rows:
+            print("\nEMIT-ENTRY INVALID: no arm merged — check the server has "
+                  "merging ON and the guard OFF, and rerun.")
+            return 1
+        totals = sorted({t for r in merged_rows for t in (r[1], r[2])})
+        divergent = [r for r in merged_rows if not r[5]]
+        if divergent:
+            lo = max(r[1] for r in divergent)
+            hi = min(r[2] for r in divergent)
+            threshold, note = lo, (
+                f"boundary bracketed in ({lo}, {hi}) tokens/rank; "
+                f"{len(divergent)}/{len(merged_rows)} merged arms diverged"
+            )
+        else:
+            threshold, note = None, (
+                f"all {len(merged_rows)} merged arms bit-identical across the "
+                f"swept range"
+            )
+        entry = {
+            "model": BASE_MODEL.rsplit("/", 1)[-1],
+            "tp": cli.tp,
+            "dp": cli.dp,
+            "threshold_tokens_per_rank": threshold,
+            "measured_range_tokens_per_rank": [totals[0], totals[-1]],
+            "measured": {
+                "date": time.strftime("%Y-%m-%d"),
+                "rank": RANK,
+                "note": note,
+            },
+        }
+        print("\nE0_CALIBRATION_ENTRY (review, then add to "
+              "training/backends/miles/e0_calibration.json):")
+        print(json.dumps(entry, indent=2))
+        return 0
+
     if not cli.expect_band and not merged_any:
         fails.append("no arm merged at all — the gate would pass vacuously")
 

--- a/tests/test_e0_registry.py
+++ b/tests/test_e0_registry.py
@@ -1,0 +1,93 @@
+"""E0 calibration registry resolution.
+
+The co-batch guard threshold is a measured per-(model x parallel config)
+constant. Resolution order: env override > registry entry (null = guard
+open) > UNCALIBRATED (co-batching must be disabled). These tests pin that
+contract and that the shipped registry parses.
+"""
+
+import json
+
+import pytest
+
+try:
+    from training.backends.miles.e0_registry import (
+        _REGISTRY_PATH,
+        resolve_e0,
+    )
+except ImportError:  # pragma: no cover
+    resolve_e0 = None
+
+pytestmark = pytest.mark.skipif(
+    resolve_e0 is None, reason="training package not importable"
+)
+
+
+@pytest.fixture()
+def registry(tmp_path):
+    p = tmp_path / "e0_calibration.json"
+    p.write_text(json.dumps({
+        "schema": 1,
+        "entries": [
+            {"model": "ModelA", "tp": 1, "dp": 2,
+             "threshold_tokens_per_rank": 512,
+             "measured_range_tokens_per_rank": [189, 1512]},
+            {"model": "ModelB", "tp": 2, "dp": 1,
+             "threshold_tokens_per_rank": None,
+             "measured_range_tokens_per_rank": [189, 1512]},
+        ],
+    }))
+    return p
+
+
+def test_env_override_wins(monkeypatch, registry):
+    monkeypatch.setenv("TINKERCLOUD_MILES_COBATCH_E0_TOKENS", "256")
+    res = resolve_e0("Org/ModelA", tp=1, dp=2, registry_path=registry)
+    assert (res.source, res.threshold, res.disable_cobatch) == ("env", 256, False)
+
+
+def test_env_zero_disables_guard_not_cobatch(monkeypatch, registry):
+    monkeypatch.setenv("TINKERCLOUD_MILES_COBATCH_E0_TOKENS", "0")
+    res = resolve_e0("Org/ModelA", tp=1, dp=2, registry_path=registry)
+    assert (res.source, res.threshold, res.disable_cobatch) == ("env", 0, False)
+
+
+def test_registry_threshold(monkeypatch, registry):
+    monkeypatch.delenv("TINKERCLOUD_MILES_COBATCH_E0_TOKENS", raising=False)
+    res = resolve_e0("Org/ModelA", tp=1, dp=2, registry_path=registry)
+    assert (res.source, res.threshold, res.disable_cobatch) == ("registry", 512, False)
+
+
+def test_registry_null_means_guard_open(monkeypatch, registry):
+    monkeypatch.delenv("TINKERCLOUD_MILES_COBATCH_E0_TOKENS", raising=False)
+    res = resolve_e0("ModelB", tp=2, dp=1, registry_path=registry)
+    assert (res.source, res.threshold, res.disable_cobatch) == ("registry", 0, False)
+
+
+def test_parallel_shape_is_part_of_the_key(monkeypatch, registry):
+    monkeypatch.delenv("TINKERCLOUD_MILES_COBATCH_E0_TOKENS", raising=False)
+    res = resolve_e0("ModelA", tp=2, dp=1, registry_path=registry)
+    assert res.source == "uncalibrated"
+    assert res.disable_cobatch is True
+
+
+def test_missing_entry_disables_cobatch(monkeypatch, registry):
+    monkeypatch.delenv("TINKERCLOUD_MILES_COBATCH_E0_TOKENS", raising=False)
+    res = resolve_e0("NeverMeasured", tp=1, dp=2, registry_path=registry)
+    assert (res.source, res.disable_cobatch) == ("uncalibrated", True)
+
+
+def test_unreadable_registry_is_uncalibrated(monkeypatch, tmp_path):
+    monkeypatch.delenv("TINKERCLOUD_MILES_COBATCH_E0_TOKENS", raising=False)
+    res = resolve_e0("ModelA", tp=1, dp=2, registry_path=tmp_path / "absent.json")
+    assert (res.source, res.disable_cobatch) == ("uncalibrated", True)
+
+
+def test_shipped_registry_parses_and_seeds_resolve(monkeypatch):
+    monkeypatch.delenv("TINKERCLOUD_MILES_COBATCH_E0_TOKENS", raising=False)
+    data = json.loads(_REGISTRY_PATH.read_text())
+    assert data["schema"] == 1 and data["entries"]
+    r05 = resolve_e0("Qwen/Qwen2.5-0.5B", tp=1, dp=2)
+    assert (r05.source, r05.threshold) == ("registry", 512)
+    r8b = resolve_e0("Qwen/Qwen3-8B-Base", tp=2, dp=1)
+    assert (r8b.source, r8b.threshold, r8b.disable_cobatch) == ("registry", 0, False)

--- a/training/backends/miles/backend.py
+++ b/training/backends/miles/backend.py
@@ -588,9 +588,24 @@ class MilesBackend(TrainingBackend):
                 pool.cobatch_reorder = bool(int(
                     os.environ.get("TINKERCLOUD_MILES_COBATCH_REORDER", "0") or 0
                 ))
-                pool.cobatch_e0_tokens = int(
-                    os.environ.get("TINKERCLOUD_MILES_COBATCH_E0_TOKENS", "512") or 0
-                )
+                if pool.cobatch_max_samples > 0:
+                    # The guard threshold is a measured per-(model x parallel
+                    # config) constant, resolved from the calibration registry
+                    # (env override wins; an uncalibrated config gets no
+                    # merging at all). See e0_registry.
+                    from .e0_registry import resolve_e0
+                    res = resolve_e0(
+                        base_model,
+                        tp=int(getattr(args, "tensor_model_parallel_size", 1) or 1),
+                        dp=_dp_size(args),
+                    )
+                    pool.cobatch_e0_tokens = res.threshold
+                    if res.disable_cobatch:
+                        pool.cobatch_max_samples = 0
+                        logger.warning(
+                            "Pool co-batching requested but DISABLED: "
+                            "E0 calibration missing for this config"
+                        )
                 pool.dispatcher = asyncio.create_task(self._pool_dispatcher_loop(pool))
                 if pool.cobatch_max_samples > 0:
                     logger.info(
@@ -602,7 +617,8 @@ class MilesBackend(TrainingBackend):
                     logger.info(
                         "Pool co-batch E0 guard: %s",
                         f"refuse merges crossing {pool.cobatch_e0_tokens} tokens/rank"
-                        if pool.cobatch_e0_tokens > 0 else "OFF (merges may break E0)",
+                        if pool.cobatch_e0_tokens > 0
+                        else "open (no exactness boundary in the calibrated range)",
                     )
                 self._pool = pool
 

--- a/training/backends/miles/backend.py
+++ b/training/backends/miles/backend.py
@@ -743,14 +743,21 @@ class MilesBackend(TrainingBackend):
                     and nxt.loss_fn == op.loss_fn
                     and nxt.tenant not in blocked
                     and total + nxt.num_samples <= pool.cobatch_max_samples
-                    and self.converter.cobatch_preserves_token_bucket(
+                ):
+                    if self.converter.cobatch_preserves_token_bucket(
                         [o.rollout_data for o in batch] + [nxt.rollout_data],
                         _dp_size(pool.args),
                         pool.cobatch_e0_tokens,
-                    )
-                ):
-                    batch.append(nxt)
-                    total += nxt.num_samples
+                    ):
+                        batch.append(nxt)
+                        total += nxt.num_samples
+                    else:
+                        # E0 guard refusal ENDS the merge window: deferring a
+                        # refused fb would convoy it behind blocked-tenant
+                        # bookkeeping and replay for no gain (the next window
+                        # re-evaluates it as head).
+                        carry = nxt
+                        break
                 elif (
                     pool.cobatch_reorder
                     and nxt.kind != "stop"

--- a/training/backends/miles/e0_calibration.json
+++ b/training/backends/miles/e0_calibration.json
@@ -1,0 +1,33 @@
+{
+  "schema": 1,
+  "entries": [
+    {
+      "model": "Qwen2.5-0.5B",
+      "tp": 1,
+      "dp": 2,
+      "threshold_tokens_per_rank": 512,
+      "measured_range_tokens_per_rank": [189, 1512],
+      "measured": {
+        "date": "2026-08-21",
+        "gpu": "H200",
+        "rank": 32,
+        "image": "miles_tinker_seam:20260730",
+        "note": "bit-identity boundary located in [508, 566]; 23/23 pairs, 7/7 out-of-sample predictions"
+      }
+    },
+    {
+      "model": "Qwen3-8B-Base",
+      "tp": 2,
+      "dp": 1,
+      "threshold_tokens_per_rank": null,
+      "measured_range_tokens_per_rank": [189, 1512],
+      "measured": {
+        "date": "2026-08-24",
+        "gpu": "H200",
+        "rank": 32,
+        "image": "miles_tinker_seam:20260730",
+        "note": "all merges bit-identical across the swept range, including every boundary-crossing arm"
+      }
+    }
+  ]
+}

--- a/training/backends/miles/e0_registry.py
+++ b/training/backends/miles/e0_registry.py
@@ -1,0 +1,103 @@
+"""E0 co-batching calibration registry.
+
+The bit-exactness boundary that the co-batch admission guard enforces is a
+MEASURED, per-(model x parallel config) constant, not a policy: at
+Qwen2.5-0.5B/dp2 gradients diverge when a call's per-rank token total
+crosses ~512, while at Qwen3-8B-Base/tp2 no boundary exists anywhere in the
+swept range. The registry (e0_calibration.json) records those measurements;
+this module resolves the guard threshold for a pool boot.
+
+Resolution order:
+  1. TINKERCLOUD_MILES_COBATCH_E0_TOKENS set and non-empty -> explicit
+     override (an operator decision; logged as such).
+  2. Registry entry for (model basename, tp, dp) -> its measured threshold;
+     ``null`` in the registry means "no boundary found in the measured
+     range" and resolves to guard-open (0).
+  3. No entry -> UNCALIBRATED: the caller must disable co-batching
+     entirely. Merging a configuration whose exactness behavior was never
+     measured would turn the guard into an assertion.
+
+New entries come from the calibration sweep
+(`scripts/gates/g6b_cobatch_token_bucket.py --emit-entry`, guard off) and
+land here by pull request — the entry is the reviewable certificate.
+"""
+
+import json
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+_REGISTRY_PATH = Path(__file__).with_name("e0_calibration.json")
+
+
+@dataclass(frozen=True)
+class E0Resolution:
+    source: str                    # "env" | "registry" | "uncalibrated"
+    threshold: int                 # tokens/rank; 0 = guard open (no refusals)
+    disable_cobatch: bool          # True only for "uncalibrated"
+
+
+def _load_entries(path: Path = _REGISTRY_PATH) -> list:
+    data = json.loads(path.read_text())
+    if data.get("schema") != 1:
+        raise ValueError(f"unsupported e0_calibration schema: {data.get('schema')!r}")
+    return data["entries"]
+
+
+def resolve_e0(base_model: str, tp: int, dp: int,
+               registry_path: Path = _REGISTRY_PATH) -> E0Resolution:
+    """Resolve the E0 guard threshold for a pool boot.
+
+    ``base_model`` may be a hub id ("Qwen/Qwen2.5-0.5B") or a basename;
+    registry keys are basenames.
+    """
+    env = os.environ.get("TINKERCLOUD_MILES_COBATCH_E0_TOKENS", "")
+    if env.strip() != "":
+        thr = int(env)
+        logger.info(
+            "E0 guard threshold from env override: %d tokens/rank "
+            "(registry not consulted)", thr,
+        )
+        return E0Resolution(source="env", threshold=thr, disable_cobatch=False)
+
+    basename = base_model.rsplit("/", 1)[-1]
+    try:
+        entries = _load_entries(registry_path)
+    except (OSError, ValueError, KeyError) as e:
+        logger.warning("E0 calibration registry unreadable (%s); treating "
+                       "config as UNCALIBRATED", e)
+        entries = []
+    for ent in entries:
+        if (ent.get("model") == basename
+                and int(ent.get("tp", 0)) == int(tp)
+                and int(ent.get("dp", 0)) == int(dp)):
+            thr = ent.get("threshold_tokens_per_rank")
+            if thr is None:
+                logger.info(
+                    "E0 calibration for (%s, tp=%d, dp=%d): no exactness "
+                    "boundary in measured range %s — guard open",
+                    basename, tp, dp, ent.get("measured_range_tokens_per_rank"),
+                )
+                return E0Resolution(source="registry", threshold=0,
+                                    disable_cobatch=False)
+            logger.info(
+                "E0 calibration for (%s, tp=%d, dp=%d): threshold %d "
+                "tokens/rank (measured %s)",
+                basename, tp, dp, int(thr), ent.get("measured", {}).get("date"),
+            )
+            return E0Resolution(source="registry", threshold=int(thr),
+                                disable_cobatch=False)
+
+    logger.warning(
+        "E0 calibration MISSING for (%s, tp=%d, dp=%d): co-batching DISABLED "
+        "for this pool. To enable it, run the calibration sweep "
+        "(scripts/gates/g6b_cobatch_token_bucket.py --emit-entry with the "
+        "guard off on this exact model + parallel config) and add the "
+        "emitted entry to e0_calibration.json.",
+        basename, tp, dp,
+    )
+    return E0Resolution(source="uncalibrated", threshold=0, disable_cobatch=True)


### PR DESCRIPTION
Three commits:

- **E0 calibration registry**: the co-batch guard's bit-exactness threshold is a measured, per-(model x parallel config) constant (Qwen2.5-0.5B/dp2: ~512 tokens/rank; Qwen3-8B-Base/tp2: no boundary in the swept range). `e0_calibration.json` records the measurements; `e0_registry.resolve_e0` resolves the pool's threshold at boot — env override > registry (null = guard open) > UNCALIBRATED, which disables co-batching for that pool with a warning naming the missing entry. New entries land by PR, so each threshold is a reviewable measurement, not a policy.
- **Guard refusal = carry, not defer**: a guard-refused fb used to enter the reorder-defer path (blocked-tenant bookkeeping + replay), roughly halving throughput when the guard binds. Refusal now ends the merge window and the op becomes the next head. Per-tenant FIFO unchanged; deferral keeps only its original purpose.
- **g6b `--emit-entry`** calibration mode (guard-off sweep -> registry entry, human-reviewed) + `tests/test_e0_registry.py` pinning the resolution order and the shipped registry.