### PR TITLE
E0 calibration: joint logprob+grad observable, kernel-regime warm-up, measured no-safe-region verdict

### DIFF
--- a/scripts/gates/g6b_cobatch_token_bucket.py
+++ b/scripts/gates/g6b_cobatch_token_bucket.py
@@ -20,6 +20,12 @@ and asserts two things, because either alone is trivially satisfiable:
   (B) the arms the law says are SAFE still merge -- a guard that is switched
       off passes B
 
+Bit-identity is judged on TWO observables jointly: the fp32 grad-norm AND
+the per-sample response log-probs (repr-exact). Grad-norm alone is blunt --
+an fp32-rounded scalar hides ~1e-7 relative logit drift that per-token
+fp32 log-probs expose exactly (the 2026-08-25 G7 adjudication: merges
+grad-identical yet log-prob-divergent on the rebuilt image).
+
 PASS requires both. Run against a pool-mode server with merging on:
   TINKERCLOUD_MILES_MULTILORA_SLOTS>0, COBATCH_MAX_SAMPLES>=2048.
 
@@ -87,6 +93,10 @@ def step_lr0(model_id):
     sys.exit(2)
 
 
+def lps_of(fb_result):
+    return repr([o["logprobs"].to_torch().tolist() for o in fb_result.loss_fn_outputs])
+
+
 def per_rank(n, dp, tok):
     """Same arithmetic the server guard uses: pad to a dp multiple, then stride."""
     lengths = [tok] * n
@@ -116,21 +126,30 @@ def main():
     tc_a = sc.create_lora_training_client(base_model=BASE_MODEL, rank=RANK)
     tc_b = sc.create_lora_training_client(base_model=BASE_MODEL, rank=RANK)
     print(f"A={tc_a.model_id} B={tc_b.model_id}", flush=True)
-    blocker = make_datums(int(os.environ.get("G6B_BLOCKER", "2")), salt=9)
+    # The blocker must still be RUNNING when both fbs reach the queue, or the
+    # arm silently executes solo (2/8 arms merged on the 2026-08-25 build
+    # with the old 2-datum blocker + 0.2s settle — the build outran it).
+    blocker = make_datums(int(os.environ.get("G6B_BLOCKER", "256")), salt=9)
     rows, fails = [], []
 
     try:
-        make_datums(8, salt=99)  # warm-up shapes below
+        # Kernel-regime warm-up: the first larger-shape call permanently
+        # shifts the process's kernel selection (solo logprobs move 1-2 ulp
+        # once, then solo and merged are bit-stable — g7diag2_regime,
+        # 2026-08-25). Flip before any baseline; arm 0 additionally stays
+        # excluded from gate semantics as a second guard.
+        tc_a.forward(make_datums(256, salt=99), "cross_entropy").result()
         for idx, n in enumerate(ns):
             a_ds, b_ds = make_datums(n, salt=1), make_datums(n, salt=2)
             solo_t, co_t = per_rank(n, cli.dp, tok), per_rank(2 * n, cli.dp, tok)
             safe = (solo_t <= THRESHOLD) == (co_t <= THRESHOLD)
 
             r_solo = tc_a.forward_backward(a_ds, "cross_entropy").result()
+            lp_solo = lps_of(r_solo)
             gn_solo = step_lr0(tc_a.model_id).get("grad_norm")
 
             fut_blk = tc_a.forward(blocker, "cross_entropy")
-            time.sleep(float(os.environ.get("G6B_SETTLE", "0.2")))
+            time.sleep(float(os.environ.get("G6B_SETTLE", "0.1")))
             fut_a = tc_a.forward_backward(a_ds, "cross_entropy")
             fut_b = tc_b.forward_backward(b_ds, "cross_entropy")
             fut_blk.result()
@@ -139,20 +158,24 @@ def main():
             gn_co = step_lr0(tc_a.model_id).get("grad_norm")
             step_lr0(tc_b.model_id)
 
-            identical = repr(gn_solo) == repr(gn_co)
-            rows.append((n, solo_t, co_t, safe, merged, identical, gn_solo, gn_co))
+            gn_id = repr(gn_solo) == repr(gn_co)
+            lp_id = lps_of(r_co) == lp_solo
+            identical = gn_id and lp_id
+            rows.append((n, solo_t, co_t, safe, merged, identical, gn_id, lp_id))
             if idx == 0:
                 continue                        # arm 0 absorbs kernel warm-up
             if cli.emit_entry:
                 continue                        # calibration: no gate semantics
             if cli.expect_band:
                 if safe and not identical:
-                    fails.append(f"n={n} is SAFE by the law but diverged")
+                    fails.append(f"n={n} is SAFE by the law but diverged "
+                                 f"(grad_norm={gn_id}, logprobs={lp_id})")
                 if not safe and identical and merged:
                     fails.append(f"n={n} should straddle and diverge, but was identical")
             else:
                 if not identical:
-                    fails.append(f"n={n} NOT bit-identical ({gn_solo!r} vs {gn_co!r})")
+                    fails.append(f"n={n} NOT bit-identical "
+                                 f"(grad_norm={gn_id}, logprobs={lp_id})")
                 if safe and not merged:
                     fails.append(f"n={n} is safe but did NOT merge (guard too strict / merging off)")
     finally:
@@ -163,10 +186,11 @@ def main():
             except Exception as e:  # noqa: BLE001
                 print(f"DELETE FAILED {m}: {e}")
 
-    print(f"\n{'n':>4} {'solo/rk':>8} {'co/rk':>7} {'law':>7} {'merged':>7} {'bit-id':>7}")
-    for n, s, c, safe, merged, identical, _, _ in rows:
+    print(f"\n{'n':>4} {'solo/rk':>8} {'co/rk':>7} {'law':>7} {'merged':>7} "
+          f"{'bit-id':>7} {'gn-id':>6} {'lp-id':>6}")
+    for n, s, c, safe, merged, identical, gn_id, lp_id in rows:
         print(f"{n:>4} {s:>8} {c:>7} {'safe' if safe else 'STRADDLE':>8} "
-              f"{str(merged):>7} {str(identical):>7}")
+              f"{str(merged):>7} {str(identical):>7} {str(gn_id):>6} {str(lp_id):>6}")
 
     merged_any = any(r[4] for r in rows[1:])
     print(f"\n(A) all bit-identical : {all(r[5] for r in rows[1:])}")
@@ -185,13 +209,29 @@ def main():
             return 1
         totals = sorted({t for r in merged_rows for t in (r[1], r[2])})
         divergent = [r for r in merged_rows if not r[5]]
+        ident = [r for r in merged_rows if r[5]]
         if divergent:
-            lo = max(r[1] for r in divergent)
-            hi = min(r[2] for r in divergent)
-            threshold, note = lo, (
-                f"boundary bracketed in ({lo}, {hi}) tokens/rank; "
-                f"{len(divergent)}/{len(merged_rows)} merged arms diverged"
-            )
+            # A token-bucket law fits only if some T is crossed by EVERY
+            # divergent arm and by NO identical arm. Otherwise the config has
+            # no safe region a threshold can express (-1: co-batching off).
+            def crosses(r, t):
+                return (r[1] <= t) != (r[2] <= t)
+            candidates = [t for t in totals
+                          if all(crosses(r, t) for r in divergent)
+                          and not any(crosses(r, t) for r in ident)]
+            if candidates:
+                lo, hi = min(candidates), max(candidates)
+                threshold, note = lo, (
+                    f"boundary bracketed in [{lo}, {hi}] tokens/rank; "
+                    f"{len(divergent)}/{len(merged_rows)} merged arms diverged"
+                )
+            else:
+                threshold, note = -1, (
+                    f"NO safe region: {len(divergent)}/{len(merged_rows)} "
+                    f"merged arms diverged and no token-bucket boundary "
+                    f"separates them from the identical arms "
+                    f"(grad/logprob joint observable)"
+                )
         else:
             threshold, note = None, (
                 f"all {len(merged_rows)} merged arms bit-identical across the "

--- a/scripts/gates/g7_reorder_merge.py
+++ b/scripts/gates/g7_reorder_merge.py
@@ -12,6 +12,9 @@ window microseconds after its fb (measured: 0 merges across a full
 2-tenant recipe arm). The reorder drain defers OTHER tenants' non-fb ops
 past the window — legal because only per-tenant submission order is
 contractual (isolation invariant, G4). This gate checks the relaxation:
+  P0: kernel-regime warm-up — one large forward, discarded. The first
+     larger-shape call shifts kernel selection once (1-2 ulp); baselines
+     must be captured post-flip or every later comparison false-fails.
   P1: tenants A and B on one pool.
   P2 solo baselines: fb alone + step(lr=0) per tenant -> grad_norm + logprobs.
   P3 pipelined+reordered: [fb_A, step_A, fb_B, step_B] submitted back-to-back
@@ -24,6 +27,14 @@ contractual (isolation invariant, G4). This gate checks the relaxation:
      — logprobs must stay bit-stable every round; merge count reported
      (timing-dependent, not asserted).
 PASS = every comparison bit-identical (repr equality).
+
+G7_EXPECT selects the calibrated mode (default "merge"):
+  merge  — the registry admits merges here: P3 must merge AND be bit-exact.
+  refuse — the registry measured no safe region (threshold -1) and disabled
+           co-batching: P3/P4 must NOT merge, and the reorder/carry machinery
+           must leave every solo result bit-identical to baseline.
+The expectation is an input, not auto-detected: a merge path that silently
+stopped merging must fail the merge mode, not pass as refusal.
 """
 import os, sys, time
 
@@ -96,9 +107,12 @@ def merged_flag(res):
 
 
 LR0 = types.AdamParams(learning_rate=0.0)
+EXPECT = os.environ.get("G7_EXPECT", "merge")
+assert EXPECT in ("merge", "refuse"), f"G7_EXPECT must be merge|refuse, got {EXPECT!r}"
 
 
 def main():
+    print(f"G7 mode: {EXPECT}", flush=True)
     sc = tinker.ServiceClient()
 
     print("P1: two tenants on one pool", flush=True)
@@ -109,6 +123,14 @@ def main():
     probe_a = make_datums(8, salt=1)
     probe_b = make_datums(8, salt=2)
     blocker = make_datums(2, salt=9)   # >= DP size (known gap, 003)
+
+    print("P0 kernel-regime warm-up (large forward, result discarded)", flush=True)
+    # The first larger-shape call permanently shifts the process's kernel
+    # selection: solo logprobs move 1-2 ulp ONCE, then everything — solo and
+    # merged alike — is bit-stable (g7diag2_regime, 2026-08-25). A baseline
+    # captured pre-flip fails every post-merge comparison, which is exactly
+    # how this gate false-failed. Flip the regime before any baseline.
+    tc_a.forward(make_datums(256, salt=8), "cross_entropy").result()
 
     print("P2 solo baselines", flush=True)
     ra = tc_a.forward_backward(probe_a, "cross_entropy").result()
@@ -128,9 +150,14 @@ def main():
     fut_blk.result()
     res_a, res_b = fut_a.result(), fut_b.result()
     fut_sa.result(), fut_sb.result()
-    check("P3 merge engaged (A)", merged_flag(res_a),
-          f"(metrics A={sorted((res_a.metrics or {}))})")
-    check("P3 merge engaged (B)", merged_flag(res_b))
+    if EXPECT == "merge":
+        check("P3 merge engaged (A)", merged_flag(res_a),
+              f"(metrics A={sorted((res_a.metrics or {}))})")
+        check("P3 merge engaged (B)", merged_flag(res_b))
+    else:
+        check("P3 merge refused (A)", not merged_flag(res_a),
+              f"(metrics A={sorted((res_a.metrics or {}))})")
+        check("P3 merge refused (B)", not merged_flag(res_b))
     check("P3 A logprobs pipelined==solo", lps_of(res_a) == lp_a_solo)
     check("P3 B logprobs pipelined==solo", lps_of(res_b) == lp_b_solo)
     # Post-round state probes: the deferred steps must have consumed exactly
@@ -154,6 +181,8 @@ def main():
         res_a, res_b = fut_a.result(), fut_b.result()
         fut_sa.result(), fut_sb.result()
         merges += int(merged_flag(res_a) and merged_flag(res_b))
+        if EXPECT == "refuse":
+            check(f"P4 r{rnd} no merge", not merged_flag(res_a) and not merged_flag(res_b))
         check(f"P4 r{rnd} A logprobs stable", lps_of(res_a) == lp_a_solo)
         check(f"P4 r{rnd} B logprobs stable", lps_of(res_b) == lp_b_solo)
     print(f"  natural-traffic merge rounds: {merges}/5 (informational)", flush=True)

--- a/tests/test_e0_registry.py
+++ b/tests/test_e0_registry.py
@@ -35,6 +35,9 @@ def registry(tmp_path):
             {"model": "ModelB", "tp": 2, "dp": 1,
              "threshold_tokens_per_rank": None,
              "measured_range_tokens_per_rank": [189, 1512]},
+            {"model": "ModelC", "tp": 1, "dp": 2,
+             "threshold_tokens_per_rank": -1,
+             "measured_range_tokens_per_rank": [189, 1512]},
         ],
     }))
     return p
@@ -62,6 +65,12 @@ def test_registry_null_means_guard_open(monkeypatch, registry):
     monkeypatch.delenv("TINKERCLOUD_MILES_COBATCH_E0_TOKENS", raising=False)
     res = resolve_e0("ModelB", tp=2, dp=1, registry_path=registry)
     assert (res.source, res.threshold, res.disable_cobatch) == ("registry", 0, False)
+
+
+def test_registry_no_safe_region_disables_cobatch(monkeypatch, registry):
+    monkeypatch.delenv("TINKERCLOUD_MILES_COBATCH_E0_TOKENS", raising=False)
+    res = resolve_e0("ModelC", tp=1, dp=2, registry_path=registry)
+    assert (res.source, res.threshold, res.disable_cobatch) == ("registry", 0, True)
 
 
 def test_parallel_shape_is_part_of_the_key(monkeypatch, registry):

--- a/training/backends/miles/backend.py
+++ b/training/backends/miles/backend.py
@@ -603,8 +603,10 @@ class MilesBackend(TrainingBackend):
                     if res.disable_cobatch:
                         pool.cobatch_max_samples = 0
                         logger.warning(
-                            "Pool co-batching requested but DISABLED: "
-                            "E0 calibration missing for this config"
+                            "Pool co-batching requested but DISABLED: %s",
+                            "calibration measured no safe region for this config"
+                            if res.source == "registry"
+                            else "E0 calibration missing for this config",
                         )
                 pool.dispatcher = asyncio.create_task(self._pool_dispatcher_loop(pool))
                 if pool.cobatch_max_samples > 0:

--- a/training/backends/miles/e0_calibration.json
+++ b/training/backends/miles/e0_calibration.json
@@ -12,7 +12,7 @@
         "gpu": "H200",
         "rank": 32,
         "image": "miles_tinker_seam:20260730",
-        "note": "bit-identity boundary located in [508, 566]; 23/23 pairs, 7/7 out-of-sample predictions"
+        "note": "bit-identity boundary located in [508, 566]; 23/23 pairs, 7/7 out-of-sample predictions. Re-measured 2026-08-25 with the logprob-extended instrument after kernel-regime warm-up: grad boundary bracket [504, 567) — 512 stands; logprobs merge-invariant at every width"
       }
     },
     {
@@ -26,7 +26,7 @@
         "gpu": "H200",
         "rank": 32,
         "image": "miles_tinker_seam:20260730",
-        "note": "all merges bit-identical across the swept range, including every boundary-crossing arm"
+        "note": "all merges bit-identical across the swept range, including every boundary-crossing arm. Re-measured 2026-08-25 with the logprob-extended instrument: bit-identical on grads AND logprobs, range extended to [504, 3024] tokens/rank"
       }
     }
   ]

--- a/training/backends/miles/e0_registry.py
+++ b/training/backends/miles/e0_registry.py
@@ -12,10 +12,20 @@ Resolution order:
      override (an operator decision; logged as such).
   2. Registry entry for (model basename, tp, dp) -> its measured threshold;
      ``null`` in the registry means "no boundary found in the measured
-     range" and resolves to guard-open (0).
+     range" and resolves to guard-open (0); ``-1`` means "measured: NO safe
+     region — some merge inside a single bucket already diverges" and
+     resolves to co-batching disabled (a measured verdict, unlike 3).
   3. No entry -> UNCALIBRATED: the caller must disable co-batching
      entirely. Merging a configuration whose exactness behavior was never
      measured would turn the guard into an assertion.
+
+The calibration observable is per-sample response LOG-PROBS compared
+bit-wise, jointly with the fp32 grad-norm. Grad-norm alone is too blunt:
+it is an fp32-rounded scalar (ulp ~7.6e-6 at magnitude 128), so ~1e-7
+relative logit drift under a changed batch layout is invisible in it while
+per-token fp32 log-probs expose the same drift exactly. An entry measured
+with the grad-only instrument can therefore admit merges that are not
+E0 over the full observable set.
 
 New entries come from the calibration sweep
 (`scripts/gates/g6b_cobatch_token_bucket.py --emit-entry`, guard off) and
@@ -38,7 +48,7 @@ _REGISTRY_PATH = Path(__file__).with_name("e0_calibration.json")
 class E0Resolution:
     source: str                    # "env" | "registry" | "uncalibrated"
     threshold: int                 # tokens/rank; 0 = guard open (no refusals)
-    disable_cobatch: bool          # True only for "uncalibrated"
+    disable_cobatch: bool          # "uncalibrated", or measured no-safe-region
 
 
 def _load_entries(path: Path = _REGISTRY_PATH) -> list:
@@ -84,6 +94,14 @@ def resolve_e0(base_model: str, tp: int, dp: int,
                 )
                 return E0Resolution(source="registry", threshold=0,
                                     disable_cobatch=False)
+            if int(thr) < 0:
+                logger.warning(
+                    "E0 calibration for (%s, tp=%d, dp=%d): measured NO safe "
+                    "region (%s) — co-batching DISABLED for this pool",
+                    basename, tp, dp, ent.get("measured", {}).get("note"),
+                )
+                return E0Resolution(source="registry", threshold=0,
+                                    disable_cobatch=True)
             logger.info(
                 "E0 calibration for (%s, tp=%d, dp=%d): threshold %d "
                 "tokens/rank (measured %s)",


### PR DESCRIPTION
The E0 gates (g6b, g7) had two measurement bugs that could produce wrong verdicts in both directions: an observable too coarse to see real drift, and a baseline-capture ordering that invented drift where there was none. This PR fixes both, adds a missing verdict to the calibration registry, closes two ways the gates could pass without testing anything, and updates the calibration entries from a re-measurement with the fixed instrument.

**Judge bit-identity on per-token logprobs jointly with grad_norm.**
grad_norm is a single fp32 scalar — ulp ~7.6e-6 at magnitude 128 — so logit drift around 1e-7-relative is invisible to it: it can report "identical" while tokens have drifted. Per-token fp32 logprobs expose that drift exactly. g6b now records and asserts both observables per arm, and `--emit-entry` derives registry entries from the joint verdict.

**Warm up the kernel regime before capturing any baseline.**
The first forward at a larger shape permanently flips kernel selection in an actor process: values move 1-2 ulp, once, and everything afterwards is mutually bit-exact. A baseline captured before that flip mismatches every later run — g7_reorder_merge did exactly that: its baselines were captured pre-flip, its own merge phase flipped the process, and every subsequent logprob comparison failed while the system was actually exact. Both gates now run one discarded large forward before any baseline; g6b's arm-0 exclusion stays as a second guard.

**Registry: `threshold_tokens_per_rank: -1` = measured, no safe region.**
Previously the registry could say "safe below N", "unbounded", or "uncalibrated" (refuse). New fourth verdict: calibration ran and found no token-bucket law separating divergent from identical merges — co-batching is disabled by measurement, distinct from never-measured. Resolver, boot log, and tests cover it.

**No vacuous passes.**
- `G7_EXPECT=merge|refuse`: on a stack whose calibration disables co-batching, G7 used to pass trivially because nothing merged. The caller now declares the expected outcome and a refusal is asserted explicitly.
- g6b blocker 2 -> 256 datums, settle 0.2 -> 0.1s: the blocker request had become fast enough to finish during the settle sleep, so arms silently ran solo (2/8 actually merged).

**Re-measurement** (notes in `e0_calibration.json`): Qwen2.5-0.5B tp1/dp2 grad boundary bracket [504, 567) — the shipped 512 threshold stands — with logprobs merge-invariant at every width; Qwen3-8B-Base tp2/dp1 bit-identical on both observables across [504, 3024] tokens/rank.
