### PR TITLE
Harden server lifecycle and align backends with the ABC

### DIFF
--- a/tests/test_backend_interface.py
+++ b/tests/test_backend_interface.py
@@ -14,6 +14,7 @@ Tests are organized by dependency level:
 """
 import asyncio
 import importlib.util
+import inspect
 import logging
 import pytest
 
@@ -23,7 +24,7 @@ from tinkercloud.training.backends.base import (
     TrainingBackend,
     UnsupportedFeatureError,
 )
-from tinkercloud.training.backends.factory import BackendFactory
+from tinkercloud.training.backends.factory import BackendFactory, SUPPORTED_BACKENDS
 
 # Guard for NeMo RL availability
 HAS_NEMO_RL = importlib.util.find_spec("nemo_rl") is not None
@@ -141,6 +142,41 @@ class TestTrainingBackendABC:
             assert hasattr(TrainingBackend, method_name), (
                 f"TrainingBackend missing required method: {method_name}"
             )
+
+
+class TestBackendSignatureContract:
+    """Every registered backend must accept what the services pass to the ABC methods."""
+
+    _VARIADIC = (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD)
+
+    @pytest.mark.parametrize("backend_type", SUPPORTED_BACKENDS)
+    def test_signatures_compatible_with_abc(self, backend_type):
+        try:
+            cls = BackendFactory.backend_class(backend_type)
+        except ImportError as e:
+            pytest.skip(f"{backend_type} runtime not installed: {e}")
+        assert issubclass(cls, TrainingBackend)
+        for name in sorted(TrainingBackend.__abstractmethods__):
+            abc_sig = inspect.signature(getattr(TrainingBackend, name))
+            impl_sig = inspect.signature(getattr(cls, name))
+            impl_params = impl_sig.parameters
+            impl_variadic = any(p.kind in self._VARIADIC for p in impl_params.values())
+            for p in abc_sig.parameters.values():
+                if p.kind in self._VARIADIC:
+                    continue
+                assert p.name in impl_params or impl_variadic, (
+                    f"{cls.__name__}.{name} lacks parameter {p.name!r} declared by TrainingBackend"
+                )
+            for q in impl_params.values():
+                if q.name in abc_sig.parameters or q.kind in self._VARIADIC:
+                    continue
+                assert q.default is not inspect.Parameter.empty, (
+                    f"{cls.__name__}.{name} adds required parameter {q.name!r} absent from TrainingBackend"
+                )
+
+    def test_unknown_backend_class_raises(self):
+        with pytest.raises(ValueError):
+            BackendFactory.backend_class("nope")
 
 
 class TestSamplingContract:
@@ -363,19 +399,21 @@ class TestNemoRLBackendBuffering:
             )
         assert len(handle.data_buffer) == 3
 
-    def test_forward_backward_empty_data_raises(self, backend, handle):
-        """forward_backward() with empty data should raise BackendError."""
-        with pytest.raises(BackendError, match="Empty data"):
-            asyncio.run(
-                backend.forward_backward(handle, [], "importance_sampling")
-            )
+    def test_forward_backward_empty_data_is_noop(self, backend, handle):
+        """Empty data (GRPO all-zero advantages) is a deferred no-op, not an error."""
+        result = asyncio.run(backend.forward_backward(handle, [], "importance_sampling"))
+        assert result == {
+            "loss_fn_output_type": "importance_sampling",
+            "metrics": {}, "deferred": True, "loss_fn_outputs": [],
+        }
+        assert len(handle.data_buffer) == 0
 
-    def test_apply_optimizer_step_empty_buffer_raises(self, backend, handle):
-        """apply_optimizer_step() with empty buffer should raise BackendError."""
-        with pytest.raises(BackendError, match="No buffered data"):
-            asyncio.run(
-                backend.apply_optimizer_step(handle)
-            )
+    def test_apply_optimizer_step_empty_buffer_is_noop(self, backend, handle):
+        """An empty buffer steps nothing and reports success with grad_norm 0."""
+        result = asyncio.run(backend.apply_optimizer_step(handle))
+        assert result["success"] is True
+        assert result["grad_norm"] == 0.0
+        assert result["loss_fn_outputs"] == []
 
     def test_buffer_overflow_raises(self, backend, handle):
         """forward_backward() should raise when buffer exceeds max_buffer_size (CHK006)."""
@@ -410,7 +448,10 @@ class TestNemoRLBackendBuffering:
         result = asyncio.run(
             backend.forward_backward(handle, data, "importance_sampling")
         )
-        assert result == {"metrics": {}, "deferred": True, "loss_fn_outputs": []}
+        assert result == {
+            "loss_fn_output_type": "importance_sampling",
+            "metrics": {}, "deferred": True, "loss_fn_outputs": [],
+        }
 
     def test_concurrent_forward_backward_thread_safe(self, backend, handle):
         """Concurrent forward_backward() calls should be serialized by lock (CHK018)."""

--- a/training/api.py
+++ b/training/api.py
@@ -12,6 +12,7 @@ This file contains only initialization and routing configuration.
 import asyncio
 import logging
 import os
+import signal
 import sqlite3
 from dataclasses import dataclass, field
 from typing import Any, Dict, Optional, Set
@@ -193,12 +194,26 @@ def create_app(config: Optional[TrainingConfig] = None) -> FastAPI:
 
         logger.info("✅ Dependency providers registered on app state")
 
+        # Session reaper: a session silent longer than session_timeout_s is
+        # expired and its models freed (the SDK heartbeats every 10 s).
+        application.state.session_reaper = None
+        if config_obj.session_timeout_s >= 0:
+            application.state.session_reaper = asyncio.create_task(
+                _reap_sessions_forever(application, config_obj.session_timeout_s,
+                                       config_obj.session_reap_interval_s)
+            )
+            logger.info("Session reaper enabled: timeout=%ss interval=%ss",
+                        config_obj.session_timeout_s, config_obj.session_reap_interval_s)
+
         # Initialize legacy storage for backward compatibility
         init_legacy_storage(config_obj.storage)
 
         # Initialize Ray
         if not ray.is_initialized():
             logger.info("Initializing Ray with address=%s", config_obj.ray.address)
+            # ray.init installs a SIGTERM handler that sys.exit()s, pre-empting
+            # uvicorn's graceful shutdown (and with it the model teardown above).
+            prev_sigterm = signal.getsignal(signal.SIGTERM)
             try:
                 ray.init(
                     address=config_obj.ray.address,
@@ -209,19 +224,80 @@ def create_app(config: Optional[TrainingConfig] = None) -> FastAPI:
             except Exception as e:  # pylint: disable=broad-except
                 logger.error("Failed to initialize Ray: %s", e)
                 # Continue anyway - Ray might be available later
+            finally:
+                if signal.getsignal(signal.SIGTERM) is not prev_sigterm:
+                    signal.signal(signal.SIGTERM, prev_sigterm)
 
     @application.on_event("shutdown")
     async def shutdown_event():
-        """Clean up resources on shutdown"""
+        """Free every live model (actors, placement groups) before the process exits."""
+        reaper = getattr(application.state, "session_reaper", None)
+        if reaper is not None:
+            reaper.cancel()
         runtime: TrainingRuntimeState = application.state.runtime
-        for model_id, client_info in list(runtime.training_clients.items()):
-            try:
-                logger.info("Cleaning up training client %s", model_id)
-                # Cleanup logic here
-            except Exception as e:  # pylint: disable=broad-except
-                logger.error("Error cleaning up %s: %s", model_id, e)
+        for model_id in list(runtime.training_clients):
+            await _free_model(application, model_id, reason="shutdown")
+        if ray.is_initialized():
+            ray.shutdown()
+
+    @application.exception_handler(HTTPException)
+    async def http_exception_handler(request: Request, exc: HTTPException):
+        """Handle HTTP exceptions with structured responses"""
+        return JSONResponse(
+            status_code=exc.status_code,
+            content={
+                "error": exc.detail,
+                "status_code": exc.status_code,
+                "path": str(request.url.path)
+            }
+        )
+
+    @application.exception_handler(Exception)
+    async def general_exception_handler(request: Request, exc: Exception):
+        """Handle unexpected exceptions"""
+        logger.error(f"Unexpected error: {exc}", exc_info=True)
+        return JSONResponse(
+            status_code=500,
+            content={
+                "error": "Internal server error",
+                "detail": str(exc) if os.getenv("DEBUG") else None
+            }
+        )
 
     return application
+
+
+async def _free_model(application: FastAPI, model_id: str, reason: str) -> None:
+    """Release one model's backend resources and its session link; never raises."""
+    runtime: TrainingRuntimeState = application.state.runtime
+    try:
+        logger.info("Freeing model %s (%s)", model_id, reason)
+        await application.state.model_service.delete_model(
+            model_id=model_id,
+            training_clients=runtime.training_clients,
+            metadata_storage=application.state.metadata_storage,
+        )
+    except Exception:  # pylint: disable=broad-except
+        logger.exception("Failed to free model %s (%s)", model_id, reason)
+    try:
+        application.state.session_service.remove_model(model_id)
+    except Exception:  # pylint: disable=broad-except
+        logger.exception("Failed to unlink model %s from its session", model_id)
+
+
+async def _reap_sessions_forever(application: FastAPI, timeout_s: float, interval_s: float) -> None:
+    session_service = application.state.session_service
+    while True:
+        await asyncio.sleep(interval_s)
+        try:
+            for session_id, model_ids in session_service.reap_stale_sessions(timeout_s):
+                logger.warning("Session %s silent > %ss: expired, freeing %d model(s)",
+                               session_id, timeout_s, len(model_ids))
+                for model_id in model_ids:
+                    if model_id in application.state.runtime.training_clients:
+                        await _free_model(application, model_id, reason=f"session {session_id} expired")
+        except Exception:  # pylint: disable=broad-except
+            logger.exception("Session reaper tick failed")
 
 
 app = create_app()
@@ -231,42 +307,15 @@ async def health():
     """Legacy health check function"""
     return {"status": "healthy"}
 
-# ============================================================================
-# ERROR HANDLERS
-# ============================================================================
-
-@app.exception_handler(HTTPException)
-async def http_exception_handler(request: Request, exc: HTTPException):
-    """Handle HTTP exceptions with structured responses"""
-    return JSONResponse(
-        status_code=exc.status_code,
-        content={
-            "error": exc.detail,
-            "status_code": exc.status_code,
-            "path": str(request.url.path)
-        }
-    )
-
-@app.exception_handler(Exception)
-async def general_exception_handler(request: Request, exc: Exception):
-    """Handle unexpected exceptions"""
-    logger.error(f"Unexpected error: {exc}", exc_info=True)
-    return JSONResponse(
-        status_code=500,
-        content={
-            "error": "Internal server error",
-            "detail": str(exc) if os.getenv("DEBUG") else None
-        }
-    )
-
 if __name__ == "__main__":
     import argparse
     import uvicorn
 
     parser = argparse.ArgumentParser(description="TinkerCloud Training API")
+    from .backends.factory import SUPPORTED_BACKENDS
     parser.add_argument(
         "--backend",
-        choices=["miles", "nemo_rl"],
+        choices=list(SUPPORTED_BACKENDS),
         default=None,
         help="Training backend (default: miles). Also settable via TINKERCLOUD_BACKEND env var.",
     )

--- a/training/backends/automodel/backend.py
+++ b/training/backends/automodel/backend.py
@@ -243,8 +243,12 @@ class AutomodelBackend(TrainingBackend):
 
     async def apply_optimizer_step(
         self, handle: BackendHandle, learning_rate: Optional[float] = None,
+        adam_params: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
-        """Optimizer step over accumulated grads, then zero them."""
+        """Optimizer step over accumulated grads, then zero them.
+
+        adam_params is accepted for contract uniformity; betas/eps are fixed at creation.
+        """
         h: AutomodelHandle = handle  # type: ignore[assignment]
         async with h.lock:
             return await asyncio.to_thread(self._optimizer_step, h, learning_rate)
@@ -281,7 +285,7 @@ class AutomodelBackend(TrainingBackend):
     async def sample(
         self, handle: BackendHandle, request_id: str, prompt_tokens: List[int],
         num_samples: int, sampling_params: Optional[Dict[str, Any]] = None,
-        prompt_logprobs: bool = False,
+        prompt_logprobs: bool = False, pinned_version: Optional[int] = None,
     ) -> Dict[str, Any]:
         raise _no_generation("sample")
 

--- a/training/backends/checkpoint_interchange.py
+++ b/training/backends/checkpoint_interchange.py
@@ -27,16 +27,20 @@ ADAPTER_CONFIG_FILE = "adapter_config.json"
 
 
 def resolve_checkpoint_root(path: str, create: bool = False) -> str:
-    """tinker://<run_id>/weights/<name> -> <CHECKPOINT_BASE>/<run_id>/<name>.
+    """tinker://<run_id>/weights/<name> -> <CHECKPOINT_BASE>/<run_id>/<name>;
+    tinker://<run_id>/sampler_weights/<name> -> <CHECKPOINT_BASE>/<run_id>/sampler_weights/<name>.
 
-    Filesystem paths pass through. Mirrors the URI shape minted by
-    CheckpointService.save_weights.
+    Filesystem paths pass through. Mirrors the URI shapes minted by
+    CheckpointService.save_weights / save_weights_for_sampler.
     """
     if path.startswith("tinker://"):
         parts = path[len("tinker://"):].split("/")
         run_id = parts[0]
         name = parts[-1] if len(parts) > 2 else "default"
-        local = os.path.join(CHECKPOINT_BASE, run_id, name)
+        if len(parts) > 2 and parts[1] == "sampler_weights":
+            local = os.path.join(CHECKPOINT_BASE, run_id, "sampler_weights", name)
+        else:
+            local = os.path.join(CHECKPOINT_BASE, run_id, name)
     else:
         local = path
     if create:

--- a/training/backends/factory.py
+++ b/training/backends/factory.py
@@ -1,64 +1,54 @@
 """
 Backend factory — creates the appropriate TrainingBackend from configuration.
+
+`SUPPORTED_BACKENDS` is the one allow-list; the CLI flag, the config
+validator and the signature-contract test all import it from here.
 """
+import importlib
 import logging
-from typing import Optional, Dict, Any
+from typing import Any, Dict, Optional, Type
 
 from .base import TrainingBackend
 
 logger = logging.getLogger(__name__)
+
+# backend_type -> (module relative to this package, class name)
+_BACKEND_CLASSES = {
+    "miles": (".miles.backend", "MilesBackend"),
+    "nemo_rl": (".nemo_rl.backend", "NemoRLBackend"),
+    "verl": (".verl.backend", "VerlBackend"),
+    "automodel": (".automodel.backend", "AutomodelBackend"),
+    "megatron_bridge": (".megatron_bridge.backend", "MegatronBridgeBackend"),
+}
+SUPPORTED_BACKENDS = tuple(_BACKEND_CLASSES)
 
 
 class BackendFactory:
     """Creates the appropriate backend based on configuration."""
 
     @staticmethod
+    def backend_class(backend_type: str) -> Type[TrainingBackend]:
+        """Import and return the backend class without instantiating it.
+
+        Raises ValueError for an unknown type; ImportError propagates when the
+        backend's runtime dependencies are absent.
+        """
+        try:
+            module_name, class_name = _BACKEND_CLASSES[backend_type]
+        except KeyError:
+            raise ValueError(
+                f"Unknown backend: {backend_type!r}. "
+                f"Supported backends: {', '.join(SUPPORTED_BACKENDS)}"
+            ) from None
+        module = importlib.import_module(module_name, package=__package__)
+        return getattr(module, class_name)
+
+    @staticmethod
     def create(
         backend_type: str,
         backend_overrides: Optional[Dict[str, Any]] = None,
     ) -> TrainingBackend:
-        """
-        Instantiate the training backend for the given type.
-
-        Args:
-            backend_type: "miles", "nemo_rl", "verl", "automodel", or "megatron_bridge"
-            backend_overrides: Optional backend-specific config overrides.
-
-        Returns:
-            A TrainingBackend instance.
-
-        Raises:
-            ValueError: If backend_type is unknown.
-        """
-        overrides = backend_overrides or {}
-
-        if backend_type == "miles":
-            from .miles.backend import MilesBackend
-            logger.info("Creating Miles backend")
-            return MilesBackend(overrides)
-
-        elif backend_type == "nemo_rl":
-            from .nemo_rl.backend import NemoRLBackend
-            logger.info("Creating NeMo RL backend")
-            return NemoRLBackend(overrides)
-
-        elif backend_type == "verl":
-            from .verl.backend import VerlBackend
-            logger.info("Creating veRL backend")
-            return VerlBackend(overrides)
-
-        elif backend_type == "automodel":
-            from .automodel.backend import AutomodelBackend
-            logger.info("Creating Automodel classification backend")
-            return AutomodelBackend(overrides)
-
-        elif backend_type == "megatron_bridge":
-            from .megatron_bridge.backend import MegatronBridgeBackend
-            logger.info("Creating Megatron-Bridge classification backend")
-            return MegatronBridgeBackend(overrides)
-
-        else:
-            raise ValueError(
-                f"Unknown backend: {backend_type!r}. "
-                f"Supported backends: miles, nemo_rl, verl, automodel, megatron_bridge"
-            )
+        """Instantiate the training backend for `backend_type` (see SUPPORTED_BACKENDS)."""
+        cls = BackendFactory.backend_class(backend_type)
+        logger.info("Creating %s backend (%s)", backend_type, cls.__name__)
+        return cls(backend_overrides or {})

--- a/training/backends/megatron_bridge/backend.py
+++ b/training/backends/megatron_bridge/backend.py
@@ -144,7 +144,13 @@ class MegatronBridgeBackend(TrainingBackend):
         batch = self.converter.forward_backward_to_backend(data, loss_fn, {"seq_length": h.seq_length})
         return await _get(h.worker.forward_backward.remote(batch))
 
-    async def apply_optimizer_step(self, handle: BackendHandle, learning_rate: Optional[float] = None) -> Dict[str, Any]:
+    async def apply_optimizer_step(
+        self,
+        handle: BackendHandle,
+        learning_rate: Optional[float] = None,
+        adam_params: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        # adam_params accepted for contract uniformity; betas/eps are fixed at creation.
         h: MegatronBridgeHandle = handle  # type: ignore[assignment]
         return await _get(h.worker.apply_optimizer_step.remote(learning_rate))
 
@@ -155,7 +161,8 @@ class MegatronBridgeBackend(TrainingBackend):
 
     async def sample(self, handle: BackendHandle, request_id: str, prompt_tokens: List[int],
                      num_samples: int, sampling_params: Optional[Dict[str, Any]] = None,
-                     prompt_logprobs: bool = False) -> Dict[str, Any]:
+                     prompt_logprobs: bool = False,
+                     pinned_version: Optional[int] = None) -> Dict[str, Any]:
         raise _no_generation("sample")
 
     async def get_logprobs(self, handle: BackendHandle, data: List[Dict]) -> List[Any]:

--- a/training/backends/miles/backend.py
+++ b/training/backends/miles/backend.py
@@ -16,7 +16,7 @@ from typing import Any, Dict, List, Optional
 
 import ray
 
-from ..base import BackendError, BackendHandle, TrainingBackend
+from ..base import BackendError, BackendHandle, TrainingBackend, UnsupportedFeatureError
 from ..checkpoint_interchange import (
     CHECKPOINT_BASE,
     export_hf_adapter,
@@ -1151,8 +1151,11 @@ class MilesBackend(TrainingBackend):
         async def _run() -> str:
             offload_train = h.args.offload_train if h.args else False
             if offload_train:
-                logger.info("Skipping save_model (offload_train=True)")
-                return checkpoint_path
+                # Never return a path nothing was written to.
+                raise UnsupportedFeatureError(
+                    "save_checkpoint with offload_train", backend="miles",
+                    suggestion="boot the actor group without --offload-train",
+                )
 
             # Pool mode: save_due_adapter_checkpoints only writes adapters with
             # registry step > 0 at a save-interval multiple (interval is 1 at

--- a/training/config.py
+++ b/training/config.py
@@ -182,7 +182,7 @@ class BackendConfig(BaseModel):
 
     backend_type: str = Field(
         default_factory=lambda: os.getenv("TINKERCLOUD_BACKEND", "miles"),
-        description="Training backend: 'miles', 'nemo_rl', 'automodel', or 'megatron_bridge'"
+        description="Training backend; see training.backends.factory.SUPPORTED_BACKENDS"
     )
     backend_overrides: Dict[str, Any] = Field(
         default_factory=dict,
@@ -191,11 +191,11 @@ class BackendConfig(BaseModel):
 
     @validator("backend_type")
     def validate_backend_type(cls, v):
-        """Ensure backend type is supported."""
-        supported = ("miles", "nemo_rl", "automodel", "megatron_bridge")
-        if v not in supported:
+        """Ensure backend type is supported (single allow-list lives in the factory)."""
+        from .backends.factory import SUPPORTED_BACKENDS
+        if v not in SUPPORTED_BACKENDS:
             raise ValueError(
-                f"Unsupported backend: {v!r}. Supported: {', '.join(supported)}"
+                f"Unsupported backend: {v!r}. Supported: {', '.join(SUPPORTED_BACKENDS)}"
             )
         return v
 
@@ -263,6 +263,16 @@ class TrainingConfig(BaseModel):
     allow_partial_batches: bool = Field(
         default_factory=lambda: os.getenv("ALLOW_PARTIAL_BATCHES", "false").lower() == "true",
         description="Allow forward_backward batches that are not divisible by data-parallel size"
+    )
+    # The SDK heartbeats every 10 s; a session silent longer than the timeout
+    # is expired and its models are freed. -1 disables the reaper.
+    session_timeout_s: float = Field(
+        default_factory=lambda: float(os.getenv("SESSION_TIMEOUT_S", "600")),
+        description="Expire sessions with no heartbeat for this many seconds (-1 disables)"
+    )
+    session_reap_interval_s: float = Field(
+        default_factory=lambda: float(os.getenv("SESSION_REAP_INTERVAL_S", "60")),
+        description="How often the session reaper runs, in seconds"
     )
 
     @staticmethod

--- a/training/routers/checkpoints.py
+++ b/training/routers/checkpoints.py
@@ -247,17 +247,16 @@ async def weights_info(
 
     model_id = path_parts[0]
     checkpoint_name = path_parts[2] if len(path_parts) >= 3 else None
+    if checkpoint_name and path_parts[1] == "sampler_weights":
+        checkpoint_name = f"sampler_{checkpoint_name}"  # metadata key used by save_weights_for_sampler
     logger.info(f"Extracted model_id: {model_id}, checkpoint_name: {checkpoint_name}")
 
     # Try to find model in active training clients first
     if model_id in training_clients:
         client_info = training_clients[model_id]
         base_model = client_info.get("base_model", "")
-        args = client_info.get("args", {})
-        lora_rank = getattr(args, "lora_rank", None) if args else None
-
-        # Determine if LoRA is enabled
-        is_lora = lora_rank is not None and lora_rank > 0
+        lora_rank = int((client_info.get("lora_config") or {}).get("rank") or 0)
+        is_lora = lora_rank > 0
 
         # Verify checkpoint exists if name was provided
         if checkpoint_name:

--- a/training/routers/models.py
+++ b/training/routers/models.py
@@ -138,18 +138,8 @@ async def create_model(
             detail=f"Session not found: {request.session_id}"
         )
 
-    # Link model to session with seq_id and context for matching
-    session_service.add_model(
-        session_id=request.session_id,
-        model_id=model_id,
-        model_seq_id=request.model_seq_id,
-        base_model=request.base_model,
-        model_path=request.checkpoint_path  # May be None, that's OK
-    )
-    logger.info(f"Model {model_id} (seq={request.model_seq_id}) linked to session {request.session_id}")
-
     async def execute():
-        return await service.create_model(
+        result = await service.create_model(
             model_id=model_id,
             request_id=request_id,
             base_model=request.base_model,
@@ -170,6 +160,17 @@ async def create_model(
             num_labels=request.num_labels,
             head_config=request.head_config,
         )
+        # Link only once the backend holds the model, so a failed create
+        # leaves no dangling session->model entry.
+        session_service.add_model(
+            session_id=request.session_id,
+            model_id=model_id,
+            model_seq_id=request.model_seq_id,
+            base_model=request.base_model,
+            model_path=request.checkpoint_path,
+        )
+        logger.info(f"Model {model_id} (seq={request.model_seq_id}) linked to session {request.session_id}")
+        return result
 
     # Create async task
     task_manager.create_task(

--- a/training/routers/training.py
+++ b/training/routers/training.py
@@ -18,6 +18,7 @@ from ..models.requests import ForwardRequest, ForwardBackwardRequest, OptimStepR
 from ..models.responses import AsyncOperationResponse
 from ..services.training_service import TrainingService
 from ..core.task_manager import TaskManager
+from ..core.dependencies import verify_api_key_dep
 from ..storage import FuturesStorage
 
 logger = logging.getLogger(__name__)
@@ -73,6 +74,7 @@ def get_task_manager(
 @router.post("/api/v1/forward", response_model=AsyncOperationResponse)
 async def forward(
     request: ForwardRequest,
+    _: None = Depends(verify_api_key_dep),
     http_request: Request = None,
     service: TrainingService = Depends(get_training_service),
     task_manager: TaskManager = Depends(get_task_manager),
@@ -125,6 +127,7 @@ async def forward(
 @router.post("/api/v1/forward_backward", response_model=AsyncOperationResponse)
 async def forward_backward(
     request: ForwardBackwardRequest,
+    _: None = Depends(verify_api_key_dep),
     http_request: Request = None,
     service: TrainingService = Depends(get_training_service),
     task_manager: TaskManager = Depends(get_task_manager),
@@ -175,6 +178,7 @@ async def forward_backward(
 @router.post("/api/v1/optim_step", response_model=AsyncOperationResponse)
 async def optim_step(
     request: OptimStepRequest,
+    _: None = Depends(verify_api_key_dep),
     http_request: Request = None,
     service: TrainingService = Depends(get_training_service),
     task_manager: TaskManager = Depends(get_task_manager),

--- a/training/services/checkpoint_service.py
+++ b/training/services/checkpoint_service.py
@@ -14,7 +14,7 @@ from typing import Dict, Any, Optional
 
 from ..backends.base import TrainingBackend
 from ..storage import MetadataStorage
-from ..utils.helpers import generate_step_id
+from ..backends.checkpoint_interchange import resolve_checkpoint_root
 
 logger = logging.getLogger(__name__)
 
@@ -24,6 +24,12 @@ class CheckpointService:
 
     def __init__(self, backend: TrainingBackend):
         self.backend = backend
+
+    @staticmethod
+    def _next_step_id(client_info: Dict[str, Any]) -> int:
+        """Monotonic per-model save counter (the backend's iteration label)."""
+        client_info["save_counter"] = client_info.get("save_counter", 0) + 1
+        return client_info["save_counter"]
 
     async def save_weights(
         self,
@@ -48,7 +54,7 @@ class CheckpointService:
 
         # Generate checkpoint name and step_id
         checkpoint_name = path or f"checkpoint_{int(time.time())}"
-        step_id = generate_step_id(checkpoint_name)
+        step_id = self._next_step_id(client_info)
         checkpoint_path = f"tinker://{training_run_id}/weights/{checkpoint_name}"
 
         logger.info("[%s] Saving weights for %s to %s", request_id, model_id, checkpoint_path)
@@ -124,12 +130,14 @@ class CheckpointService:
             logger.info("[%s] Saving weights for sampler: %s", request_id, model_id)
 
             checkpoint_name = path or name or f"sampler_{int(time.time())}"
-            step_id = generate_step_id(checkpoint_name)
-            checkpoint_path = f"/data/checkpoints/tinker/iter_{step_id:07d}"
-            tinker_uri = f"tinker://{training_run_id}/weights/{checkpoint_name}"
+            step_id = self._next_step_id(client_info)
+            tinker_uri = f"tinker://{training_run_id}/sampler_weights/{checkpoint_name}"
+            # The backend resolves the URI through resolve_checkpoint_root, so the
+            # recorded filesystem path is where the bytes actually land.
+            checkpoint_path = resolve_checkpoint_root(tinker_uri)
 
             # Delegate actual save to backend
-            await self.backend.save_checkpoint(handle, checkpoint_path, step_id=step_id)
+            await self.backend.save_checkpoint(handle, tinker_uri, step_id=step_id)
 
             # Save checkpoint metadata
             metadata_storage.save_checkpoint(

--- a/training/services/model_service.py
+++ b/training/services/model_service.py
@@ -99,7 +99,7 @@ class ModelService:
             "created_at": datetime.now().isoformat(),
             "checkpoint_path": checkpoint_path,
             "model_owner": "kgateway-user",
-            "is_lora": lora_config is not None,
+            "is_lora": bool(lora_config and lora_config.get("rank", 0) > 0),
             "lora_rank": lora_config.get("rank", 0) if lora_config else 0,
             "is_rlve": rlve_config is not None and rlve_config.get("enabled", False),
             "corrupted": False,
@@ -117,6 +117,7 @@ class ModelService:
             "training_run_id": training_run_id,
             "hf_path": hf_path,
             "base_model": base_model,
+            "lora_config": lora_config,
             "router_ip": getattr(handle, "router_ip", None),
             "router_port": getattr(handle, "router_port", None),
             "rlve_config": rlve_config,
@@ -199,23 +200,20 @@ class ModelService:
         client_info = training_clients[model_id]
         args = client_info.get("args")
 
+        # Backend-agnostic: the LoRA shape is what the client asked for at create time.
+        lora_rank = int((client_info.get("lora_config") or {}).get("rank") or 0)
+        is_lora = lora_rank > 0
         if args is not None:
             model_name = extract_model_name(args)
-            arch = detect_architecture(model_name)
-            is_lora = getattr(args, "lora_rank", 0) > 0
-            lora_rank = args.lora_rank if is_lora else None
         else:
-            # Non-Miles backend — use base_model from metadata
             model_name = client_info.get("base_model", "unknown")
-            arch = detect_architecture(model_name)
-            is_lora = False
-            lora_rank = None
+        arch = detect_architecture(model_name)
 
         return {
             "model_id": model_id,
             "model_data": {"arch": arch, "model_name": model_name},
             "is_lora": is_lora,
-            "lora_rank": lora_rank,
+            "lora_rank": lora_rank if is_lora else None,
             "model_name": model_name,
         }
 

--- a/training/services/session_service.py
+++ b/training/services/session_service.py
@@ -373,6 +373,27 @@ class SessionService:
                 stale.append(session_id)
         return stale
 
+    def reap_stale_sessions(self, timeout_s: float) -> List[Tuple[str, List[str]]]:
+        """Expire sessions with no heartbeat for more than `timeout_s`.
+
+        Drops them from memory and storage and returns (session_id, model_ids)
+        pairs; the caller owns freeing the models.
+        """
+        now = datetime.now()
+        reaped: List[Tuple[str, List[str]]] = []
+        for session_id, session in list(self._sessions.items()):
+            if (now - session.last_heartbeat).total_seconds() <= timeout_s:
+                continue
+            self._sessions.pop(session_id, None)
+            for model_id in session.model_ids:
+                self._model_to_session.pop(model_id, None)
+            for sampler_id in session.sampling_session_ids:
+                self._samplers.pop(sampler_id, None)
+            if self._storage:
+                self._storage.delete_session(session_id)
+            reaped.append((session_id, list(session.model_ids)))
+        return reaped
+
     def get_active_session_count(self) -> int:
         """Get count of tracked sessions."""
         return len(self._sessions)

--- a/training/utils/__init__.py
+++ b/training/utils/__init__.py
@@ -8,7 +8,6 @@ from .auth import APIKeyAuth, verify_api_key
 from .helpers import (
     generate_request_id,
     generate_model_id,
-    generate_step_id,
     format_timestamp,
     extract_error_message,
     validate_batch_data,
@@ -32,7 +31,6 @@ __all__ = [
     # Helpers
     "generate_request_id",
     "generate_model_id",
-    "generate_step_id",
     "format_timestamp",
     "extract_error_message",
     "validate_batch_data",

--- a/training/utils/helpers.py
+++ b/training/utils/helpers.py
@@ -3,7 +3,6 @@ Helper utilities for the training API.
 
 This module provides common helper functions used across the training API.
 """
-import hashlib
 import logging
 import uuid
 from datetime import datetime
@@ -36,24 +35,6 @@ def generate_model_id(prefix: str = "model") -> str:
         Unique model ID in format: prefix_<hex16>
     """
     return f"{prefix}_{uuid.uuid4().hex[:16]}"
-
-
-def generate_step_id(checkpoint_name: str, max_step: int = 100000) -> int:
-    """
-    Generate a consistent step ID from checkpoint name.
-
-    Uses MD5 hash to ensure the same checkpoint name always
-    maps to the same step ID, enabling deterministic checkpoint paths.
-
-    Args:
-        checkpoint_name: Name of the checkpoint
-        max_step: Maximum step value (modulo)
-
-    Returns:
-        Step ID (integer)
-    """
-    hash_digest = hashlib.md5(checkpoint_name.encode()).hexdigest()
-    return int(hash_digest[:8], 16) % max_step
 
 
 def format_timestamp(timestamp: Optional[datetime] = None) -> str:


### PR DESCRIPTION
## What

- Require the API key on `/forward`, `/forward_backward`, `/optim_step`; every other route already did.
- Register the exception handlers inside `create_app()` so the `python -m training.api` app has them.
- Single backend allow-list `SUPPORTED_BACKENDS` (`backends/factory.py`) shared by the CLI flag, the config validator, and a new signature-contract test over every registered backend. The test caught `adam_params` missing on the two classification backends' `apply_optimizer_step` and `pinned_version` missing on their `sample()`; both fixed.
- Shutdown frees every live model and calls `ray.shutdown()`. `ray.init` installs a SIGTERM handler that `sys.exit()`s and pre-empts uvicorn's graceful shutdown; the server now restores uvicorn's handler after `ray.init`.
- Periodic session reaper (`SESSION_TIMEOUT_S`, default 600 s, `-1` disables; `SESSION_REAP_INTERVAL_S`, default 60 s): silent sessions are expired and their models freed.
- `is_lora` / `lora_rank` come from the stored `lora_config` on every backend instead of Megatron args.
- A model is linked to its session only after the backend create succeeds.
- Miles `save_checkpoint` under `offload_train` raises `UnsupportedFeatureError` instead of returning a path nothing was written to.
- Persistent `save_weights_for_sampler` mints `tinker://<run>/sampler_weights/<name>` and writes where `resolve_checkpoint_root` maps it; `weights_info` resolves that URI. `step_id` is a monotonic per-model counter.
- Three stale NeMo RL buffering tests aligned with the empty-data / empty-buffer no-op contract.

## Verification

- `tests/test_backend_interface.py` + converter/interchange/validator/e0/miles unit tests: 124 passed on the nemo_rl image, 30 passed on the miles image (contract test covers all five backends across the two).
- HTTP-layer smoke against `create_app()` with a fake Ray: training routes return 401/403 without a key; the HTTPException handler shape is present on the factory app; the reaper task runs and expires a stale session from memory and storage.
- Live nemo_rl server, Qwen2.5-0.5B-Instruct rank-8 LoRA: create → forward_backward → optim_step → `get_info` reports LoRA rank 8 → `save_state` + `save_weights_for_sampler` → `weights_info` on both URIs → SIGTERM with the model live → log shows the model freed, 0 live placement groups, 0 alive actors, 0 MiB on all GPUs, no tracebacks → restart → `create_training_client_from_state` → train → SIGTERM → same clean state → third restart clean.
