### PR TITLE
Add a deterministic fake backend and an SDK-driven protocol test suite

### DIFF
--- a/tests/protocol/conftest.py
+++ b/tests/protocol/conftest.py
@@ -1,0 +1,114 @@
+"""Protocol suite: a real `tinker` SDK against a live server on the fake backend.
+
+No GPU, no Ray. One server per test session; each test creates its own models.
+"""
+import json
+import os
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+import requests
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+API_KEY = "tml-protocol-test-key"
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+class Server:
+    def __init__(self, tmp: Path):
+        self.port = _free_port()
+        self.base_url = f"http://127.0.0.1:{self.port}"
+        self.metadata_dir = tmp / "metadata"
+        self.checkpoint_base = tmp / "checkpoints"
+        self.trace_path = tmp / "trace.jsonl"
+        self.log_path = tmp / "server.log"
+        for d in (self.metadata_dir, self.checkpoint_base):
+            d.mkdir(parents=True, exist_ok=True)
+        env = {
+            **os.environ,
+            "PYTHONPATH": str(REPO_ROOT),
+            "METADATA_DIR": str(self.metadata_dir),
+            "TINKERCLOUD_CHECKPOINT_BASE": str(self.checkpoint_base),
+            "TINKERCLOUD_BACKEND": "fake",
+            "TINKER_API_KEY": API_KEY,
+            "FAKE_BACKEND_TRACE": str(self.trace_path),
+            "TRAINING_HOST": "127.0.0.1",
+            "TRAINING_PORT": str(self.port),
+            "SESSION_TIMEOUT_S": "-1",
+            "RAY_DISABLE_AUTO_INIT": "1",
+        }
+        self.log = open(self.log_path, "w")
+        self.proc = subprocess.Popen(
+            [sys.executable, "-m", "training.api", "--backend", "fake",
+             "--host", "127.0.0.1", "--port", str(self.port)],
+            cwd=str(REPO_ROOT), env=env, stdout=self.log, stderr=subprocess.STDOUT,
+        )
+
+    def wait_healthy(self, timeout_s: float = 60.0) -> None:
+        deadline = time.time() + timeout_s
+        while time.time() < deadline:
+            if self.proc.poll() is not None:
+                raise RuntimeError(f"server exited early; log:\n{self.log_path.read_text()[-4000:]}")
+            try:
+                if requests.get(self.base_url + "/health", timeout=2).status_code == 200:
+                    return
+            except requests.RequestException:
+                pass
+            time.sleep(0.25)
+        raise RuntimeError(f"server not healthy in {timeout_s}s; log:\n{self.log_path.read_text()[-4000:]}")
+
+    def stop(self) -> None:
+        if self.proc.poll() is None:
+            self.proc.terminate()
+            try:
+                self.proc.wait(timeout=30)
+            except subprocess.TimeoutExpired:
+                self.proc.kill()
+        self.log.close()
+
+    def trace(self):
+        if not self.trace_path.exists():
+            return []
+        return [json.loads(line) for line in self.trace_path.read_text().splitlines() if line.strip()]
+
+    def post(self, path: str, body: dict, key: str | None = API_KEY, **kw):
+        headers = {"X-API-Key": key} if key else {}
+        return requests.post(self.base_url + path, json=body, headers=headers, timeout=kw.pop("timeout", 30))
+
+
+@pytest.fixture(scope="session")
+def server(tmp_path_factory):
+    srv = Server(tmp_path_factory.mktemp("protocol"))
+    try:
+        srv.wait_healthy()
+        yield srv
+    finally:
+        srv.stop()
+
+
+@pytest.fixture(scope="session")
+def service_client(server):
+    os.environ["TINKER_BASE_URL"] = server.base_url
+    os.environ["TINKER_API_KEY"] = API_KEY
+    import tinker
+    return tinker.ServiceClient(base_url=server.base_url, api_key=API_KEY)
+
+
+def make_datum(tokens):
+    import tinker
+    return tinker.Datum(
+        model_input=tinker.ModelInput.from_ints(tokens[:-1]),
+        loss_fn_inputs={
+            "weights": tinker.TensorData(data=[1.0] * (len(tokens) - 1), dtype="float32", shape=[len(tokens) - 1]),
+            "target_tokens": tinker.TensorData(data=tokens[1:], dtype="int64", shape=[len(tokens) - 1]),
+        },
+    )

--- a/tests/protocol/test_auth.py
+++ b/tests/protocol/test_auth.py
@@ -1,0 +1,22 @@
+"""Every mutating route requires the API key; the training routes used to be open."""
+import pytest
+
+
+@pytest.mark.parametrize("path,body", [
+    ("/api/v1/forward", {"model_id": "model_x", "forward_input": {"data": [], "loss_fn": "cross_entropy"}}),
+    ("/api/v1/forward_backward", {"model_id": "model_x", "forward_backward_input": {"data": [], "loss_fn": "cross_entropy"}}),
+    ("/api/v1/optim_step", {"model_id": "model_x", "adam_params": {"learning_rate": 1e-4}}),
+    ("/api/v1/save_weights", {"model_id": "model_x", "path": "x"}),
+    ("/api/v1/asample", {"prompt": {"tokens": [1, 2]}, "num_samples": 1}),
+])
+def test_missing_key_is_rejected(server, path, body):
+    r = server.post(path, body, key=None)
+    assert r.status_code in (401, 403), (path, r.status_code, r.text)
+    r = server.post(path, body, key="wrong-key")
+    assert r.status_code in (401, 403), (path, r.status_code, r.text)
+
+
+def test_http_error_body_shape(server):
+    r = server.post("/api/v1/optim_step", {"model_id": "model_nope", "adam_params": {"learning_rate": 1e-4}})
+    assert r.status_code == 404
+    assert r.json()["path"] == "/api/v1/optim_step"  # custom handler is bound on the served app

--- a/tests/protocol/test_baseline.py
+++ b/tests/protocol/test_baseline.py
@@ -1,0 +1,54 @@
+"""Regression floor: the plain SDK training loop must work before any protocol change lands."""
+from tinker import types
+
+from .conftest import make_datum
+
+
+def test_train_save_unload(service_client, server):
+    tc = service_client.create_lora_training_client(base_model="fake/tiny", rank=8)
+    assert tc.model_id.startswith("model_")
+
+    tokens = list(range(10, 20))
+    fb = tc.forward_backward([make_datum(tokens)] * 2, "cross_entropy")
+    op = tc.optim_step(types.AdamParams(learning_rate=0.5))
+    fb_out = fb.result()
+    op_out = op.result()
+
+    # one logprob per model_input token, deterministic values
+    assert len(fb_out.loss_fn_outputs) == 2
+    lp = fb_out.loss_fn_outputs[0]["logprobs"].data
+    assert lp == [-(t % 7) / 7.0 for t in tokens[:-1]]
+    assert op_out.metrics["grad_norm"] == 1.0  # first optimizer step on this model
+
+    fwd = tc.forward([make_datum(tokens)], "cross_entropy").result()
+    assert fwd.loss_fn_outputs[0]["logprobs"].data == lp
+
+    path = tc.save_state("baseline").result().path
+    assert path == f"tinker://{tc.model_id}/weights/baseline"
+
+    ops = [t["op"] for t in server.trace() if t["model_id"] == tc.model_id]
+    assert ops[:4] == ["create_model", "forward_backward", "apply_optimizer_step", "forward"]
+    assert "save_checkpoint" in ops
+
+    r = server.post("/api/v1/unload_model", {"model_id": tc.model_id})
+    assert r.status_code == 200
+    rid = r.json()["request_id"]
+    r = server.post("/api/v1/retrieve_future", {"request_id": rid}, timeout=60)
+    assert r.status_code == 200, r.text
+    assert server.post("/api/v1/get_info", {"model_id": tc.model_id}).status_code == 404
+
+
+def test_load_from_state_round_trips_weights(service_client, server):
+    tc = service_client.create_lora_training_client(base_model="fake/tiny", rank=4)
+    tokens = list(range(1, 8))
+    tc.forward_backward([make_datum(tokens)], "cross_entropy")
+    tc.optim_step(types.AdamParams(learning_rate=0.25)).result()
+    path = tc.save_state("rt").result().path
+
+    tc2 = service_client.create_training_client_from_state(path)
+    assert tc2.model_id != tc.model_id
+    created = [t for t in server.trace() if t["op"] == "create_model" and t["model_id"] == tc2.model_id]
+    assert created and created[0]["checkpoint_path"] == path
+    # the loaded model continues from the saved weights: w = 0.25 * 1 pending microbatch
+    op = tc2.optim_step(types.AdamParams(learning_rate=0.0)).result()
+    assert op.metrics["fake_w"] == 0.25

--- a/tests/protocol/test_model_info.py
+++ b/tests/protocol/test_model_info.py
@@ -1,0 +1,49 @@
+"""LoRA info comes from the stored lora_config; a failed create leaves no session link."""
+import sqlite3
+
+import requests
+
+from .conftest import API_KEY
+
+
+def test_get_info_and_weights_info_report_lora(service_client, server):
+    tc = service_client.create_lora_training_client(base_model="fake/tiny", rank=16)
+    info = server.post("/api/v1/get_info", {"model_id": tc.model_id}).json()
+    assert info["is_lora"] is True and info["lora_rank"] == 16
+
+    path = tc.save_state("info").result().path
+    wi = server.post("/api/v1/weights_info", {"tinker_path": path}).json()
+    assert wi == {"base_model": "fake/tiny", "is_lora": True, "lora_rank": 16}
+
+    spath = tc.save_weights_for_sampler("sinfo").result().path
+    assert spath == f"tinker://{tc.model_id}/sampler_weights/sinfo"
+    wi = server.post("/api/v1/weights_info", {"tinker_path": spath}).json()
+    assert wi["is_lora"] is True and wi["lora_rank"] == 16
+    saved = [t for t in server.trace() if t["op"] == "save_checkpoint" and t["checkpoint_path"] == spath]
+    assert saved and saved[0]["root"].endswith(f"/{tc.model_id}/sampler_weights/sinfo")
+
+
+def test_full_param_model_reports_no_lora(service_client, server):
+    tc = service_client.create_lora_training_client(base_model="fake/tiny", rank=0)
+    info = server.post("/api/v1/get_info", {"model_id": tc.model_id}).json()
+    assert info["is_lora"] is False and info["lora_rank"] is None
+
+
+def test_failed_create_leaves_no_session_link(server):
+    sess = server.post("/api/v1/create_session", {"tags": [], "user_metadata": {}, "sdk_version": "t"}).json()
+    session_id = sess["session_id"]
+    # the fake backend rejects non-LM objectives, so this create fails inside the task
+    r = server.post("/api/v1/create_model", {
+        "session_id": session_id, "model_seq_id": 1, "base_model": "fake/tiny",
+        "lora_config": {"rank": 8}, "objective": "classification", "num_labels": 3,
+    })
+    assert r.status_code == 200, r.text
+    fut = server.post("/api/v1/retrieve_future", {"request_id": r.json()["request_id"]}, timeout=60)
+    assert fut.status_code == 400, fut.text  # failed future
+    summary = requests.get(f"{server.base_url}/api/v1/sessions/{session_id}",
+                           headers={"X-API-Key": API_KEY}, timeout=10)
+    assert summary.status_code == 200, summary.text
+    assert summary.json()["training_run_ids"] == []
+    with sqlite3.connect(server.metadata_dir / "sessions.db") as db:
+        rows = db.execute("SELECT model_id FROM session_models WHERE session_id = ?", (session_id,)).fetchall()
+    assert rows == []

--- a/training/api.py
+++ b/training/api.py
@@ -209,7 +209,9 @@ def create_app(config: Optional[TrainingConfig] = None) -> FastAPI:
         init_legacy_storage(config_obj.storage)
 
         # Initialize Ray
-        if not ray.is_initialized():
+        if not getattr(backend, "needs_ray", True):
+            logger.info("Backend %s does not use Ray; skipping ray.init", backend_type)
+        elif not ray.is_initialized():
             logger.info("Initializing Ray with address=%s", config_obj.ray.address)
             # ray.init installs a SIGTERM handler that sys.exit()s, pre-empting
             # uvicorn's graceful shutdown (and with it the model teardown above).

--- a/training/backends/base.py
+++ b/training/backends/base.py
@@ -45,6 +45,9 @@ class TrainingBackend(ABC):
     translate to Miles or NeMo RL native APIs.
     """
 
+    # False for in-process backends (no Ray actors); the server then skips ray.init.
+    needs_ray: bool = True
+
     @abstractmethod
     async def create_model(
         self,

--- a/training/backends/checkpoint_interchange.py
+++ b/training/backends/checkpoint_interchange.py
@@ -19,7 +19,7 @@ from typing import Optional
 
 logger = logging.getLogger(__name__)
 
-CHECKPOINT_BASE = "/data/checkpoints"
+CHECKPOINT_BASE = os.getenv("TINKERCLOUD_CHECKPOINT_BASE", "/data/checkpoints")
 HF_ADAPTER_DIRNAME = "hf_adapter"
 ADAPTER_WEIGHTS_FILE = "adapter_model.safetensors"
 ADAPTER_WEIGHTS_TORCH_FILE = "adapter_model.bin"

--- a/training/backends/factory.py
+++ b/training/backends/factory.py
@@ -19,6 +19,7 @@ _BACKEND_CLASSES = {
     "verl": (".verl.backend", "VerlBackend"),
     "automodel": (".automodel.backend", "AutomodelBackend"),
     "megatron_bridge": (".megatron_bridge.backend", "MegatronBridgeBackend"),
+    "fake": (".fake.backend", "FakeBackend"),  # deterministic CPU backend for protocol tests
 }
 SUPPORTED_BACKENDS = tuple(_BACKEND_CLASSES)
 

--- a/training/backends/fake/__init__.py
+++ b/training/backends/fake/__init__.py
@@ -1,0 +1,4 @@
+"""Deterministic CPU backend for protocol tests (no Ray, no GPU)."""
+from .backend import FakeBackend, FakeHandle
+
+__all__ = ["FakeBackend", "FakeHandle"]

--- a/training/backends/fake/backend.py
+++ b/training/backends/fake/backend.py
@@ -1,0 +1,233 @@
+"""
+FakeBackend — a deterministic, in-process TrainingBackend with no GPU and no Ray.
+
+It exists so the HTTP/session/futures/checkpoint protocol above the backends
+can be exercised by the real `tinker` SDK in CI. Every observable is a pure
+function of the inputs:
+
+- logprobs[i] = -(token_i % 7) / 7, one per model_input token
+- grad_norm   = number of optimizer steps taken on the model (1-based)
+- sample      = tokens derived from (prompt, seed, sample index); the same
+                seed always yields the same tokens
+- weights     = a scalar `w` advanced by lr * pending_microbatches per step,
+                so a save/load round trip is checkable
+
+Set FAKE_BACKEND_TRACE=<path> to append one JSON line per backend call
+({"op", "model_id", ...args}) — tests read this instead of poking internals.
+"""
+import json
+import logging
+import os
+import random
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from ..base import BackendError, BackendHandle, TrainingBackend
+from ..checkpoint_interchange import resolve_checkpoint_root
+
+logger = logging.getLogger(__name__)
+
+STATE_FILE = "fake_state.json"
+
+
+@dataclass
+class FakeHandle(BackendHandle):
+    base_model: str = ""
+    lora_config: Optional[Dict[str, Any]] = None
+    hf_path: str = ""
+    w: float = 0.0
+    weight_version: int = 0
+    step_count: int = 0
+    pending: int = 0
+    has_rollout: bool = True  # discoverable as a sampling target
+    metrics: Dict[str, Any] = field(default_factory=dict)
+
+
+def _tokens_of(model_input: Any) -> List[int]:
+    """Accept the router's pydantic ModelInput or a plain dict."""
+    get = (lambda k: getattr(model_input, k, None)) if not isinstance(model_input, dict) else model_input.get
+    if get("tokens"):
+        return list(get("tokens"))
+    if get("input_ids"):
+        return list(get("input_ids"))
+    out: List[int] = []
+    for chunk in get("chunks") or []:
+        toks = chunk.get("tokens") if isinstance(chunk, dict) else getattr(chunk, "tokens", None)
+        out.extend(toks or [])
+    return out
+
+
+def _datum_parts(datum: Any):
+    if isinstance(datum, dict):
+        return datum["model_input"], datum.get("loss_fn_inputs") or {}
+    return datum.model_input, datum.loss_fn_inputs or {}
+
+
+def logprobs_for(tokens: List[int]) -> List[float]:
+    return [-(t % 7) / 7.0 for t in tokens]
+
+
+class FakeBackend(TrainingBackend):
+    needs_ray = False
+
+    def __init__(self, overrides: Optional[Dict[str, Any]] = None):
+        self.overrides = overrides or {}
+        self._models: Dict[str, FakeHandle] = {}
+        self._trace_path = os.getenv("FAKE_BACKEND_TRACE")
+
+    # --- tracing ---------------------------------------------------------
+    def _trace(self, op: str, model_id: str, **kw: Any) -> None:
+        if not self._trace_path:
+            return
+        with open(self._trace_path, "a") as f:
+            f.write(json.dumps({"op": op, "model_id": model_id, **kw}, default=str) + "\n")
+
+    def _handle(self, handle: BackendHandle, op: str) -> FakeHandle:
+        h = self._models.get(handle.model_id)
+        if h is None:
+            raise BackendError(f"Model {handle.model_id} not found", backend="fake", operation=op)
+        return h
+
+    # --- lifecycle -------------------------------------------------------
+    async def create_model(
+        self, model_id: str, request_id: str, base_model: str, num_gpus: int,
+        lora_config: Optional[Dict[str, Any]] = None, parallelism: Optional[Dict[str, Any]] = None,
+        rl_config: Optional[Dict[str, Any]] = None, rollout_config: Optional[Dict[str, Any]] = None,
+        debug_train_only: bool = False, checkpoint_path: Optional[str] = None,
+        max_batch_size: int = 4096, max_seq_len: int = 2048,
+        rlve_config: Optional[Dict[str, Any]] = None, wandb_config: Optional[Dict[str, Any]] = None,
+        staleness_k: int = 0, objective: str = "language_modeling",
+        num_labels: Optional[int] = None, head_config: Optional[Dict[str, Any]] = None,
+    ) -> BackendHandle:
+        if objective != "language_modeling":
+            raise BackendError(f"objective {objective!r} unsupported", backend="fake", operation="create_model")
+        h = FakeHandle(model_id=model_id, backend_type="fake", base_model=base_model,
+                       lora_config=lora_config, hf_path=base_model)
+        if checkpoint_path:
+            self._load_into(h, checkpoint_path)
+        self._models[model_id] = h
+        self._trace("create_model", model_id, base_model=base_model, lora_config=lora_config,
+                    checkpoint_path=checkpoint_path)
+        return h
+
+    async def delete_model(self, handle: BackendHandle) -> None:
+        self._models.pop(handle.model_id, None)
+        self._trace("delete_model", handle.model_id)
+
+    # --- training --------------------------------------------------------
+    def _outputs(self, data: List[Any]):
+        outputs, losses = [], []
+        for datum in data:
+            model_input, _ = _datum_parts(datum)
+            lp = logprobs_for(_tokens_of(model_input))
+            losses.append(-sum(lp) / max(len(lp), 1))
+            outputs.append({"logprobs": {"data": lp, "shape": [len(lp)], "dtype": "float32"}})
+        return outputs, (sum(losses) / len(losses) if losses else 0.0)
+
+    async def forward(self, handle: BackendHandle, data: List[Any], loss_fn: str) -> Dict[str, Any]:
+        h = self._handle(handle, "forward")
+        outputs, _ = self._outputs(data)
+        self._trace("forward", h.model_id, n=len(data), loss_fn=loss_fn)
+        return {"type": "forward", "loss_fn_output_type": loss_fn, "loss_fn_outputs": outputs, "metrics": {}}
+
+    async def forward_backward(self, handle: BackendHandle, data: List[Any], loss_fn: str) -> Dict[str, Any]:
+        h = self._handle(handle, "forward_backward")
+        outputs, loss = self._outputs(data)
+        h.pending += 1
+        self._trace("forward_backward", h.model_id, n=len(data), loss_fn=loss_fn)
+        return {
+            "loss_fn_output_type": loss_fn,
+            "loss": loss,
+            "metrics": {"loss:mean": loss},
+            "loss_fn_outputs": outputs,
+            "deferred": False,
+        }
+
+    async def apply_optimizer_step(
+        self, handle: BackendHandle, learning_rate: Optional[float] = None,
+        adam_params: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        h = self._handle(handle, "apply_optimizer_step")
+        lr = learning_rate if learning_rate is not None else 0.0
+        h.step_count += 1
+        h.w += lr * h.pending
+        h.pending = 0
+        h.weight_version += 1
+        self._trace("apply_optimizer_step", h.model_id, learning_rate=lr, adam_params=adam_params)
+        return {
+            "success": True,
+            "grad_norm": float(h.step_count),
+            "learning_rates": [],
+            "model_id": h.model_id,
+            "metrics": {"total_loss": 0.0, "fake_w": h.w},
+            "weight_version": h.weight_version,
+        }
+
+    async def get_logprobs(self, handle: BackendHandle, data: List[Any]) -> List[Any]:
+        self._handle(handle, "get_logprobs")
+        return [logprobs_for(_tokens_of(_datum_parts(d)[0])) for d in data]
+
+    # --- generation ------------------------------------------------------
+    async def update_inference_weights(self, handle: BackendHandle) -> None:
+        self._trace("update_inference_weights", handle.model_id)
+
+    async def prepare_for_generation(self, handle: BackendHandle) -> None:
+        self._handle(handle, "prepare_for_generation")
+
+    async def sample(
+        self, handle: BackendHandle, request_id: str, prompt_tokens: List[int], num_samples: int,
+        sampling_params: Optional[Dict[str, Any]] = None, prompt_logprobs: bool = False,
+        pinned_version: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        h = self._handle(handle, "sample")
+        params = dict(sampling_params or {})
+        max_tokens = int(params.get("max_tokens") or 4)
+        seed = params.get("seed")
+        stop_ids = set(params.get("stop_token_ids") or [])
+        self._trace("sample", h.model_id, prompt_len=len(prompt_tokens), num_samples=num_samples,
+                    sampling_params=params, prompt_logprobs=prompt_logprobs, pinned_version=pinned_version)
+        sequences = []
+        for i in range(num_samples):
+            rng = random.Random((seed if seed is not None else sum(prompt_tokens)) * 1000 + i)
+            toks, stop_reason = [], "length"
+            for _ in range(max_tokens):
+                t = rng.randrange(4, 1000)
+                if t in stop_ids:
+                    stop_reason = "stop"
+                    break
+                toks.append(t)
+            sequences.append({"tokens": toks, "logprobs": logprobs_for(toks),
+                              "text": None, "stop_reason": stop_reason})
+        out: Dict[str, Any] = {
+            "sequences": sequences,
+            "prompt_logprobs": ([None] + logprobs_for(prompt_tokens)[1:]) if prompt_logprobs else None,
+            "weight_version": h.weight_version,
+            "latest_weight_version": h.weight_version,
+        }
+        return out
+
+    # --- checkpoints -----------------------------------------------------
+    async def save_checkpoint(self, handle: BackendHandle, checkpoint_path: str, step_id: Optional[int] = None) -> str:
+        h = self._handle(handle, "save_checkpoint")
+        root = resolve_checkpoint_root(checkpoint_path, create=True)
+        with open(os.path.join(root, STATE_FILE), "w") as f:
+            json.dump({"w": h.w, "weight_version": h.weight_version, "base_model": h.base_model,
+                       "lora_config": h.lora_config, "step_id": step_id}, f)
+        self._trace("save_checkpoint", h.model_id, checkpoint_path=checkpoint_path, root=root, step_id=step_id)
+        return checkpoint_path
+
+    def _load_into(self, h: FakeHandle, checkpoint_path: str) -> None:
+        root = resolve_checkpoint_root(checkpoint_path)
+        path = os.path.join(root, STATE_FILE)
+        if not os.path.exists(path):
+            raise BackendError(f"Checkpoint {checkpoint_path} not found at {path}",
+                               backend="fake", operation="load_checkpoint")
+        with open(path) as f:
+            st = json.load(f)
+        h.w = st["w"]
+        h.weight_version = st["weight_version"]
+
+    async def load_checkpoint(self, handle: BackendHandle, checkpoint_path: str) -> None:
+        h = self._handle(handle, "load_checkpoint")
+        self._load_into(h, checkpoint_path)
+        self._trace("load_checkpoint", h.model_id, checkpoint_path=checkpoint_path)


### PR DESCRIPTION
## What

- `training/backends/fake`: an in-process `TrainingBackend` with no GPU and no Ray. Logprobs, `grad_norm`, samples, and weights are pure functions of the inputs; every call can be traced to a JSONL file via `FAKE_BACKEND_TRACE`. Registered as backend type `fake`.
- `tests/protocol`: launches `python -m training.api --backend fake` on a free port and drives it with the real `tinker` SDK. Covers the baseline train/save/unload loop, the load-from-state weight round trip, API-key enforcement on every mutating route, the error-body shape of the served app, LoRA info from `get_info` / `weights_info` (including the `sampler_weights` URI), and that a failed create leaves no session link.
- `TrainingBackend.needs_ray` (False skips `ray.init` at startup) and `TINKERCLOUD_CHECKPOINT_BASE` to relocate the checkpoint root.

## Verification

`pytest tests/protocol`: 11 passed in ~3 s on a CPU-only machine with only `fastapi`, `uvicorn`, `pydantic`, `httpx`, `requests`, and the `tinker` SDK installed. Existing unit suites unchanged.
