### PR TITLE
pod_ready_miles: fix model-args script name mapping

### DIFF
--- a/scripts/pod_ready_miles.sh
+++ b/scripts/pod_ready_miles.sh
@@ -47,7 +47,10 @@ fi
 
 echo "==> [4/6] torch_dist conversion"
 if ! EX "ls /data/.cache/huggingface/${MODEL}_torch_dist/iter_* >/dev/null 2>&1 || test -f /data/.cache/huggingface/${MODEL}_torch_dist/latest_checkpointed_iteration.txt"; then
-  MODEL_SH=$(echo "$MODEL" | tr '[:upper:]' '[:lower:]' | sed 's/^qwen/qwen/')
+  # scripts/models/ names keep the size capitalized (qwen3-8B.sh) and have
+  # no -Base suffix; full lowercasing never matched (latent until the first
+  # fresh-pod 8B conversion, 2026-08-25).
+  MODEL_SH=$(echo "$MODEL" | sed 's/-Base$//; s/^Qwen/qwen/')
   EX "set -u; export HF_HOME=/data/.cache/huggingface PYTHONDONTWRITEBYTECODE=1
       cd /root/miles && source scripts/models/${MODEL_SH}.sh
       PYTHONPATH=/root/Megatron-LM torchrun --nproc-per-node 1 \


### PR DESCRIPTION
scripts/models/ names keep the size capitalized (qwen3-8B.sh) and carry
no -Base suffix; lowercasing the whole model name could never match, so
the torch_dist conversion branch sourced nothing and torchrun failed on
num_layers=None. Latent until the first fresh-pod 8B conversion: every
prior pod already had the torch_dist directory, so the branch never
executed.