### PR TITLE
Protocol fidelity: loss registry, strict sampler routing, full sampling params, checkpoint endpoints, request ordering, one logprob per target

### DIFF
--- a/tests/protocol/test_checkpoints.py
+++ b/tests/protocol/test_checkpoints.py
@@ -43,7 +43,7 @@ def test_load_weights_first_request_rule(service_client, server):
     p = src.save_state("w").result().path
 
     fresh = service_client.create_lora_training_client(base_model="fake/tiny", rank=2)
-    r = server.post("/api/v1/load_weights", {"model_id": fresh.model_id, "path": p, "optimizer": False, "seq_id": 1})
+    r = server.post("/api/v1/load_weights", {"model_id": fresh.model_id, "path": p, "optimizer": False, "seq_id": 1001})
     assert r.status_code == 200, r.text
     fut = server.post("/api/v1/retrieve_future", {"request_id": r.json()["request_id"]}, timeout=60)
     assert fut.status_code == 200 and fut.json()["path"] == p, fut.text
@@ -51,7 +51,7 @@ def test_load_weights_first_request_rule(service_client, server):
     op = fresh.optim_step(types.AdamParams(learning_rate=0.0)).result()
     assert op.metrics["fake_w"] == 0.5
 
-    r = server.post("/api/v1/load_weights", {"model_id": fresh.model_id, "path": p, "optimizer": False, "seq_id": 3})
+    r = server.post("/api/v1/load_weights", {"model_id": fresh.model_id, "path": p, "optimizer": False, "seq_id": 1003})
     assert r.status_code == 400 and "not permitted" in r.json()["error"], r.text
 
     trained = service_client.create_lora_training_client(base_model="fake/tiny", rank=2)

--- a/tests/protocol/test_checkpoints.py
+++ b/tests/protocol/test_checkpoints.py
@@ -1,0 +1,64 @@
+"""Checkpoint listing, typed delete, and load_weights as a first request only."""
+import requests
+from tinker import types
+
+from .conftest import API_KEY, make_datum
+
+
+def _delete(server, model_id, checkpoint_id, **q):
+    return requests.delete(f"{server.base_url}/api/v1/training_runs/{model_id}/checkpoints/{checkpoint_id}",
+                           headers={"X-API-Key": API_KEY}, params=q or None, timeout=30)
+
+
+def test_list_and_delete(service_client, server):
+    tc = service_client.create_lora_training_client(base_model="fake/tiny", rank=2)
+    p = tc.save_state("c1").result().path
+    sp = tc.save_weights_for_sampler("c1").result().path  # same id, other kind
+    rest = service_client.create_rest_client()
+    listed = rest.list_checkpoints(tc.model_id).result().checkpoints
+    assert {(c.checkpoint_id, c.checkpoint_type, c.tinker_path) for c in listed} == {
+        ("weights/c1", "training", p), ("sampler_weights/c1", "sampler", sp)}
+    assert all(c.size_bytes and c.size_bytes > 0 for c in listed)
+
+    # bare id is ambiguous -> 400; the SDK's own delete sends the typed form
+    assert _delete(server, tc.model_id, "c1").status_code == 400
+    rest.delete_checkpoint_from_tinker_path(sp).result()
+    remaining = rest.list_checkpoints(tc.model_id).result().checkpoints
+    assert [c.checkpoint_id for c in remaining] == ["weights/c1"]
+    assert server.post("/api/v1/weights_info", {"tinker_path": sp}).status_code == 404
+    assert server.post("/api/v1/weights_info", {"tinker_path": p}).status_code == 200
+    # bytes are gone for the deleted kind only
+    assert not (server.checkpoint_base / tc.model_id / "sampler_weights" / "c1").exists()
+    assert (server.checkpoint_base / tc.model_id / "c1").exists()
+
+    assert _delete(server, tc.model_id, "c1", checkpoint_type="training").status_code == 204
+    assert rest.list_checkpoints(tc.model_id).result().checkpoints == []
+    assert _delete(server, tc.model_id, "weights/c1").status_code == 404
+
+
+def test_load_weights_first_request_rule(service_client, server):
+    src = service_client.create_lora_training_client(base_model="fake/tiny", rank=2)
+    src.forward_backward([make_datum([1, 2, 3])], "cross_entropy")
+    src.optim_step(types.AdamParams(learning_rate=0.5)).result()
+    p = src.save_state("w").result().path
+
+    fresh = service_client.create_lora_training_client(base_model="fake/tiny", rank=2)
+    r = server.post("/api/v1/load_weights", {"model_id": fresh.model_id, "path": p, "optimizer": False, "seq_id": 1})
+    assert r.status_code == 200, r.text
+    fut = server.post("/api/v1/retrieve_future", {"request_id": r.json()["request_id"]}, timeout=60)
+    assert fut.status_code == 200 and fut.json()["path"] == p, fut.text
+    # the loaded weights carry: w was 0.5 after src's step
+    op = fresh.optim_step(types.AdamParams(learning_rate=0.0)).result()
+    assert op.metrics["fake_w"] == 0.5
+
+    r = server.post("/api/v1/load_weights", {"model_id": fresh.model_id, "path": p, "optimizer": False, "seq_id": 3})
+    assert r.status_code == 400 and "not permitted" in r.json()["error"], r.text
+
+    trained = service_client.create_lora_training_client(base_model="fake/tiny", rank=2)
+    trained.forward_backward([make_datum([1, 2, 3])], "cross_entropy").result()
+    r = server.post("/api/v1/load_weights", {"model_id": trained.model_id, "path": p, "optimizer": False})
+    assert r.status_code == 400
+    r = server.post("/api/v1/load_weights", {"model_id": fresh.model_id, "path": "tinker://nope/weights/x", "optimizer": False})
+    assert r.status_code in (400, 404)
+    r = server.post("/api/v1/load_weights", {"model_id": "model_missing", "path": p, "optimizer": False})
+    assert r.status_code == 404

--- a/tests/protocol/test_loss_fns.py
+++ b/tests/protocol/test_loss_fns.py
@@ -1,0 +1,59 @@
+"""loss_fn names are whitelisted and loss_fn_config is validated per name and delivered to the backend."""
+import pytest
+from tinker import types
+
+from .conftest import make_datum
+
+
+def _fb_body(model_id, loss_fn, cfg=None):
+    tokens = list(range(3, 9))
+    datum = {
+        "model_input": {"chunks": [{"type": "encoded_text", "tokens": tokens[:-1]}]},
+        "loss_fn_inputs": {
+            "weights": {"data": [1.0] * 5, "dtype": "float32", "shape": [5]},
+            "target_tokens": {"data": tokens[1:], "dtype": "int64", "shape": [5]},
+        },
+    }
+    inp = {"data": [datum], "loss_fn": loss_fn}
+    if cfg is not None:
+        inp["loss_fn_config"] = cfg
+    return {"model_id": model_id, "forward_backward_input": inp}
+
+
+@pytest.fixture(scope="module")
+def model(service_client):
+    return service_client.create_lora_training_client(base_model="fake/tiny", rank=4)
+
+
+@pytest.mark.parametrize("loss_fn,cfg,detail", [
+    ("ppo_loss", None, "Unknown loss_fn"),
+    ("cross_entropy", {"beta": 0.1}, "not valid for"),
+    ("ppo", {"beta": 0.1}, "not valid for"),
+    ("cispo", {"clip_low_threshold": 1.5}, "clip thresholds"),
+])
+def test_invalid_loss_requests_are_400(server, model, loss_fn, cfg, detail):
+    r = server.post("/api/v1/forward_backward", _fb_body(model.model_id, loss_fn, cfg))
+    assert r.status_code == 400, (r.status_code, r.text)
+    assert detail in r.json()["error"]
+    r = server.post("/api/v1/forward", {"model_id": model.model_id,
+                                        "forward_input": {**_fb_body(model.model_id, loss_fn, cfg)["forward_backward_input"]}})
+    assert r.status_code == 400, (r.status_code, r.text)
+
+
+@pytest.mark.parametrize("loss_fn,cfg", [
+    ("cross_entropy", None),
+    ("importance_sampling", None),
+    ("ppo", {"clip_low_threshold": 0.9, "clip_high_threshold": 1.1}),
+    ("cispo", {"clip_low_threshold": 0.8, "clip_high_threshold": 1.2}),
+    ("dro", {"beta": 0.05}),
+])
+def test_supported_losses_reach_backend_with_config(service_client, server, model, loss_fn, cfg):
+    tokens = list(range(20, 27))
+    fb = model.forward_backward([make_datum(tokens)], loss_fn, loss_fn_config=cfg).result()
+    model.optim_step(types.AdamParams(learning_rate=0.0)).result()
+    assert fb.loss_fn_outputs[0]["logprobs"].data == [-(t % 7) / 7.0 for t in tokens[:-1]]
+    for k, v in (cfg or {}).items():
+        assert fb.metrics[f"{k}:mean"] == v, fb.metrics  # fb metrics carry a ":<reduction>" suffix
+    seen = [t for t in server.trace() if t["op"] == "forward_backward" and t["model_id"] == model.model_id]
+    assert seen[-1]["loss_fn"] == loss_fn
+    assert (seen[-1]["loss_fn_config"] or None) == cfg

--- a/tests/protocol/test_ordering.py
+++ b/tests/protocol/test_ordering.py
@@ -1,0 +1,76 @@
+"""seq_id idempotency and per-model program order over the HTTP protocol."""
+import concurrent.futures
+
+from tinker import types
+
+from .conftest import make_datum
+
+
+def _fb(server, model_id, seq_id, tokens):
+    return server.post("/api/v1/forward_backward", {
+        "model_id": model_id, "seq_id": seq_id,
+        "forward_backward_input": {"data": [{
+            "model_input": {"tokens": tokens[:-1]},
+            "loss_fn_inputs": {"weights": {"data": [1.0] * (len(tokens) - 1), "dtype": "float32", "shape": [len(tokens) - 1]},
+                               "target_tokens": {"data": tokens[1:], "dtype": "int64", "shape": [len(tokens) - 1]}}}],
+            "loss_fn": "cross_entropy"}})
+
+
+def _optim(server, model_id, seq_id, lr=1.0):
+    return server.post("/api/v1/optim_step", {"model_id": model_id, "seq_id": seq_id, "adam_params": {"learning_rate": lr}})
+
+
+def _wait(server, rid):
+    r = server.post("/api/v1/retrieve_future", {"request_id": rid}, timeout=60)
+    assert r.status_code == 200, r.text
+    return r.json()
+
+
+def test_retry_with_same_seq_id_is_idempotent(service_client, server):
+    tc = service_client.create_lora_training_client(base_model="fake/tiny", rank=2)
+    # raw seq_ids live above the SDK client's own counter (which starts at 1)
+    r1 = _fb(server, tc.model_id, 1001, [1, 2, 3, 4]); r2 = _fb(server, tc.model_id, 1001, [1, 2, 3, 4])
+    assert r1.status_code == 200 and r2.status_code == 200
+    assert r1.json()["request_id"] == r2.json()["request_id"]
+    _wait(server, r1.json()["request_id"])
+    fbs = [t for t in server.trace() if t["op"] == "forward_backward" and t["model_id"] == tc.model_id]
+    assert len(fbs) == 1  # the retry ran nothing
+    # a reused seq_id with a different payload / operation is a client error (400: the SDK would retry a 409)
+    r = _fb(server, tc.model_id, 1001, [9, 9, 9, 9])
+    assert r.status_code == 400 and "sequence number 1001 was reused" in r.json()["error"], r.text
+    assert _optim(server, tc.model_id, 1001).status_code == 400
+    # the SDK's own retries reuse seq_id transparently
+    op = tc.optim_step(types.AdamParams(learning_rate=0.5)).result()
+    assert op.metrics["fake_w"] == 0.5  # exactly one pending microbatch was applied
+
+
+def test_program_order_is_kept_under_concurrent_submission(service_client, server):
+    tc = service_client.create_lora_training_client(base_model="fake/tiny", rank=2)
+    m = tc.model_id
+    # fire fb(1) optim(2) fb(3) optim(4) fb(5) save(6) without waiting for any result
+    calls = [lambda: _fb(server, m, 1, [1, 2, 3]), lambda: _optim(server, m, 2, 1.0),
+             lambda: _fb(server, m, 3, [4, 5, 6]), lambda: _fb(server, m, 4, [7, 8, 9]), lambda: _optim(server, m, 5, 1.0),
+             lambda: server.post("/api/v1/save_weights", {"model_id": m, "path": "ord", "seq_id": 6})]
+    rids = [c().json()["request_id"] for c in calls]
+    results = [_wait(server, rid) for rid in rids]
+    # each optimizer step saw exactly the microbatches submitted before it: w = 1*1, then 1*1 + 1*2
+    assert results[1]["metrics"]["fake_w"] == 1.0
+    assert results[4]["metrics"]["fake_w"] == 3.0
+    ops = [t["op"] for t in server.trace() if t["model_id"] == m and t["op"] != "create_model"]
+    assert ops == ["forward_backward", "apply_optimizer_step", "forward_backward", "forward_backward",
+                   "apply_optimizer_step", "save_checkpoint"]
+
+
+def test_parallel_clients_do_not_interleave_each_others_steps(service_client, server):
+    a = service_client.create_lora_training_client(base_model="fake/tiny", rank=2)
+    b = service_client.create_lora_training_client(base_model="fake/tiny", rank=2)
+
+    def loop(tc, lr):
+        for i in range(3):
+            tc.forward_backward([make_datum([1, 2, 3, 4])], "cross_entropy")
+            tc.optim_step(types.AdamParams(learning_rate=lr)).result()
+        return tc.optim_step(types.AdamParams(learning_rate=0.0)).result().metrics["fake_w"]
+
+    with concurrent.futures.ThreadPoolExecutor(2) as ex:
+        wa, wb = ex.map(lambda args: loop(*args), [(a, 1.0), (b, 10.0)])
+    assert wa == 3.0 and wb == 30.0

--- a/tests/protocol/test_sampler_routing.py
+++ b/tests/protocol/test_sampler_routing.py
@@ -1,0 +1,77 @@
+"""A sampling request resolves to exactly the model its sampler was minted from; there is no fallback."""
+import pytest
+from tinker import types
+
+from .conftest import make_datum
+
+
+def _sample_ops(server, model_id):
+    return [t for t in server.trace() if t["op"] == "sample" and t["model_id"] == model_id]
+
+
+def test_sampler_routes_to_its_own_model(service_client, server):
+    a = service_client.create_lora_training_client(base_model="fake/tiny", rank=4)
+    b = service_client.create_lora_training_client(base_model="fake/tiny", rank=4)
+    sa = a.save_weights_and_get_sampling_client("sa")
+    sb = b.save_weights_and_get_sampling_client("sb")
+    params = types.SamplingParams(max_tokens=3, temperature=1.0)
+    prompt = types.ModelInput.from_ints([1, 2, 3])
+    ra = sa.sample(prompt=prompt, num_samples=2, sampling_params=params).result()
+    rb = sb.sample(prompt=prompt, num_samples=1, sampling_params=params).result()
+    assert len(ra.sequences) == 2 and len(rb.sequences) == 1
+    assert [t["num_samples"] for t in _sample_ops(server, a.model_id)] == [2]
+    assert [t["num_samples"] for t in _sample_ops(server, b.model_id)] == [1]
+
+
+def test_model_path_names_the_model(service_client, server):
+    a = service_client.create_lora_training_client(base_model="fake/tiny", rank=4)
+    b = service_client.create_lora_training_client(base_model="fake/tiny", rank=4)
+    path = b.save_weights_for_sampler("byname").result().path
+    sc = service_client.create_sampling_client(model_path=path)  # create_sampling_session bound to b
+    sc.sample(prompt=types.ModelInput.from_ints([4, 5]), num_samples=1,
+              sampling_params=types.SamplingParams(max_tokens=2)).result()
+    assert len(_sample_ops(server, b.model_id)) == 1
+    assert _sample_ops(server, a.model_id) == []
+
+
+def test_pinned_version_travels_with_the_sampler(service_client, server):
+    a = service_client.create_lora_training_client(base_model="fake/tiny", rank=4)
+    a.forward_backward([make_datum([1, 2, 3, 4])], "cross_entropy")
+    a.optim_step(types.AdamParams(learning_rate=0.1)).result()
+    s1 = a.save_weights_and_get_sampling_client("v1")  # weight_version 1
+    a.forward_backward([make_datum([1, 2, 3, 4])], "cross_entropy")
+    a.optim_step(types.AdamParams(learning_rate=0.1)).result()
+    s1.sample(prompt=types.ModelInput.from_ints([9]), num_samples=1,
+              sampling_params=types.SamplingParams(max_tokens=1)).result()
+    assert _sample_ops(server, a.model_id)[-1]["pinned_version"] == 1
+
+
+def test_base_model_only_is_rejected(service_client, server):
+    with pytest.raises(Exception) as ei:
+        service_client.create_sampling_client(base_model="fake/tiny")
+    assert "base-model sampling is not supported" in str(ei.value)
+    r = server.post("/api/v1/asample", {"prompt": {"tokens": [1]}, "num_samples": 1, "base_model": "fake/tiny"})
+    assert r.status_code == 400 and "base-model sampling" in r.json()["error"]
+    r = server.post("/api/v1/sample", {"prompts": [[1]], "num_samples": 1, "base_model": "fake/tiny"})
+    assert r.status_code == 400
+
+
+def test_unknown_sampler_and_model_are_404(service_client, server):
+    r = server.post("/api/v1/asample", {"prompt": {"tokens": [1]}, "num_samples": 1, "sampling_session_id": "nope"})
+    assert r.status_code == 404
+    r = server.post("/api/v1/asample", {"prompt": {"tokens": [1]}, "num_samples": 1, "model_path": "tinker://model_gone/weights/x"})
+    assert r.status_code == 404
+    r = server.post("/api/v1/create_sampling_client", {"model_path": "tinker://model_gone/weights/x"})
+    assert r.status_code == 404
+    r = server.post("/api/v1/asample", {"prompt": {"tokens": [1]}, "num_samples": 1})
+    assert r.status_code == 400
+
+
+def test_sampler_of_unloaded_model_is_404(service_client, server):
+    a = service_client.create_lora_training_client(base_model="fake/tiny", rank=4)
+    sa = a.save_weights_and_get_sampling_client("gone")
+    rid = server.post("/api/v1/unload_model", {"model_id": a.model_id}).json()["request_id"]
+    assert server.post("/api/v1/retrieve_future", {"request_id": rid}, timeout=60).status_code == 200
+    r = server.post("/api/v1/asample", {"prompt": {"tokens": [1]}, "num_samples": 1,
+                                        "sampling_session_id": sa._sampling_session_id})
+    assert r.status_code == 404

--- a/tests/protocol/test_sampling_params.py
+++ b/tests/protocol/test_sampling_params.py
@@ -27,7 +27,8 @@ def test_seed_reproduces_and_samples_differ(service_client, server):
     a = sc.sample(prompt=prompt, num_samples=3, sampling_params=types.SamplingParams(max_tokens=6, seed=7)).result()
     b = sc.sample(prompt=prompt, num_samples=3, sampling_params=types.SamplingParams(max_tokens=6, seed=7)).result()
     c = sc.sample(prompt=prompt, num_samples=3, sampling_params=types.SamplingParams(max_tokens=6, seed=8)).result()
-    toks = lambda r: [s.tokens for s in r.sequences]
+    def toks(r):
+        return [s.tokens for s in r.sequences]
     assert toks(a) == toks(b)
     assert toks(a) != toks(c)
     assert len({tuple(t) for t in toks(a)}) == 3  # the samples of one request are distinct

--- a/tests/protocol/test_sampling_params.py
+++ b/tests/protocol/test_sampling_params.py
@@ -1,0 +1,46 @@
+"""Every SamplingParams field reaches the backend for every sample; seeds reproduce."""
+from tinker import types
+
+
+def _last_sample(server, model_id):
+    return [t for t in server.trace() if t["op"] == "sample" and t["model_id"] == model_id][-1]
+
+
+def test_all_params_reach_backend(service_client, server):
+    tc = service_client.create_lora_training_client(base_model="fake/tiny", rank=2)
+    sc = tc.save_weights_and_get_sampling_client("p")
+    params = types.SamplingParams(max_tokens=5, temperature=0.3, top_p=0.8, top_k=7, seed=42, stop=["END", "\n"])
+    sc.sample(prompt=types.ModelInput.from_ints([1, 2]), num_samples=2, sampling_params=params).result()
+    seen = _last_sample(server, tc.model_id)["sampling_params"]
+    assert seen["max_tokens"] == 5 and seen["temperature"] == 0.3 and seen["top_p"] == 0.8
+    assert seen["top_k"] == 7 and seen["seed"] == 42 and seen["stop"] == ["END", "\n"]
+    # integer stop entries travel as stop_token_ids
+    params = types.SamplingParams(max_tokens=5, stop=[9, 10])
+    sc.sample(prompt=types.ModelInput.from_ints([1, 2]), num_samples=1, sampling_params=params).result()
+    assert _last_sample(server, tc.model_id)["sampling_params"]["stop_token_ids"] == [9, 10]
+
+
+def test_seed_reproduces_and_samples_differ(service_client, server):
+    tc = service_client.create_lora_training_client(base_model="fake/tiny", rank=2)
+    sc = tc.save_weights_and_get_sampling_client("s")
+    prompt = types.ModelInput.from_ints([3, 4, 5])
+    a = sc.sample(prompt=prompt, num_samples=3, sampling_params=types.SamplingParams(max_tokens=6, seed=7)).result()
+    b = sc.sample(prompt=prompt, num_samples=3, sampling_params=types.SamplingParams(max_tokens=6, seed=7)).result()
+    c = sc.sample(prompt=prompt, num_samples=3, sampling_params=types.SamplingParams(max_tokens=6, seed=8)).result()
+    toks = lambda r: [s.tokens for s in r.sequences]
+    assert toks(a) == toks(b)
+    assert toks(a) != toks(c)
+    assert len({tuple(t) for t in toks(a)}) == 3  # the samples of one request are distinct
+    assert all(len(s.tokens) == 6 and s.stop_reason == "length" for s in a.sequences)
+
+
+def test_stop_token_ends_generation(service_client, server):
+    tc = service_client.create_lora_training_client(base_model="fake/tiny", rank=2)
+    sc = tc.save_weights_and_get_sampling_client("t")
+    prompt = types.ModelInput.from_ints([3])
+    free = sc.sample(prompt=prompt, num_samples=1, sampling_params=types.SamplingParams(max_tokens=8, seed=1)).result()
+    stop_id = free.sequences[0].tokens[2]
+    stopped = sc.sample(prompt=prompt, num_samples=1,
+                        sampling_params=types.SamplingParams(max_tokens=8, seed=1, stop=[stop_id])).result()
+    assert stopped.sequences[0].tokens == free.sequences[0].tokens[:2]
+    assert stopped.sequences[0].stop_reason == "stop"

--- a/tests/test_loss_registry.py
+++ b/tests/test_loss_registry.py
@@ -1,0 +1,77 @@
+"""core.loss_registry validation and the service-level backend support check."""
+import asyncio
+
+import pytest
+
+from tinkercloud.training.core import loss_registry
+from tinkercloud.training.backends.base import BackendHandle, TrainingBackend, UnsupportedFeatureError
+from tinkercloud.training.services.training_service import TrainingService
+
+
+@pytest.mark.parametrize("name", sorted(loss_registry.LOSS_FNS))
+def test_every_name_accepts_empty_config(name):
+    loss_registry.validate(name, None)
+    loss_registry.validate(name, {})
+
+
+def test_unknown_name_rejected():
+    with pytest.raises(ValueError, match="Unknown loss_fn"):
+        loss_registry.validate("ppo_loss", None)
+
+
+@pytest.mark.parametrize("name,cfg", [
+    ("cross_entropy", {"beta": 1.0}),
+    ("importance_sampling", {"clip_low_threshold": 0.9}),
+    ("ppo", {"beta": 0.1}),
+    ("dro", {"clip_low_threshold": 0.9}),
+])
+def test_disallowed_key_rejected(name, cfg):
+    with pytest.raises(ValueError, match="not valid for"):
+        loss_registry.validate(name, cfg)
+
+
+def test_clip_thresholds_bracket_one():
+    loss_registry.validate("ppo", {"clip_low_threshold": 0.8, "clip_high_threshold": 1.2})
+    with pytest.raises(ValueError, match="clip thresholds"):
+        loss_registry.validate("cispo", {"clip_low_threshold": 1.1})
+    with pytest.raises(ValueError, match="must be a number"):
+        loss_registry.validate("ppo", {"clip_low_threshold": "0.8"})
+
+
+def test_clip_thresholds_defaults():
+    assert loss_registry.clip_thresholds(None) == (0.8, 1.2)
+    assert loss_registry.clip_thresholds({"clip_high_threshold": 1.3}) == (0.8, 1.3)
+
+
+class _Stub(TrainingBackend):
+    SUPPORTED_LOSS_FNS = frozenset({"cross_entropy"})
+
+    def __init__(self):
+        self.calls = []
+
+    async def create_model(self, *a, **k): ...
+    async def forward(self, handle, data, loss_fn, loss_fn_config=None):
+        self.calls.append(("forward", loss_fn, loss_fn_config)); return {"loss_fn_outputs": [], "metrics": {}}
+    async def forward_backward(self, handle, data, loss_fn, loss_fn_config=None):
+        self.calls.append(("fb", loss_fn, loss_fn_config)); return {"loss_fn_outputs": [], "metrics": {}}
+    async def apply_optimizer_step(self, handle, learning_rate=None, adam_params=None): ...
+    async def update_inference_weights(self, handle): ...
+    async def save_checkpoint(self, handle, checkpoint_path, step_id=None): ...
+    async def load_checkpoint(self, handle, checkpoint_path): ...
+    async def delete_model(self, handle): ...
+    async def get_logprobs(self, handle, data): ...
+    async def sample(self, handle, request_id, prompt_tokens, num_samples, sampling_params=None,
+                     prompt_logprobs=False, pinned_version=None): ...
+    async def prepare_for_generation(self, handle): ...
+
+
+def test_service_rejects_unsupported_loss_before_backend_call():
+    stub = _Stub()
+    svc = TrainingService(backend=stub)
+    ci = {"backend_handle": BackendHandle(model_id="m", backend_type="stub")}
+    with pytest.raises(UnsupportedFeatureError, match="ppo"):
+        asyncio.run(svc.forward_backward("m", [], "ppo", ci, loss_fn_config={"clip_low_threshold": 0.9}))
+    assert stub.calls == []
+    asyncio.run(svc.forward_backward("m", [], "cross_entropy", ci))
+    asyncio.run(svc.forward("m", [], "cross_entropy", ci, loss_fn_config=None))
+    assert stub.calls == [("fb", "cross_entropy", None), ("forward", "cross_entropy", None)]

--- a/tests/test_miles_rl_layout.py
+++ b/tests/test_miles_rl_layout.py
@@ -1,0 +1,40 @@
+"""Miles RL datum layout: the response is exactly the T wire targets, tensors untouched."""
+import importlib.util
+
+import pytest
+
+if importlib.util.find_spec("torch") is None:
+    pytest.skip("torch not installed", allow_module_level=True)
+
+from tinkercloud.training.core.data_converter import TinkerDataConverter
+
+
+def _datum(T=6, with_target=True):
+    tokens = list(range(10, 10 + T))
+    target = [t + 1 for t in tokens]
+    inputs = {
+        "weights": {"data": [0.0, 0.0] + [1.0] * (T - 2), "dtype": "float32", "shape": [T]},
+        "logprobs": {"data": [-0.1 * (k + 1) for k in range(T)], "dtype": "float32", "shape": [T]},
+        "advantages": {"data": [float(k) for k in range(T)], "dtype": "float32", "shape": [T]},
+    }
+    if with_target:
+        inputs["target_tokens"] = {"data": target, "dtype": "int64", "shape": [T]}
+    return {"model_input": {"tokens": tokens}, "loss_fn_inputs": inputs}, tokens, target
+
+
+def test_rl_datum_appends_final_target_and_keeps_tensors_aligned():
+    d, tokens, target = _datum()
+    rd = TinkerDataConverter().forward_backward_to_rollout([d], is_rl=True)
+    assert rd["tokens"][0].tolist() == tokens + [target[-1]]
+    assert rd["response_lengths"] == [len(tokens)]
+    assert rd["advantages"][0].tolist() == [float(k) for k in range(len(tokens))]
+    assert rd["log_probs"][0].tolist() == pytest.approx([-0.1 * (k + 1) for k in range(len(tokens))])
+    assert rd["loss_masks"][0].tolist() == [0.0, 0.0] + [1.0] * (len(tokens) - 2)
+
+
+def test_rl_datum_without_target_drops_the_last_entry():
+    d, tokens, _ = _datum(with_target=False)
+    rd = TinkerDataConverter().forward_backward_to_rollout([d], is_rl=True)
+    assert rd["tokens"][0].tolist() == tokens
+    assert rd["response_lengths"] == [len(tokens) - 1]
+    assert rd["advantages"][0].tolist() == [float(k) for k in range(len(tokens) - 1)]  # drop-last, not drop-first

--- a/tests/test_ordering.py
+++ b/tests/test_ordering.py
@@ -1,0 +1,77 @@
+"""services.ordering: passes overlap, barriers wait, program order is kept per model."""
+import asyncio
+
+import pytest
+
+from tinkercloud.training.services.ordering import BARRIER, PASS, ModelQueues
+
+
+def _op(log, name, gate=None, delay=0.0):
+    async def run():
+        log.append(f"start {name}")
+        if gate is not None:
+            await gate.wait()
+        if delay:
+            await asyncio.sleep(delay)
+        log.append(f"end {name}")
+        return name
+    return run
+
+
+def test_barrier_waits_for_earlier_passes_to_complete():
+    async def main():
+        q = ModelQueues(); log = []; gate = asyncio.Event()
+        t1 = asyncio.create_task(q.run("m", PASS, _op(log, "fb1", gate)))
+        await asyncio.sleep(0.01)
+        t2 = asyncio.create_task(q.run("m", BARRIER, _op(log, "optim")))
+        await asyncio.sleep(0.01)
+        assert log == ["start fb1"]  # optim has not started: fb1 still in flight
+        gate.set()
+        await asyncio.gather(t1, t2)
+        assert log == ["start fb1", "end fb1", "start optim", "end optim"]
+    asyncio.run(main())
+
+
+def test_pass_after_barrier_starts_only_after_barrier_started():
+    async def main():
+        q = ModelQueues(); log = []; gate_fb1 = asyncio.Event(); gate_optim = asyncio.Event()
+        t1 = asyncio.create_task(q.run("m", PASS, _op(log, "fb1", gate_fb1)))
+        await asyncio.sleep(0.01)
+        t2 = asyncio.create_task(q.run("m", BARRIER, _op(log, "optim", gate_optim)))
+        await asyncio.sleep(0.01)
+        t3 = asyncio.create_task(q.run("m", PASS, _op(log, "fb2")))
+        await asyncio.sleep(0.01)
+        assert log == ["start fb1"]  # fb2 held behind the not-yet-started barrier
+        gate_fb1.set(); await asyncio.sleep(0.01)
+        # optim started; fb2 may now run and overlap with it
+        assert log[:3] == ["start fb1", "end fb1", "start optim"] and "end optim" not in log
+        assert "start fb2" in log
+        gate_optim.set()
+        await asyncio.gather(t1, t2, t3)
+        assert log.index("start fb2") > log.index("start optim")
+    asyncio.run(main())
+
+
+def test_passes_overlap_and_models_are_independent():
+    async def main():
+        q = ModelQueues(); log = []; gate = asyncio.Event()
+        a = asyncio.create_task(q.run("m", PASS, _op(log, "a", gate)))
+        b = asyncio.create_task(q.run("m", PASS, _op(log, "b", gate)))
+        other = asyncio.create_task(q.run("other", BARRIER, _op(log, "other-optim")))
+        await asyncio.sleep(0.01)
+        assert {"start a", "start b", "start other-optim", "end other-optim"} <= set(log)
+        gate.set()
+        await asyncio.gather(a, b, other)
+        assert q.inflight_count("m") == 0
+    asyncio.run(main())
+
+
+def test_failed_op_does_not_block_the_queue():
+    async def main():
+        q = ModelQueues(); log = []
+        async def boom():
+            raise RuntimeError("x")
+        with pytest.raises(RuntimeError):
+            await q.run("m", PASS, boom)
+        assert await q.run("m", BARRIER, _op(log, "after")) == "after"
+    asyncio.run(main())

--- a/training/api.py
+++ b/training/api.py
@@ -26,6 +26,7 @@ from fastapi.responses import JSONResponse
 
 # Import modules
 from .storage import FuturesStorage, MetadataStorage, SessionStorage
+from .storage.futures import DuplicateSeqId
 from .config import get_config, TrainingConfig, StorageConfig, BackendConfig
 from .core import SlimeArgumentBuilder
 from .utils import APIKeyAuth
@@ -241,6 +242,15 @@ def create_app(config: Optional[TrainingConfig] = None) -> FastAPI:
             await _free_model(application, model_id, reason="shutdown")
         if ray.is_initialized():
             ray.shutdown()
+
+    @application.exception_handler(DuplicateSeqId)
+    async def duplicate_seq_id_handler(request: Request, exc: DuplicateSeqId):
+        """A reused (model_id, seq_id) with a different request is a client bug.
+
+        400 rather than 409: the SDK retries 408/409/429/5xx for hours, and a
+        conflict can never succeed on retry."""
+        return JSONResponse(status_code=400, content={"error": str(exc), "status_code": 400,
+                                                      "path": str(request.url.path)})
 
     @application.exception_handler(HTTPException)
     async def http_exception_handler(request: Request, exc: HTTPException):

--- a/training/backends/automodel/backend.py
+++ b/training/backends/automodel/backend.py
@@ -46,6 +46,7 @@ class AutomodelHandle(BackendHandle):
 
 
 class AutomodelBackend(TrainingBackend):
+    SUPPORTED_LOSS_FNS = frozenset({"cross_entropy", "classification_ce"})
     """HF-encoder classification backend (no generation plane)."""
 
     def __init__(self, overrides: Optional[Dict[str, Any]] = None):
@@ -192,6 +193,7 @@ class AutomodelBackend(TrainingBackend):
 
     async def forward(
         self, handle: BackendHandle, data: List[Dict], loss_fn: str,
+        loss_fn_config: Optional[Dict[str, float]] = None,
     ) -> Dict[str, Any]:
         """Forward-only logits pass (no gradient)."""
         import asyncio
@@ -215,6 +217,7 @@ class AutomodelBackend(TrainingBackend):
 
     async def forward_backward(
         self, handle: BackendHandle, data: List[Dict], loss_fn: str,
+        loss_fn_config: Optional[Dict[str, float]] = None,
     ) -> Dict[str, Any]:
         """Convert a classification Datum, run forward + loss.backward()
         immediately, and return the real loss (deferred=False)."""

--- a/training/backends/base.py
+++ b/training/backends/base.py
@@ -7,7 +7,7 @@ must satisfy.
 """
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, FrozenSet, List, Optional
 
 
 class BackendError(Exception):
@@ -47,6 +47,9 @@ class TrainingBackend(ABC):
 
     # False for in-process backends (no Ray actors); the server then skips ray.init.
     needs_ray: bool = True
+    # Loss names (core.loss_registry) this backend can train; TrainingService
+    # rejects others with UnsupportedFeatureError before any GPU work.
+    SUPPORTED_LOSS_FNS: FrozenSet[str] = frozenset()
 
     @abstractmethod
     async def create_model(
@@ -93,6 +96,7 @@ class TrainingBackend(ABC):
         handle: BackendHandle,
         data: List[Dict],
         loss_fn: str,
+        loss_fn_config: Optional[Dict[str, float]] = None,
     ) -> Dict[str, Any]:
         """
         Forward-only pass (no gradient computation).
@@ -108,9 +112,14 @@ class TrainingBackend(ABC):
         handle: BackendHandle,
         data: List[Dict],
         loss_fn: str,
+        loss_fn_config: Optional[Dict[str, float]] = None,
     ) -> Dict[str, Any]:
         """
         Accumulate gradients for the given data.
+
+        `loss_fn_config` carries the per-call hyperparameters validated by
+        core.loss_registry (e.g. PPO clip thresholds); a backend that cannot
+        honour a given value must raise UnsupportedFeatureError, never ignore it.
 
         Multiple forward_backward calls accumulate gradients before
         a single apply_optimizer_step call.

--- a/training/backends/fake/backend.py
+++ b/training/backends/fake/backend.py
@@ -24,6 +24,7 @@ from typing import Any, Dict, List, Optional
 
 from ..base import BackendError, BackendHandle, TrainingBackend
 from ..checkpoint_interchange import resolve_checkpoint_root
+from ...core.loss_registry import LOSS_FNS
 
 logger = logging.getLogger(__name__)
 
@@ -39,7 +40,6 @@ class FakeHandle(BackendHandle):
     weight_version: int = 0
     step_count: int = 0
     pending: int = 0
-    has_rollout: bool = True  # discoverable as a sampling target
     metrics: Dict[str, Any] = field(default_factory=dict)
 
 
@@ -69,6 +69,7 @@ def logprobs_for(tokens: List[int]) -> List[float]:
 
 class FakeBackend(TrainingBackend):
     needs_ray = False
+    SUPPORTED_LOSS_FNS = frozenset(LOSS_FNS)
 
     def __init__(self, overrides: Optional[Dict[str, Any]] = None):
         self.overrides = overrides or {}
@@ -124,21 +125,26 @@ class FakeBackend(TrainingBackend):
             outputs.append({"logprobs": {"data": lp, "shape": [len(lp)], "dtype": "float32"}})
         return outputs, (sum(losses) / len(losses) if losses else 0.0)
 
-    async def forward(self, handle: BackendHandle, data: List[Any], loss_fn: str) -> Dict[str, Any]:
+    async def forward(self, handle: BackendHandle, data: List[Any], loss_fn: str,
+                      loss_fn_config: Optional[Dict[str, float]] = None) -> Dict[str, Any]:
         h = self._handle(handle, "forward")
         outputs, _ = self._outputs(data)
-        self._trace("forward", h.model_id, n=len(data), loss_fn=loss_fn)
+        self._trace("forward", h.model_id, n=len(data), loss_fn=loss_fn, loss_fn_config=loss_fn_config)
         return {"type": "forward", "loss_fn_output_type": loss_fn, "loss_fn_outputs": outputs, "metrics": {}}
 
-    async def forward_backward(self, handle: BackendHandle, data: List[Any], loss_fn: str) -> Dict[str, Any]:
+    async def forward_backward(self, handle: BackendHandle, data: List[Any], loss_fn: str,
+                               loss_fn_config: Optional[Dict[str, float]] = None) -> Dict[str, Any]:
         h = self._handle(handle, "forward_backward")
         outputs, loss = self._outputs(data)
         h.pending += 1
-        self._trace("forward_backward", h.model_id, n=len(data), loss_fn=loss_fn)
+        self._trace("forward_backward", h.model_id, n=len(data), loss_fn=loss_fn, loss_fn_config=loss_fn_config)
+        metrics = {"loss:mean": loss}
+        for k, v in (loss_fn_config or {}).items():
+            metrics[f"{k}:mean"] = float(v)
         return {
             "loss_fn_output_type": loss_fn,
             "loss": loss,
-            "metrics": {"loss:mean": loss},
+            "metrics": metrics,
             "loss_fn_outputs": outputs,
             "deferred": False,
         }

--- a/training/backends/megatron_bridge/backend.py
+++ b/training/backends/megatron_bridge/backend.py
@@ -43,6 +43,7 @@ async def _get(ref):
 
 
 class MegatronBridgeBackend(TrainingBackend):
+    SUPPORTED_LOSS_FNS = frozenset({"cross_entropy", "classification_ce"})
     """Megatron-native classification backend (Ray-actor delegation, no gen plane)."""
 
     def __init__(self, overrides: Optional[Dict[str, Any]] = None):
@@ -134,12 +135,14 @@ class MegatronBridgeBackend(TrainingBackend):
             request_id, model_id, base_model, num_labels, seq_length, lc.get("rank", 16))
         return handle
 
-    async def forward(self, handle: BackendHandle, data: List[Dict], loss_fn: str) -> Dict[str, Any]:
+    async def forward(self, handle: BackendHandle, data: List[Dict], loss_fn: str,
+                      loss_fn_config: Optional[Dict[str, float]] = None) -> Dict[str, Any]:
         h: MegatronBridgeHandle = handle  # type: ignore[assignment]
         batch = self.converter.forward_to_backend(data, {"seq_length": h.seq_length})
         return await _get(h.worker.forward.remote(batch))
 
-    async def forward_backward(self, handle: BackendHandle, data: List[Dict], loss_fn: str) -> Dict[str, Any]:
+    async def forward_backward(self, handle: BackendHandle, data: List[Dict], loss_fn: str,
+                               loss_fn_config: Optional[Dict[str, float]] = None) -> Dict[str, Any]:
         h: MegatronBridgeHandle = handle  # type: ignore[assignment]
         batch = self.converter.forward_backward_to_backend(data, loss_fn, {"seq_length": h.seq_length})
         return await _get(h.worker.forward_backward.remote(batch))

--- a/training/backends/miles/backend.py
+++ b/training/backends/miles/backend.py
@@ -870,20 +870,16 @@ class MilesBackend(TrainingBackend):
             lps = logprobs_list[offset:offset + o.num_samples]
             offset += o.num_samples
             # Observation contract: per-datum logprobs are datum-aligned —
-            # length == the datum's model_input token length (captured at
-            # submit; rollout tokens append the final target and are +1).
-            # The RL path computes one fewer (causal shift over a
-            # full-sequence response): front-pad, which keeps suffix
-            # (action-token) alignment. Longer than the datum is a layout
-            # error: refuse rather than guess (reassemble-or-refuse).
+            # exactly one per model_input token, entry k = logprob of target k
+            # (the converter appends the final target so the response covers
+            # all T targets). Any other length is a layout error: refuse
+            # rather than guess (reassemble-or-refuse).
             in_lens = o.input_lens or []
             outs = []
             for j, lp in enumerate(lps):
                 lp_list = lp.tolist()
                 full = in_lens[j] if j < len(in_lens) and in_lens[j] > 0 else len(lp_list)
-                if len(lp_list) < full:
-                    lp_list = [0.0] * (full - len(lp_list)) + lp_list
-                elif len(lp_list) > full:
+                if len(lp_list) != full:
                     raise BackendError(
                         f"sample {j}: {len(lp_list)} logprobs for "
                         f"{full}-token input",
@@ -1438,6 +1434,14 @@ class MilesBackend(TrainingBackend):
         sequences = []
         prompt_logprobs_result = None
         base_params = dict(sampling_params or {})
+        if base_params.get("seed") is not None and not getattr(h.args, "sglang_enable_deterministic_inference", False):
+            if not getattr(h, "_seed_warned", False):
+                h._seed_warned = True
+                logger.warning(
+                    "[%s] sampling seed given but SGLang was booted without deterministic "
+                    "inference: the seed is ignored. Set SLIME_SGLANG_DETERMINISTIC=1 before create_model.",
+                    request_id,
+                )
         for i in range(num_samples):
             params = dict(base_params)
             if params.get("seed") is not None:

--- a/training/backends/miles/backend.py
+++ b/training/backends/miles/backend.py
@@ -1437,10 +1437,14 @@ class MilesBackend(TrainingBackend):
 
         sequences = []
         prompt_logprobs_result = None
-        for _ in range(num_samples):
+        base_params = dict(sampling_params or {})
+        for i in range(num_samples):
+            params = dict(base_params)
+            if params.get("seed") is not None:
+                params["seed"] = int(params["seed"]) + i  # distinct stream per sample
             result = await client.generate(
                 input_ids=prompt_tokens,
-                sampling_params=sampling_params or {},
+                sampling_params=params,
                 prompt_logprobs=prompt_logprobs,
                 lora_path=lora_path,
             )

--- a/training/backends/miles/backend.py
+++ b/training/backends/miles/backend.py
@@ -17,6 +17,7 @@ from typing import Any, Dict, List, Optional
 import ray
 
 from ..base import BackendError, BackendHandle, TrainingBackend, UnsupportedFeatureError
+from ...core.loss_registry import clip_thresholds
 from ..checkpoint_interchange import (
     CHECKPOINT_BASE,
     export_hf_adapter,
@@ -197,7 +198,25 @@ class MilesPool:
     cobatch_e0_tokens: int = 512
 
 
+def _check_miles_clip_config(h: "MilesHandle", loss_fn: str, loss_fn_config: Optional[Dict[str, float]]) -> None:
+    """Megatron reads eps_clip / eps_clip_high once at actor boot; a per-call
+    clip range is honoured only if it is exactly that range."""
+    if loss_fn != "ppo" or not loss_fn_config or h.args is None:
+        return
+    low, high = clip_thresholds(loss_fn_config)
+    boot_low = 1.0 - float(getattr(h.args, "eps_clip", 0.2))
+    boot_high = 1.0 + float(getattr(h.args, "eps_clip_high", getattr(h.args, "eps_clip", 0.2)))
+    if abs(low - boot_low) > 1e-9 or abs(high - boot_high) > 1e-9:
+        raise UnsupportedFeatureError(
+            f"ppo clip thresholds ({low}, {high})", backend="miles",
+            suggestion=f"this actor group was booted with ({boot_low:g}, {boot_high:g}); "
+                       "set SLIME_EPS_CLIP / SLIME_EPS_CLIP_HIGH before create_model",
+        )
+
+
 class MilesBackend(TrainingBackend):
+    # sft_loss / policy_loss; PPO clip range is a boot-time Megatron arg (see forward_backward).
+    SUPPORTED_LOSS_FNS = frozenset({"cross_entropy", "importance_sampling", "ppo"})
     """Thin adapter over existing Miles integration code (model_service.py / training_service.py)."""
 
     def __init__(self, overrides: Optional[Dict[str, Any]] = None):
@@ -887,6 +906,7 @@ class MilesBackend(TrainingBackend):
         handle: BackendHandle,
         data: List[Dict],
         loss_fn: str,
+        loss_fn_config: Optional[Dict[str, float]] = None,
     ) -> Dict[str, Any]:
         h: MilesHandle = handle  # type: ignore[assignment]
 
@@ -960,8 +980,10 @@ class MilesBackend(TrainingBackend):
         handle: BackendHandle,
         data: List[Dict],
         loss_fn: str,
+        loss_fn_config: Optional[Dict[str, float]] = None,
     ) -> Dict[str, Any]:
         h: MilesHandle = handle  # type: ignore[assignment]
+        _check_miles_clip_config(h, loss_fn, loss_fn_config)
         pool = self._pool
         if h.adapter_slot is not None and pool is not None:
             # Pool path: validate + convert here (CPU), then queue the GPU

--- a/training/backends/nemo_rl/backend.py
+++ b/training/backends/nemo_rl/backend.py
@@ -19,6 +19,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from ..base import BackendError, BackendHandle, TrainingBackend
+from ...core.loss_registry import clip_thresholds
 from ..checkpoint_interchange import (
     export_hf_adapter,
     resolve_checkpoint_root,
@@ -58,6 +59,7 @@ class NemoRLHandle(BackendHandle):
     training_run_id: str = ""
     debug_train_only: bool = False
     loss_fn_name: str = ""               # String name from last forward_backward()
+    loss_fn_config: Optional[Dict[str, float]] = None  # per-call hyperparameters of the buffered batch
     generation_state: str = "generation_ready"  # "generation_ready" | "training_ready"
     _generation_state_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     _training_lock: asyncio.Lock = field(default_factory=asyncio.Lock)  # Serialize optim_step GPU lifecycle
@@ -73,6 +75,8 @@ class NemoRLHandle(BackendHandle):
 
 
 class NemoRLBackend(TrainingBackend):
+    # TinkerSumCELoss / ClippedPGLossFn; cispo and dro have no NeMo RL loss.
+    SUPPORTED_LOSS_FNS = frozenset({"cross_entropy", "importance_sampling", "ppo"})
     """
     NeMo RL backend — uses Policy.train() push-mode API.
 
@@ -221,6 +225,7 @@ class NemoRLBackend(TrainingBackend):
         handle: BackendHandle,
         data: List[Dict],
         loss_fn: str,
+        loss_fn_config: Optional[Dict[str, float]] = None,
     ) -> Dict[str, Any]:
         """Forward-only pass — compute logprobs without gradients.
 
@@ -272,6 +277,7 @@ class NemoRLBackend(TrainingBackend):
         handle: BackendHandle,
         data: List[Dict],
         loss_fn: str,
+        loss_fn_config: Optional[Dict[str, float]] = None,
     ) -> Dict[str, Any]:
         """
         Buffer incoming data per R9 strategy. NO GPU training work yet.
@@ -338,10 +344,19 @@ class NemoRLBackend(TrainingBackend):
                             operation="forward_backward",
                         )
 
+                # One loss configuration per optimizer step: the buffer trains as
+                # a single policy.train() call, so a differing config cannot be honoured.
+                if h.data_buffer and (h.loss_fn_name, h.loss_fn_config or {}) != (loss_fn, loss_fn_config or {}):
+                    raise BackendError(
+                        f"loss mismatch within one optimizer step: buffered "
+                        f"{h.loss_fn_name!r} {h.loss_fn_config or {}}, new {loss_fn!r} {loss_fn_config or {}}",
+                        backend="nemo_rl", operation="forward_backward",
+                    )
                 h.data_buffer.append(batched_data)
                 buffer_len = len(h.data_buffer)
-                # Store loss_fn name for apply_optimizer_step() response
+                # Store loss_fn name + config for apply_optimizer_step()
                 h.loss_fn_name = loss_fn
+                h.loss_fn_config = dict(loss_fn_config) if loss_fn_config else None
 
             logger.info(
                 "Buffered microbatch %d for model %s (%d samples)",
@@ -447,6 +462,10 @@ class NemoRLBackend(TrainingBackend):
                 buffered_batches = h.data_buffer
                 h.data_buffer = []
                 num_buffered = len(buffered_batches)
+                # The config that governed this buffer; a pipelined fb(N+1) may
+                # overwrite h.loss_fn_config before we reach policy.train().
+                step_loss_config = h.loss_fn_config
+                h.loss_fn_config = None
 
             # Concatenate outside the lock (CPU-bound, no contention needed)
             phases: Dict[str, float] = {}  # Q3-R2 per-step cost decomposition
@@ -565,6 +584,16 @@ class NemoRLBackend(TrainingBackend):
                         # importable in the shared venv on server + workers).
                         from .losses import TinkerSumCELoss
                         active_loss_fn = TinkerSumCELoss()
+                    elif h.loss_fn_name == "ppo" and step_loss_config:
+                        # Per-call clip range: rebuild the clipped-PG loss from the
+                        # create-time config with the client's thresholds.
+                        from nemo_rl.algorithms.loss_functions import ClippedPGLossFn
+                        low, high = clip_thresholds(step_loss_config)
+                        active_loss_fn = ClippedPGLossFn({
+                            **h.config["loss_fn"],
+                            "ratio_clip_min": 1.0 - low,
+                            "ratio_clip_max": high - 1.0,
+                        })
                     else:
                         active_loss_fn = h.loss_fn  # ClippedPGLossFn (RL)
 
@@ -657,12 +686,18 @@ class NemoRLBackend(TrainingBackend):
                 {k: round(v, 3) for k, v in phases.items()},
             )
 
+            metrics = dict(result.get("metrics", {}))
+            if h.loss_fn_name == "ppo":
+                low, high = clip_thresholds(step_loss_config)
+                metrics["clip_low_threshold"] = low
+                metrics["clip_high_threshold"] = high
+
             return {
                 "success": True,
                 "grad_norm": result.get("grad_norm", 0.0),
                 "learning_rates": [],
                 "model_id": h.model_id,
-                "metrics": result.get("metrics", {}),
+                "metrics": metrics,
                 "loss_fn_outputs": loss_fn_outputs,
                 # A4 ver(S): post-step version state for driver-side accounting
                 "weight_version": h.weight_version,

--- a/training/backends/nemo_rl/backend.py
+++ b/training/backends/nemo_rl/backend.py
@@ -912,8 +912,9 @@ class NemoRLBackend(TrainingBackend):
         )
         # ver(S) monitor (A4): certify the version actually served against the
         # declared bound, and stamp it into the response. Versions are read
-        # post-serve; a concurrent optim_step could bump weight_version between
-        # flush and here, but ops on one model are FIFO-serialized upstream.
+        # post-serve; sampling is not part of the model's ordered training
+        # program (services.ordering), so a concurrent optim_step can bump
+        # weight_version between flush and here — the stamp is best-effort.
         served_v = h.generation_synced_version
         latest_v = h.weight_version
         if latest_v - served_v > h.staleness_k:

--- a/training/backends/nemo_rl/generation.py
+++ b/training/backends/nemo_rl/generation.py
@@ -168,41 +168,42 @@ async def _batched_nemo_rl_generate(
         "input_lengths": input_lengths,
     })
 
-    # Extract sampling params from first request (batch assumes uniform params)
-    # For heterogeneous params, use per-sample _tinker_ fields
-    first_params = batch[0].sampling_params or {}
-    max_new_tokens = first_params.get("max_tokens", 256)
-    temperature = first_params.get("temperature", 0.7)
-    top_p = first_params.get("top_p", 0.9)
-    greedy = temperature <= 0.01
+    # Every sampling parameter is a per-row column: the vLLM worker builds one
+    # SamplingParams per row, so requests with different max_tokens, stop
+    # strings, seeds, ... share a batch without one request's values leaking
+    # into another's. Padding rows copy the last real row.
+    def row_params(i: int) -> Dict[str, Any]:
+        return expanded_params[min(i, actual_size - 1)] or {}
 
-    # Per-sample params via _tinker_ fields
-    data["_tinker_max_new_tokens"] = [
-        (expanded_params[i] or {}).get("max_tokens", max_new_tokens)
-        for i in range(actual_size)
-    ] + [max_new_tokens] * (padded_size - actual_size)
+    def row_stop_strings(i: int) -> List[str]:
+        raw = row_params(i).get("stop")
+        if isinstance(raw, str):
+            return [raw]
+        if isinstance(raw, list):
+            return [s for s in raw if isinstance(s, str)]
+        return []
+
+    def row_seed(i: int) -> Optional[int]:
+        seed = row_params(i).get("seed")
+        if seed is None or i >= actual_size:
+            return None
+        return int(seed) + request_indices[i][1]  # distinct stream per sample of a request
+
+    data["_tinker_max_new_tokens"] = [int(row_params(i).get("max_tokens") or 256) for i in range(padded_size)]
     data["_tinker_temperature"] = [
-        (expanded_params[i] or {}).get("temperature", temperature)
-        for i in range(actual_size)
-    ] + [temperature] * (padded_size - actual_size)
-    data["_tinker_top_p"] = [
-        (expanded_params[i] or {}).get("top_p", top_p)
-        for i in range(actual_size)
-    ] + [top_p] * (padded_size - actual_size)
-
-    raw_stop = first_params.get("stop")
-    stop_strings: List[str] = []
-    if raw_stop is not None:
-        if isinstance(raw_stop, str):
-            stop_strings = [raw_stop]
-        elif isinstance(raw_stop, list) and raw_stop and isinstance(raw_stop[0], str):
-            stop_strings = list(raw_stop)
-    if stop_strings:
-        data["stop_strings"] = [stop_strings] * padded_size
-
-    any_prompt_logprobs = any(req.prompt_logprobs for req in batch)
-    if any_prompt_logprobs:
-        data["_tinker_prompt_logprobs"] = [True] * padded_size
+        (0.0 if float(row_params(i).get("temperature", 0.7)) <= 0.01 else float(row_params(i).get("temperature", 0.7)))
+        for i in range(padded_size)
+    ]
+    data["_tinker_top_p"] = [float(row_params(i).get("top_p", 0.9)) for i in range(padded_size)]
+    data["_tinker_top_k"] = [row_params(i).get("top_k") for i in range(padded_size)]
+    data["_tinker_seed"] = [row_seed(i) for i in range(padded_size)]
+    data["_tinker_stop_token_ids"] = [list(row_params(i).get("stop_token_ids") or []) for i in range(padded_size)]
+    data["stop_strings"] = [row_stop_strings(i) for i in range(padded_size)]
+    data["_tinker_prompt_logprobs"] = [
+        bool(batch[request_indices[i][0]].prompt_logprobs) if i < actual_size else False
+        for i in range(padded_size)
+    ]
+    greedy = False  # per-row temperature 0.0 is greedy in vLLM
 
     logger.info(
         "[%s] Batched NeMo RL generate: %d requests → %d samples (padded to %d)",
@@ -227,8 +228,10 @@ async def _batched_nemo_rl_generate(
         out_logprobs = logprobs_tensor[i, prompt_len:prompt_len + gen_len].tolist()
         text = tokenizer.decode(out_tokens) if tokenizer else None
 
+        stop_strings = row_stop_strings(i)
+        stop_ids = set(data["_tinker_stop_token_ids"][i])
         stop_reason = "length"
-        if out_tokens and eos_id is not None and out_tokens[-1] == eos_id:
+        if out_tokens and ((eos_id is not None and out_tokens[-1] == eos_id) or out_tokens[-1] in stop_ids):
             stop_reason = "stop"
         elif text and stop_strings:
             for ss in stop_strings:

--- a/training/backends/verl/backend.py
+++ b/training/backends/verl/backend.py
@@ -70,6 +70,7 @@ class VerlHandle(BackendHandle):
 
 
 class VerlBackend(TrainingBackend):
+    SUPPORTED_LOSS_FNS = frozenset({"cross_entropy", "importance_sampling", "ppo"})  # losses.LOSS_FNS
     """veRL backend using upstream TinkerTrainingWorker split primitives."""
 
     def __init__(self, overrides: Optional[Dict[str, Any]] = None):
@@ -187,6 +188,7 @@ class VerlBackend(TrainingBackend):
         handle: BackendHandle,
         data: List[Dict],
         loss_fn: str,
+        loss_fn_config: Optional[Dict[str, float]] = None,
     ) -> Dict[str, Any]:
         h: VerlHandle = handle  # type: ignore[assignment]
         async with h._lock:
@@ -254,6 +256,7 @@ class VerlBackend(TrainingBackend):
         handle: BackendHandle,
         data: List[Dict],
         loss_fn: str,
+        loss_fn_config: Optional[Dict[str, float]] = None,
     ) -> Dict[str, Any]:
         logprobs = await self.get_logprobs(handle, data)
         return {"loss_fn_output_type": loss_fn, "loss_fn_outputs": logprobs, "metrics": {}}

--- a/training/core/data_converter.py
+++ b/training/core/data_converter.py
@@ -126,10 +126,17 @@ class TinkerDataConverter:
             # Miles convention: the mask covers the response REGION, so
             # response_length is the mask's length (zeros inside are allowed);
             # counting nonzeros breaks prompt/response alignment in get_batch.
-            # Causal N-1 trim: response == total yields an empty logit slice
-            # (same handling as the forward_backward RL path).
-            if len(loss_mask) == len(tokens) and len(tokens) > 1:
-                loss_mask = loss_mask[1:]
+            # Same layout as the forward_backward RL path: append the final
+            # target so the response is the T wire targets and the returned
+            # logprobs are T-long, entry k = logprob of target k.
+            target = cls._get_field(loss_fn_inputs, "target_tokens")
+            if target is None:
+                target = cls._get_field(loss_fn_inputs, "target")
+            target_data = cls.extract_tensor_data(target) if target is not None else None
+            if target_data and len(loss_mask) == len(tokens) and len(tokens) > 0:
+                tokens_list[-1] = torch.cat([tokens_list[-1], torch.tensor(target_data[-1:], dtype=torch.long)])
+            elif len(loss_mask) == len(tokens) and len(tokens) > 1:
+                loss_mask = loss_mask[:-1]  # no target on the wire: the last target is unknowable
             loss_masks_list.append(loss_mask)
             response_lengths_list.append(len(loss_mask))
             # print(f"[CONVERTER DEBUG SFT] Sample {len(loss_masks_list)-1}: loss_mask sum={response_length}, len={len(loss_mask)}", flush=True)
@@ -243,7 +250,13 @@ class TinkerDataConverter:
                 # Step 1: Extract raw data from loss_fn_inputs
                 logprobs = cls._get_field(loss_fn_inputs, "logprobs")
                 logprobs_data = cls.extract_tensor_data(logprobs) if logprobs is not None else None
+                # Loss mask: `mask` when the client sends one; otherwise the
+                # target-aligned `weights` (custom-loss datums); otherwise all ones
+                # (the cookbook's RL datums strip the mask and rely on zero
+                # advantages outside the response).
                 mask = cls._get_field(loss_fn_inputs, "mask")
+                if mask is None:
+                    mask = cls._get_field(loss_fn_inputs, "weights")
                 mask_data = cls.extract_tensor_data(mask) if mask is not None else None
 
                 # Step 2: Determine response_len from mask or logprobs
@@ -251,26 +264,39 @@ class TinkerDataConverter:
                     response_len = len(mask_data)
                 elif logprobs_data is not None:
                     response_len = len(logprobs_data)
-                    # print(f"[CONVERTER RL] Sample {idx}: No mask, using logprobs length={response_len} (tokens={len(tokens)})", flush=True)
                 else:
                     response_len = len(tokens)
-                    # print(f"[CONVERTER RL] Sample {idx}: No mask/logprobs, using token length={response_len}", flush=True)
 
-                # Step 3: Handle causal LM shift (N-1 adjustment)
-                #
-                # When response_len == token_length (entire sequence is "response"),
-                # Miles computes N-1 logits because logits[i] predicts tokens[i+1].
-                # We must trim all per-token data to N-1 to match.
-                # See: miles/backends/megatron_utils/loss.py:100-108
+                # Step 3: Causal shift. The wire datum is pre-shifted: model_input
+                # has T tokens and every per-token tensor has T entries, entry k
+                # describing target k = model_input[k+1] (k < T-1) or the final
+                # target (k = T-1). Miles computes one logprob per position after
+                # the first token, so with model_input alone it would see only
+                # T-1 targets: the final response token would get no loss or
+                # logprob, and any trim shifts the tensors against the positions
+                # they describe. Append the final target instead, as the SFT path
+                # and the NeMo RL converter do, so the response is exactly the T
+                # targets and every tensor lines up untouched.
                 token_length = len(tokens)
-                needs_causal_trim = (response_len == token_length and token_length > 1)
-                if needs_causal_trim:
-                    # print(f"[CONVERTER RL] Sample {idx}: Applying N-1 causal trim ({response_len} -> {response_len - 1})", flush=True)
+                target = cls._get_field(loss_fn_inputs, "target_tokens")
+                if target is None:
+                    target = cls._get_field(loss_fn_inputs, "target")
+                target_data = cls.extract_tensor_data(target) if target is not None else None
+                needs_causal_trim = False
+                if target_data and response_len == token_length and token_length > 0:
+                    tokens_list[-1] = torch.cat([
+                        tokens_list[-1], torch.tensor(target_data[-1:], dtype=torch.long),
+                    ])
+                elif response_len == token_length and token_length > 1:
+                    # No target on the wire (not a Tinker RL datum): the last
+                    # target is unknowable, so drop the LAST entry of each tensor
+                    # (the one describing it) and train on T-1 positions.
+                    logger.warning("RL datum %d carries no target_tokens; training on %d of %d targets", idx, token_length - 1, token_length)
+                    needs_causal_trim = True
                     response_len = token_length - 1
 
-                # Helper to trim tensor data for causal LM shift (skip first element)
                 def maybe_trim(data: list) -> list:
-                    return data[1:] if needs_causal_trim and data else data
+                    return data[:-1] if needs_causal_trim and data else data
 
                 # Step 4: Build per-token tensors (all must have length = response_len)
                 if mask_data is not None:

--- a/training/core/loss_registry.py
+++ b/training/core/loss_registry.py
@@ -1,0 +1,52 @@
+"""
+Loss-function registry: the names the API accepts and the `loss_fn_config`
+keys each one takes. Validated at the HTTP boundary (400 on failure) so a
+misspelt name or a stray key never silently degrades to a default.
+
+Per-backend support is declared on TrainingBackend.SUPPORTED_LOSS_FNS and
+checked by TrainingService.
+"""
+from typing import Dict, FrozenSet, Mapping, Optional
+
+CLIP_KEYS = frozenset({"clip_low_threshold", "clip_high_threshold"})
+
+# name -> allowed loss_fn_config keys
+LOSS_FNS: Dict[str, FrozenSet[str]] = {
+    "cross_entropy": frozenset(),
+    "importance_sampling": frozenset(),
+    "ppo": CLIP_KEYS,
+    "cispo": CLIP_KEYS,
+    "dro": frozenset({"beta"}),
+    "classification_ce": frozenset(),
+}
+
+# Tinker's documented PPO/CISPO defaults (epsilon 0.2 either side).
+DEFAULT_CLIP_LOW = 0.8
+DEFAULT_CLIP_HIGH = 1.2
+
+
+def validate(loss_fn: str, loss_fn_config: Optional[Mapping[str, float]] = None) -> None:
+    """Raise ValueError if `loss_fn` is unknown or `loss_fn_config` carries a key it does not take."""
+    allowed = LOSS_FNS.get(loss_fn)
+    if allowed is None:
+        raise ValueError(f"Unknown loss_fn {loss_fn!r}; supported: {', '.join(sorted(LOSS_FNS))}")
+    for key, value in (loss_fn_config or {}).items():
+        if key not in allowed:
+            take = f"takes {', '.join(sorted(allowed))}" if allowed else "takes no loss_fn_config"
+            raise ValueError(f"loss_fn_config key {key!r} is not valid for {loss_fn!r} ({take})")
+        if not isinstance(value, (int, float)) or isinstance(value, bool):
+            raise ValueError(f"loss_fn_config[{key!r}] must be a number, got {type(value).__name__}")
+    if loss_fn_config and CLIP_KEYS & set(loss_fn_config):
+        low = loss_fn_config.get("clip_low_threshold", DEFAULT_CLIP_LOW)
+        high = loss_fn_config.get("clip_high_threshold", DEFAULT_CLIP_HIGH)
+        if not (0.0 <= low <= 1.0 <= high):
+            raise ValueError(
+                f"clip thresholds must satisfy 0 <= clip_low_threshold <= 1 <= clip_high_threshold, got {low}, {high}"
+            )
+
+
+def clip_thresholds(loss_fn_config: Optional[Mapping[str, float]]) -> tuple:
+    """(low, high) with Tinker's defaults filled in."""
+    cfg = loss_fn_config or {}
+    return (float(cfg.get("clip_low_threshold", DEFAULT_CLIP_LOW)),
+            float(cfg.get("clip_high_threshold", DEFAULT_CLIP_HIGH)))

--- a/training/core/slime_builder.py
+++ b/training/core/slime_builder.py
@@ -246,6 +246,12 @@ class SlimeArgumentBuilder:
             '--eps-clip-high', os.environ.get('SLIME_EPS_CLIP_HIGH', '0.28'),
             # Entropy coefficient (0 = no entropy bonus, matches Miles native)
             '--entropy-coef', os.environ.get('SLIME_ENTROPY_COEF', '0.00'),
+        ]
+        # Per-request sampling seeds are honoured by SGLang only under
+        # deterministic inference (a boot-time engine mode with a throughput cost).
+        if os.environ.get('SLIME_SGLANG_DETERMINISTIC', '0') == '1':
+            minimal_args += ['--sglang-enable-deterministic-inference']
+        minimal_args += [
             # Weight decay - must be in minimal_args so Megatron's parse_args sees it
             # (Megatron defaults to 0.01; set to 0 for RL where weight decay fights policy updates)
             '--weight-decay', os.environ.get('SLIME_WEIGHT_DECAY', '0.0'),

--- a/training/core/task_manager.py
+++ b/training/core/task_manager.py
@@ -16,6 +16,7 @@ import asyncio
 import logging
 from typing import Callable, Dict, Any, Optional, Awaitable
 from ..storage import FuturesStorage
+from ..services import ordering
 
 logger = logging.getLogger(__name__)
 
@@ -63,8 +64,9 @@ class TaskManager:
         operation: str,
         model_id: str,
         payload: Dict[str, Any],
-        task_func: Callable[[], Awaitable[Dict[str, Any]]]
-    ) -> None:
+        task_func: Callable[[], Awaitable[Dict[str, Any]]],
+        seq_id: Optional[int] = None,
+    ) -> str:
         """
         Create and track a background async task with automatic error handling.
 
@@ -95,21 +97,28 @@ class TaskManager:
                 task_func=do_training
             )
         """
-        # Save future with pending status
-        self.futures_storage.save_future(
+        # Save future with pending status; a retried seq_id returns the earlier request
+        owner = self.futures_storage.save_future(
             request_id=request_id,
             operation=operation,
             payload=payload,
-            model_id=model_id
+            model_id=model_id,
+            seq_id=seq_id,
         )
+        if owner != request_id:
+            return owner
+        kind = ordering.KINDS.get(operation)
 
         async def wrapped_task():
             """Wrapper that handles success/failure and storage updates"""
             try:
                 logger.info(f"[{request_id}] Starting {operation} for {model_id}")
 
-                # Execute the actual business logic
-                result = await task_func()
+                # Execute the actual business logic, in the model's program order
+                if kind is not None:
+                    result = await ordering.queues.run(model_id, kind, task_func)
+                else:
+                    result = await task_func()
 
                 # Update storage with success
                 self.futures_storage.update_status(
@@ -144,6 +153,7 @@ class TaskManager:
 
         # Prevent garbage collection
         task.add_done_callback(lambda t: None)
+        return request_id
 
     def get_task(self, request_id: str) -> Optional[asyncio.Task]:
         """

--- a/training/models/requests.py
+++ b/training/models/requests.py
@@ -205,10 +205,12 @@ class SaveWeightsRequest(BaseModel):
 
 
 class LoadWeightsRequest(BaseModel):
-    """Request to load model weights."""
+    """Request to load model weights (permitted only as a model's first request)."""
 
     model_id: str = Field(..., description="Model ID")
-    path: str = Field(..., description="Checkpoint path to load from")
+    path: str = Field(..., description="tinker://<run>/weights/<name> to load from")
+    optimizer: bool = Field(default=False, description="Also restore optimizer state (not supported; must be false)")
+    seq_id: Optional[int] = Field(default=None, description="Sequence ID for ordering")
 
 
 class RetrieveFutureRequest(BaseModel):

--- a/training/models/requests.py
+++ b/training/models/requests.py
@@ -141,6 +141,7 @@ class UnloadModelRequest(BaseModel):
     """
 
     model_id: str = Field(..., description="Model ID to unload")
+    seq_id: Optional[int] = Field(default=None, description="Per-model sequence number (idempotent retries)")
     type: str = Field(default="unload_model", description="Request type")
 
 
@@ -202,6 +203,7 @@ class SaveWeightsRequest(BaseModel):
 
     model_id: str = Field(..., description="Model ID")
     path: Optional[str] = Field(default=None, description="Checkpoint name/path")
+    seq_id: Optional[int] = Field(default=None, description="Per-model sequence number (idempotent retries)")
 
 
 class LoadWeightsRequest(BaseModel):
@@ -433,12 +435,14 @@ class ForwardRequest(BaseModel):
     """Forward pass request (new format)."""
     model_id: str = Field(..., description="Model ID")
     forward_input: ForwardInput = Field(..., description="Forward pass data")
+    seq_id: Optional[int] = Field(default=None, description="Per-model sequence number (idempotent retries)")
 
 
 class ForwardBackwardRequest(BaseModel):
     """Forward-backward pass request (supports both old and new formats)."""
     model_id: str = Field(..., description="Model ID")
     forward_backward_input: Optional[ForwardBackwardInput] = Field(default=None, description="Training data (new format)")
+    seq_id: Optional[int] = Field(default=None, description="Per-model sequence number (idempotent retries)")
     # Old format fields (for backward compatibility with HTTP tests)
     data: Optional[List[ForwardBackwardDatum]] = Field(default=None, description="Training data (old format)")
     loss_fn: Optional[str] = Field(default=None, description="Loss function (old format)")
@@ -493,6 +497,7 @@ class OptimStepRequest(BaseModel):
     model_id: str = Field(..., description="Model ID")
     adam_params: Optional[AdamParams] = Field(default=None, description="Adam optimizer parameters")
     step_num: Optional[int] = Field(default=None, ge=0, description="Step number for logging")
+    seq_id: Optional[int] = Field(default=None, description="Per-model sequence number (idempotent retries)")
 
 
 class ASampleRequest(BaseModel):

--- a/training/models/requests.py
+++ b/training/models/requests.py
@@ -370,6 +370,7 @@ class ForwardInput(BaseModel):
     """Batch of forward data."""
     data: List[ForwardDatum] = Field(..., description="Batch data")
     loss_fn: str = Field(default="cross_entropy", description="Loss function")
+    loss_fn_config: Optional[Dict[str, float]] = Field(default=None, description="Loss hyperparameters (see core.loss_registry)")
 
 
 class ForwardBackwardDatum(BaseModel):
@@ -381,7 +382,8 @@ class ForwardBackwardDatum(BaseModel):
 class ForwardBackwardInput(BaseModel):
     """Batch of forward_backward data."""
     data: List[ForwardBackwardDatum] = Field(..., description="Batch data")
-    loss_fn: str = Field(default="cross_entropy", description="Loss function (cross_entropy, ppo_loss, etc.)")
+    loss_fn: str = Field(default="cross_entropy", description="Loss function name (see core.loss_registry)")
+    loss_fn_config: Optional[Dict[str, float]] = Field(default=None, description="Loss hyperparameters (see core.loss_registry)")
 
 
 # ============= Sampling Models =============

--- a/training/routers/checkpoints.py
+++ b/training/routers/checkpoints.py
@@ -120,11 +120,12 @@ async def save_weights(
         )
 
     # Create async task
-    task_manager.create_task(
+    request_id = task_manager.create_task(
         request_id=request_id,
         operation="save_weights",
         model_id=request.model_id,
         payload=request.dict(),
+        seq_id=request.seq_id,
         task_func=execute
     )
 
@@ -188,11 +189,12 @@ async def save_weights_for_sampler(
         return SaveWeightsForSamplerResult(**result)
 
     # Create async task
-    task_manager.create_task(
+    request_id = task_manager.create_task(
         request_id=request_id,
         operation="save_weights_for_sampler",
         model_id=request.model_id,
         payload=request.dict(),
+        seq_id=request.seq_id,
         task_func=execute
     )
 
@@ -241,9 +243,10 @@ async def load_weights(
             training_clients=training_clients, metadata_storage=metadata_storage,
         )
 
-    task_manager.create_task(
+    request_id = task_manager.create_task(
         request_id=request_id, operation="load_weights", model_id=request.model_id,
-        payload=request.dict(), task_func=execute,
+        payload=request.dict(),
+        seq_id=request.seq_id, task_func=execute,
     )
     return AsyncOperationResponse(request_id=request_id, model_id=request.model_id)
 

--- a/training/routers/checkpoints.py
+++ b/training/routers/checkpoints.py
@@ -18,6 +18,7 @@ from ..core.task_manager import TaskManager
 from ..core.dependencies import verify_api_key_dep
 from ..storage import MetadataStorage, FuturesStorage
 from ..models.requests import (
+    LoadWeightsRequest,
     SaveWeightsRequest,
     SaveWeightsForSamplerRequest,
     WeightsInfoRequest,
@@ -25,9 +26,9 @@ from ..models.requests import (
 from ..models.responses import (
     AsyncOperationResponse,
     SaveWeightsForSamplerResult,
-    DeprecatedEndpointError,
     WeightsInfoResponse,
 )
+from fastapi import Response
 from ..utils import generate_request_id
 
 logger = logging.getLogger(__name__)
@@ -201,22 +202,99 @@ async def save_weights_for_sampler(
     )
 
 
-@router.post("/api/v1/load_weights")
+@router.post("/api/v1/load_weights", response_model=AsyncOperationResponse)
 async def load_weights(
-    _: None = Depends(verify_api_key_dep)
+    request: LoadWeightsRequest,
+    _: None = Depends(verify_api_key_dep),
+    service: CheckpointService = Depends(get_checkpoint_service),
+    task_manager: TaskManager = Depends(get_task_manager),
+    futures_storage: FuturesStorage = Depends(get_futures_storage),
+    metadata_storage: MetadataStorage = Depends(get_metadata_storage),
+    training_clients: Dict = Depends(get_training_clients),
 ):
-    """Deprecated endpoint - use checkpoint_path in create_model instead."""
-    return DeprecatedEndpointError(
-        error="Endpoint deprecated",
-        reason="load_weights is no longer supported as a separate operation",
-        solution={
-            "description": "Use checkpoint_path parameter in create_model request",
-            "example": {
-                "base_model": "meta-llama/Llama-3.1-8B",
-                "checkpoint_path": "tinker://run_abc123/weights/checkpoint_001"
-            }
-        }
+    """Load a saved training checkpoint into a model.
+
+    Permitted only as the model's first request (before any forward /
+    forward_backward / optim_step), matching the Tinker service; later loads
+    belong in a fresh model created with checkpoint_path.
+    """
+    if request.model_id not in training_clients:
+        raise HTTPException(status_code=404, detail=f"Model {request.model_id} not found")
+    if request.optimizer:
+        raise HTTPException(status_code=400, detail="load_weights with optimizer=true is not supported")
+    if futures_storage.has_training_requests(request.model_id):
+        raise HTTPException(
+            status_code=400,
+            detail=f"LoadWeights is not permitted with seq_id {request.seq_id}: the model has already "
+                   "trained; create a new model with checkpoint_path instead",
+        )
+    parts = request.path.removeprefix("tinker://").split("/")
+    if not request.path.startswith("tinker://") or len(parts) != 3 or parts[1] != "weights":
+        raise HTTPException(status_code=400, detail=f"path must be tinker://<run>/weights/<name>, got {request.path!r}")
+    if metadata_storage.load_checkpoint(parts[0], parts[2]) is None:
+        raise HTTPException(status_code=404, detail=f"Checkpoint not found: {request.path}")
+    request_id = generate_request_id()
+
+    async def execute():
+        return await service.load_weights(
+            model_id=request.model_id, request_id=request_id, path=request.path,
+            training_clients=training_clients, metadata_storage=metadata_storage,
+        )
+
+    task_manager.create_task(
+        request_id=request_id, operation="load_weights", model_id=request.model_id,
+        payload=request.dict(), task_func=execute,
     )
+    return AsyncOperationResponse(request_id=request_id, model_id=request.model_id)
+
+
+@router.get("/api/v1/training_runs/{model_id}/checkpoints")
+async def list_checkpoints(
+    model_id: str,
+    _: None = Depends(verify_api_key_dep),
+    service: CheckpointService = Depends(get_checkpoint_service),
+    metadata_storage: MetadataStorage = Depends(get_metadata_storage),
+):
+    """Checkpoints of a training run, in the SDK's CheckpointsListResponse shape."""
+    if metadata_storage.load_training_run(model_id) is None:
+        raise HTTPException(status_code=404, detail=f"Training run not found: {model_id}")
+    return {"checkpoints": service.list_checkpoints(model_id, metadata_storage), "cursor": None}
+
+
+def _delete(service, metadata_storage, model_id, checkpoint_type, checkpoint_id):
+    if checkpoint_type not in ("training", "sampler"):
+        raise HTTPException(status_code=400, detail="checkpoint_type must be 'training' or 'sampler'")
+    if not service.delete_checkpoint(model_id, checkpoint_type, checkpoint_id, metadata_storage):
+        raise HTTPException(status_code=404, detail=f"Checkpoint not found: {checkpoint_type} {checkpoint_id} of {model_id}")
+    return Response(status_code=204)
+
+
+@router.delete("/api/v1/training_runs/{model_id}/checkpoints/{kind}/{checkpoint_id}")
+async def delete_checkpoint_typed(
+    model_id: str, kind: str, checkpoint_id: str,
+    _: None = Depends(verify_api_key_dep),
+    service: CheckpointService = Depends(get_checkpoint_service),
+    metadata_storage: MetadataStorage = Depends(get_metadata_storage),
+):
+    """DELETE .../checkpoints/weights/<id> or .../checkpoints/sampler_weights/<id>."""
+    kinds = {"weights": "training", "sampler_weights": "sampler"}
+    if kind not in kinds:
+        raise HTTPException(status_code=400, detail="checkpoint path must be weights/<id> or sampler_weights/<id>")
+    return _delete(service, metadata_storage, model_id, kinds[kind], checkpoint_id)
+
+
+@router.delete("/api/v1/training_runs/{model_id}/checkpoints/{checkpoint_id}")
+async def delete_checkpoint_bare(
+    model_id: str, checkpoint_id: str, checkpoint_type: str = None,
+    _: None = Depends(verify_api_key_dep),
+    service: CheckpointService = Depends(get_checkpoint_service),
+    metadata_storage: MetadataStorage = Depends(get_metadata_storage),
+):
+    """A bare id needs ?checkpoint_type=training|sampler: the two kinds can share an id."""
+    if not checkpoint_type:
+        raise HTTPException(status_code=400, detail="specify the kind: .../checkpoints/weights/<id>, "
+                            ".../checkpoints/sampler_weights/<id>, or ?checkpoint_type=training|sampler")
+    return _delete(service, metadata_storage, model_id, checkpoint_type, checkpoint_id)
 
 
 @router.post("/api/v1/weights_info", response_model=WeightsInfoResponse)

--- a/training/routers/models.py
+++ b/training/routers/models.py
@@ -243,11 +243,12 @@ async def unload_model(
         return UnloadModelResponse(model_id=model_id).dict()
 
     # Create async task
-    task_manager.create_task(
+    request_id = task_manager.create_task(
         request_id=request_id,
         operation="unload_model",
         model_id=model_id,
         payload=request.dict(),
+        seq_id=request.seq_id,
         task_func=execute
     )
 

--- a/training/routers/sampling.py
+++ b/training/routers/sampling.py
@@ -7,7 +7,7 @@ Endpoints:
 - POST /api/v1/create_sampling_client - Create SGLang sampling client
 """
 import logging
-from typing import Dict, Any
+from typing import Dict, Optional, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 
@@ -27,7 +27,6 @@ from ..models.responses import (
     CreateSamplingClientResult,
 )
 from ..utils import generate_request_id
-from ..utils.helpers import find_model_with_rollout_manager
 
 logger = logging.getLogger(__name__)
 
@@ -78,6 +77,50 @@ def get_session_service(request: Request):
     return getattr(request.app.state, "session_service", None)
 
 
+BASE_MODEL_SAMPLING_UNSUPPORTED = (
+    "base-model sampling is not supported by this deployment; create a model "
+    "and a sampler from it (save_weights_and_get_sampling_client) instead"
+)
+
+
+def resolve_target_model(
+    training_clients: Dict,
+    session_service,
+    sampling_session_id: Optional[str] = None,
+    model_path: Optional[str] = None,
+    base_model: Optional[str] = None,
+) -> tuple:
+    """Return (model_id, pinned_version) for a sampling request, or raise.
+
+    A sampler names its owning model (registered at save_weights_for_sampler /
+    create_sampling_session); a bare model_path names it by URI. There is no
+    fallback to "some model": under a multi-tenant pool that serves a
+    co-tenant's adapter, and a bare base_model has no engine behind it.
+    """
+    if sampling_session_id:
+        info = session_service.get_sampler(sampling_session_id) if session_service is not None else None
+        if info is None:
+            raise HTTPException(status_code=404, detail=f"Unknown sampling_session_id: {sampling_session_id}")
+        if not info.model_id:
+            raise HTTPException(status_code=400, detail=BASE_MODEL_SAMPLING_UNSUPPORTED)
+        if info.model_id not in training_clients:
+            raise HTTPException(status_code=404, detail=f"Sampler {sampling_session_id}'s model {info.model_id} no longer exists")
+        return info.model_id, getattr(info, "pinned_version", None)
+    if model_path:
+        model_id = model_id_from_path(model_path)
+        if model_id not in training_clients:
+            raise HTTPException(status_code=404, detail=f"Model {model_id!r} from model_path {model_path!r} not found")
+        return model_id, None
+    if base_model:
+        raise HTTPException(status_code=400, detail=BASE_MODEL_SAMPLING_UNSUPPORTED)
+    raise HTTPException(status_code=400, detail="Provide sampling_session_id or a tinker:// model_path")
+
+
+def model_id_from_path(model_path: str) -> str:
+    """tinker://<model_id>/... -> model_id."""
+    return model_path.removeprefix("tinker://").split("/")[0]
+
+
 @router.post("/api/v1/asample", response_model=AsyncOperationResponse)
 async def asample(
     request: ASampleRequest,
@@ -101,20 +144,12 @@ async def asample(
     # the live refit-every-step engine. The sampler also names its OWNING
     # model — required routing under a multi-tenant pool, where find-first
     # would serve a co-tenant's adapter.
-    pinned_version = None
-    target_model_id = None
-    if request.sampling_session_id and session_service is not None:
-        info = session_service.get_sampler(request.sampling_session_id)
-        pinned_version = getattr(info, "pinned_version", None) if info else None
-        target_model_id = getattr(info, "model_id", None) if info else None
-    if target_model_id is None and request.model_path:
-        # tinker://<model_id>/weights/... — the sampler URI names its model.
-        parts = request.model_path.removeprefix("tinker://").split("/")
-        if parts and parts[0] in training_clients:
-            target_model_id = parts[0]
-    model_id = target_model_id or find_model_with_rollout_manager(training_clients)
-    if not model_id:
-        raise HTTPException(status_code=404, detail="No model with RolloutManager found")
+    model_id, pinned_version = resolve_target_model(
+        training_clients, session_service,
+        sampling_session_id=request.sampling_session_id,
+        model_path=request.model_path, base_model=request.base_model,
+    )
+    target_model_id = model_id
 
     async def execute():
         result_dict = await service.async_sample(
@@ -158,7 +193,8 @@ async def sample(
     _: None = Depends(verify_api_key_dep),
     service: SamplingService = Depends(get_sampling_service),
     task_manager: TaskManager = Depends(get_task_manager),
-    training_clients: Dict = Depends(get_training_clients)
+    training_clients: Dict = Depends(get_training_clients),
+    session_service=Depends(get_session_service),
 ):
     """
     Synchronous sampling via SGLang.
@@ -166,10 +202,11 @@ async def sample(
     """
     request_id = generate_request_id()
 
-    # Find model with rollout manager
-    model_id = find_model_with_rollout_manager(training_clients)
-    if not model_id:
-        raise HTTPException(status_code=404, detail="No model with RolloutManager found")
+    model_id, _ = resolve_target_model(
+        training_clients, session_service,
+        sampling_session_id=request.sampling_session_id,
+        model_path=request.model_path, base_model=request.base_model,
+    )
 
     async def execute():
         result_dict = await service.sync_sample(
@@ -177,7 +214,8 @@ async def sample(
             prompts=request.prompts,
             num_samples=request.num_samples,
             sampling_params=request.sampling_params.dict() if request.sampling_params else None,
-            training_clients=training_clients
+            training_clients=training_clients,
+            model_id=model_id,
         )
 
         # Convert to response model
@@ -205,30 +243,26 @@ async def create_sampling_client(
     _: None = Depends(verify_api_key_dep),
     service: SamplingService = Depends(get_sampling_service),
     task_manager: TaskManager = Depends(get_task_manager),
-    training_clients: Dict = Depends(get_training_clients)
+    training_clients: Dict = Depends(get_training_clients),
+    session_service=Depends(get_session_service),
 ):
     """
-    Create sampling client (SGLang).
+    Create sampling client bound to the model named by model_path.
     This operation is asynchronous - use retrieve_future to check status.
     """
     request_id = generate_request_id()
 
-    # Determine model path
-    model_path = request.model_path or request.base_model
-    if not model_path:
-        raise HTTPException(status_code=400, detail="Either model_path or base_model must be provided")
-
-    # Find model with rollout manager
-    model_id = find_model_with_rollout_manager(training_clients)
-    if not model_id:
-        raise HTTPException(status_code=404, detail="No model with RolloutManager found")
+    model_id, _ = resolve_target_model(
+        training_clients, session_service,
+        model_path=request.model_path, base_model=request.base_model,
+    )
 
     async def execute():
         result_dict = await service.create_sampling_client(
             request_id=request_id,
             model_path=request.model_path,
-            base_model=request.base_model,
-            training_clients=training_clients
+            training_clients=training_clients,
+            model_id=model_id,
         )
         return CreateSamplingClientResult(**result_dict)
 

--- a/training/routers/session.py
+++ b/training/routers/session.py
@@ -11,6 +11,7 @@ Endpoints:
 """
 import logging
 import uuid
+from typing import Dict
 from fastapi import APIRouter, Depends, HTTPException, Request
 
 from ..models.requests import (
@@ -32,6 +33,13 @@ from ..services.session_service import SessionService
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["session"])
+
+
+def get_training_clients(request: Request) -> Dict:
+    runtime = getattr(request.app.state, "runtime", None)
+    if runtime is None:
+        raise RuntimeError("Training runtime state not initialized")
+    return runtime.training_clients
 
 
 def get_session_service(request: Request) -> SessionService:
@@ -98,7 +106,8 @@ async def session_heartbeat(
 async def create_sampling_session(
     request: CreateSamplingSessionRequest,
     _: None = Depends(verify_api_key_dep),
-    session_service: SessionService = Depends(get_session_service)
+    session_service: SessionService = Depends(get_session_service),
+    training_clients: Dict = Depends(get_training_clients),
 ):
     """
     Create a sampling session for inference.
@@ -113,6 +122,14 @@ async def create_sampling_session(
             detail=f"Session not found: {request.session_id}"
         )
 
+    # A sampler must name its owning model: a tinker:// model_path does; a bare
+    # base_model has no engine behind it.
+    from .sampling import resolve_target_model
+    model_id, _ = resolve_target_model(
+        training_clients, session_service,
+        model_path=request.model_path, base_model=request.base_model,
+    )
+
     # Generate sampling_session_id
     sampling_session_id = (
         f"{request.session_id}_{request.sampling_session_seq_id}_{uuid.uuid4().hex[:8]}"
@@ -122,8 +139,9 @@ async def create_sampling_session(
     session_service.add_sampling_session(
         session_id=request.session_id,
         sampling_session_id=sampling_session_id,
-        base_model=request.base_model,
-        model_path=request.model_path
+        base_model=request.base_model or training_clients[model_id].get("base_model"),
+        model_path=request.model_path,
+        model_id=model_id,
     )
 
     logger.info(

--- a/training/routers/training.py
+++ b/training/routers/training.py
@@ -121,11 +121,12 @@ async def forward(
         )
 
     # Create background task with automatic error handling
-    task_manager.create_task(
+    request_id = task_manager.create_task(
         request_id=request_id,
         operation="forward",
         model_id=request.model_id,
         payload=request.dict(),
+        seq_id=request.seq_id,
         task_func=execute_forward
     )
 
@@ -174,11 +175,12 @@ async def forward_backward(
         )
 
     # Create background task
-    task_manager.create_task(
+    request_id = task_manager.create_task(
         request_id=request_id,
         operation="forward_backward",
         model_id=request.model_id,
         payload=request.dict(),
+        seq_id=request.seq_id,
         task_func=execute_forward_backward
     )
 
@@ -224,11 +226,12 @@ async def optim_step(
         )
 
     # Create background task
-    task_manager.create_task(
+    request_id = task_manager.create_task(
         request_id=request_id,
         operation="optim_step",
         model_id=request.model_id,
         payload=request.dict(),
+        seq_id=request.seq_id,
         task_func=execute_optim_step
     )
 

--- a/training/routers/training.py
+++ b/training/routers/training.py
@@ -19,6 +19,7 @@ from ..models.responses import AsyncOperationResponse
 from ..services.training_service import TrainingService
 from ..core.task_manager import TaskManager
 from ..core.dependencies import verify_api_key_dep
+from ..core import loss_registry
 from ..storage import FuturesStorage
 
 logger = logging.getLogger(__name__)
@@ -71,6 +72,14 @@ def get_task_manager(
     return TaskManager(futures_storage)
 
 
+def _validate_loss(loss_fn: str, loss_fn_config) -> None:
+    """Unknown loss names / keys are a client error, not a silent default."""
+    try:
+        loss_registry.validate(loss_fn, loss_fn_config)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
 @router.post("/api/v1/forward", response_model=AsyncOperationResponse)
 async def forward(
     request: ForwardRequest,
@@ -99,6 +108,7 @@ async def forward(
 
     # Get client info
     client_info = training_clients[request.model_id]
+    _validate_loss(request.forward_input.loss_fn, request.forward_input.loss_fn_config)
 
     # Business logic wrapped in async task
     async def execute_forward():
@@ -107,6 +117,7 @@ async def forward(
             data=request.forward_input.data,
             loss_fn=request.forward_input.loss_fn,
             client_info=client_info,
+            loss_fn_config=request.forward_input.loss_fn_config,
         )
 
     # Create background task with automatic error handling
@@ -150,6 +161,7 @@ async def forward_backward(
 
     # Get client info
     client_info = training_clients[request.model_id]
+    _validate_loss(request.forward_backward_input.loss_fn, request.forward_backward_input.loss_fn_config)
 
     # Business logic wrapped in async task
     async def execute_forward_backward():
@@ -158,6 +170,7 @@ async def forward_backward(
             data=request.forward_backward_input.data,
             loss_fn=request.forward_backward_input.loss_fn,
             client_info=client_info,
+            loss_fn_config=request.forward_backward_input.loss_fn_config,
         )
 
     # Create background task

--- a/training/services/checkpoint_service.py
+++ b/training/services/checkpoint_service.py
@@ -7,6 +7,8 @@ Handles:
 - Checkpoint metadata management
 """
 import logging
+import os
+import shutil
 import time
 import uuid
 from datetime import datetime
@@ -82,6 +84,69 @@ class CheckpointService:
             "name": checkpoint_name,
             "type": "save_weights",
         }
+
+    async def load_weights(
+        self,
+        model_id: str,
+        request_id: str,
+        path: str,
+        training_clients: Dict[str, Dict[str, Any]],
+        metadata_storage: MetadataStorage,
+    ) -> Dict[str, Any]:
+        """Load a training checkpoint into a live model (weights only)."""
+        if model_id not in training_clients:
+            raise KeyError(f"Model {model_id} not found")
+        handle = training_clients[model_id]["backend_handle"]
+        logger.info("[%s] Loading weights for %s from %s", request_id, model_id, path)
+        await self.backend.load_checkpoint(handle, path)
+        metadata_storage.update_training_run(
+            training_clients[model_id].get("training_run_id", model_id),
+            {"loaded_from": path, "last_request_time": datetime.now().isoformat()},
+        )
+        return {"type": "load_weights", "path": path, "model_id": model_id}
+
+    @staticmethod
+    def delete_checkpoint(
+        model_id: str,
+        checkpoint_type: str,
+        checkpoint_id: str,
+        metadata_storage: MetadataStorage,
+    ) -> bool:
+        """Remove a checkpoint's metadata record and its bytes. Returns False if unknown."""
+        kind = "weights" if checkpoint_type == "training" else "sampler_weights"
+        meta_name = checkpoint_id if kind == "weights" else f"sampler_{checkpoint_id}"
+        if metadata_storage.load_checkpoint(model_id, meta_name) is None:
+            return False
+        root = resolve_checkpoint_root(f"tinker://{model_id}/{kind}/{checkpoint_id}")
+        if os.path.isdir(root):
+            shutil.rmtree(root, ignore_errors=True)
+        metadata_storage.delete_checkpoint(model_id, meta_name)
+        logger.info("Deleted %s checkpoint %s of %s (%s)", checkpoint_type, checkpoint_id, model_id, root)
+        return True
+
+    @staticmethod
+    def list_checkpoints(model_id: str, metadata_storage: MetadataStorage) -> list:
+        """Tinker-shaped checkpoint records for a training run."""
+        out = []
+        for rec in metadata_storage.list_checkpoints(model_id, limit=1000):
+            is_sampler = rec.get("type") == "sampler"
+            path = rec.get("tinker_uri") if is_sampler else rec.get("path")
+            if not path:
+                continue
+            name = path.removeprefix("tinker://").split("/")[-1]
+            kind = "sampler_weights" if is_sampler else "weights"
+            root = resolve_checkpoint_root(path)
+            size = None
+            if os.path.isdir(root):
+                size = sum(os.path.getsize(os.path.join(d, f)) for d, _, fs in os.walk(root) for f in fs)
+            out.append({
+                "checkpoint_id": f"{kind}/{name}",
+                "checkpoint_type": "sampler" if is_sampler else "training",
+                "time": rec.get("created_at"),
+                "tinker_path": path,
+                "size_bytes": size,
+            })
+        return out
 
     async def save_weights_for_sampler(
         self,

--- a/training/services/ordering.py
+++ b/training/services/ordering.py
@@ -1,0 +1,81 @@
+"""
+Per-model program order for training operations.
+
+The SDK issues a model's requests in program order and the routers turn each
+into an asyncio task, so without this layer forward_backward(N+1) could run
+before optim_step(N) had even started, and a save could observe a half-applied
+step. Two kinds of operation:
+
+- "pass"    (forward, forward_backward): may overlap with earlier work. A pass
+            starts only after every earlier operation on the model has STARTED,
+            so it can never be folded into an optimizer step that was submitted
+            before it.
+- "barrier" (optim_step, save_*, load_weights, unload_model): starts only after
+            every earlier operation on the model has COMPLETED, and nothing
+            submitted after it starts before it does.
+
+Backend-level locks remain the second line of defence; this layer makes the
+protocol's ordering explicit and backend-independent.
+"""
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Awaitable, Callable, Dict, Set
+
+logger = logging.getLogger(__name__)
+
+PASS = "pass"
+BARRIER = "barrier"
+
+# operation name -> kind; anything else is not ordered (e.g. sampling)
+KINDS = {
+    "forward": PASS,
+    "forward_backward": PASS,
+    "optim_step": BARRIER,
+    "save_weights": BARRIER,
+    "save_weights_for_sampler": BARRIER,
+    "load_weights": BARRIER,
+    "unload_model": BARRIER,
+}
+
+
+@dataclass
+class _ModelState:
+    start_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    inflight: Set[asyncio.Task] = field(default_factory=set)
+
+
+class ModelQueues:
+    """Process-wide ordering state, one entry per model."""
+
+    def __init__(self) -> None:
+        self._models: Dict[str, _ModelState] = {}
+
+    def _state(self, model_id: str) -> _ModelState:
+        st = self._models.get(model_id)
+        if st is None:
+            st = self._models[model_id] = _ModelState()
+        return st
+
+    async def run(self, model_id: str, kind: str, fn: Callable[[], Awaitable[Any]]) -> Any:
+        """Run `fn` on `model_id` honouring the ordering rules for `kind`."""
+        st = self._state(model_id)
+        async with st.start_lock:  # starts happen strictly in submission order
+            if kind == BARRIER and st.inflight:
+                earlier = list(st.inflight)
+                logger.debug("%s barrier waits for %d in-flight op(s)", model_id, len(earlier))
+                await asyncio.gather(*earlier, return_exceptions=True)
+            task = asyncio.ensure_future(fn())
+            st.inflight.add(task)
+            task.add_done_callback(st.inflight.discard)
+        return await task
+
+    def forget(self, model_id: str) -> None:
+        self._models.pop(model_id, None)
+
+    def inflight_count(self, model_id: str) -> int:
+        st = self._models.get(model_id)
+        return len(st.inflight) if st else 0
+
+
+queues = ModelQueues()

--- a/training/services/sampling_service.py
+++ b/training/services/sampling_service.py
@@ -11,7 +11,6 @@ import uuid
 from typing import Dict, Any, List, Optional
 
 from ..backends.base import BackendHandle, TrainingBackend
-from ..utils.helpers import find_model_with_rollout_manager
 
 logger = logging.getLogger(__name__)
 
@@ -25,19 +24,15 @@ class SamplingService:
     def _resolve_handle(
         self,
         training_clients: Dict[str, Dict[str, Any]],
-        model_id: Optional[str] = None,
+        model_id: Optional[str],
     ) -> BackendHandle:
-        """Return the target model's backend handle.
-
-        An explicit model_id (from the requesting sampler's session) wins:
-        find-first is only correct when a single model serves rollouts, and
-        a multi-LoRA pool has one per tenant."""
-        if model_id and model_id not in training_clients:
+        """Return the target model's backend handle. The router resolves the
+        model (sampler -> owning model, or tinker:// path); there is no
+        fallback to an arbitrary model."""
+        if not model_id:
+            raise RuntimeError("sampling request did not resolve to a model")
+        if model_id not in training_clients:
             raise RuntimeError(f"Sampler's model {model_id} no longer exists")
-        if not model_id:
-            model_id = find_model_with_rollout_manager(training_clients)
-        if not model_id:
-            raise RuntimeError("No model with RolloutManager found")
         handle = training_clients[model_id].get("backend_handle")
         if handle is None:
             raise RuntimeError(f"No backend handle for model {model_id}")
@@ -86,19 +81,16 @@ class SamplingService:
         prompts: List[List[int]],
         num_samples: int,
         sampling_params: Optional[Dict[str, Any]],
-        training_clients: Dict[str, Dict[str, Any]]
+        training_clients: Dict[str, Dict[str, Any]],
+        model_id: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
-        Synchronous sampling over multiple prompts.
+        Synchronous sampling over multiple prompts on `model_id`.
 
         Returns:
             Dict with sequences list (num_samples per prompt, flattened)
-
-        Raises:
-            RuntimeError: If no model with RolloutManager found
-            BackendError: If the inference engine is unavailable
         """
-        handle = self._resolve_handle(training_clients)
+        handle = self._resolve_handle(training_clients, model_id)
         logger.info(f"[{request_id}] Sampling {num_samples} sequences")
 
         all_sequences = []
@@ -120,25 +112,17 @@ class SamplingService:
         self,
         request_id: str,
         model_path: Optional[str],
-        base_model: Optional[str],
-        training_clients: Dict[str, Dict[str, Any]]
+        training_clients: Dict[str, Dict[str, Any]],
+        model_id: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
-        Create a sampling client bound to the serving model.
+        Create a sampling client bound to `model_id` (named by model_path).
 
         Returns:
             Dict with sampling_client_id, model_path, status
-
-        Raises:
-            ValueError: If neither model_path nor base_model provided
-            RuntimeError: If no model with RolloutManager found
-            BackendError: If the inference engine cannot be made ready
         """
-        resolved_model_path = model_path or base_model
-        if not resolved_model_path:
-            raise ValueError("Either model_path or base_model must be provided")
-
-        handle = self._resolve_handle(training_clients)
+        resolved_model_path = model_path or f"tinker://{model_id}"
+        handle = self._resolve_handle(training_clients, model_id)
         logger.info(f"[{request_id}] Creating sampling client for {resolved_model_path}")
 
         await self.backend.prepare_for_generation(handle)

--- a/training/services/training_service.py
+++ b/training/services/training_service.py
@@ -8,7 +8,7 @@ in the concrete backend implementation (e.g. MilesBackend, NemoRLBackend).
 import logging
 from typing import Dict, List, Any, Optional
 
-from ..backends.base import TrainingBackend
+from ..backends.base import TrainingBackend, UnsupportedFeatureError
 
 logger = logging.getLogger(__name__)
 
@@ -23,12 +23,21 @@ class TrainingService:
     def __init__(self, backend: TrainingBackend):
         self.backend = backend
 
+    def _check_loss_supported(self, loss_fn: str) -> None:
+        supported = getattr(self.backend, "SUPPORTED_LOSS_FNS", None)
+        if supported is not None and loss_fn not in supported:
+            raise UnsupportedFeatureError(
+                f"loss_fn {loss_fn!r}", backend=type(self.backend).__name__,
+                suggestion=f"this backend supports: {', '.join(sorted(supported))}",
+            )
+
     async def forward(
         self,
         model_id: str,
         data: List[Any],
         loss_fn: str,
         client_info: Dict[str, Any],
+        loss_fn_config: Optional[Dict[str, float]] = None,
     ) -> Dict[str, Any]:
         """
         Execute forward-only pass (no gradients).
@@ -37,9 +46,10 @@ class TrainingService:
         computing gradients.
         """
         logger.info("Forward pass for %s", model_id)
+        self._check_loss_supported(loss_fn)
 
         handle = client_info["backend_handle"]
-        result = await self.backend.forward(handle, data, loss_fn)
+        result = await self.backend.forward(handle, data, loss_fn, loss_fn_config=loss_fn_config)
 
         logger.info("Forward pass completed for %s", model_id)
         return result
@@ -50,14 +60,16 @@ class TrainingService:
         data: List[Any],
         loss_fn: str,
         client_info: Dict[str, Any],
+        loss_fn_config: Optional[Dict[str, float]] = None,
     ) -> Dict[str, Any]:
         """
         Execute forward-backward pass (accumulate gradients, no optimizer step).
         """
         logger.info("Forward-backward pass for %s", model_id)
+        self._check_loss_supported(loss_fn)
 
         handle = client_info["backend_handle"]
-        result = await self.backend.forward_backward(handle, data, loss_fn)
+        result = await self.backend.forward_backward(handle, data, loss_fn, loss_fn_config=loss_fn_config)
 
         logger.info("Forward-backward completed for %s", model_id)
         return result

--- a/training/storage/futures.py
+++ b/training/storage/futures.py
@@ -5,6 +5,7 @@ This module provides a storage layer for tracking asynchronous operations
 in the training API, using SQLite for persistence and in-memory caching
 for performance.
 """
+import hashlib
 import json
 import logging
 import sqlite3
@@ -39,6 +40,10 @@ def _serialize_result(result: Any) -> Optional[str]:
     else:
         # Plain dict or JSON-serializable object
         return json.dumps(result)
+
+
+class DuplicateSeqId(ValueError):
+    """A (model_id, seq_id) pair was reused with a different request."""
 
 
 class FuturesStorage:
@@ -92,28 +97,70 @@ class FuturesStorage:
                 CREATE INDEX IF NOT EXISTS idx_futures_model
                 ON futures(model_id)
             """)
+            # seq_id idempotency (added later; migrate older files in place)
+            columns = {row[1] for row in cursor.execute("PRAGMA table_info(futures)").fetchall()}
+            if "seq_id" not in columns:
+                cursor.execute("ALTER TABLE futures ADD COLUMN seq_id INTEGER")
+            if "payload_hash" not in columns:
+                cursor.execute("ALTER TABLE futures ADD COLUMN payload_hash TEXT")
+            cursor.execute("""
+                CREATE UNIQUE INDEX IF NOT EXISTS idx_futures_model_seq
+                ON futures(model_id, seq_id) WHERE seq_id IS NOT NULL
+            """)
 
             conn.commit()
             logger.info(f"Initialized futures database at {self.db_path}")
         finally:
             conn.close()
 
+    @staticmethod
+    def payload_hash(payload: Dict[str, Any]) -> str:
+        return hashlib.sha256(json.dumps(payload, sort_keys=True, default=str).encode()).hexdigest()
+
+    def find_by_seq_id(self, model_id: str, seq_id: int) -> Optional[Dict[str, Any]]:
+        conn = sqlite3.connect(str(self.db_path))
+        try:
+            row = conn.execute(
+                "SELECT request_id, operation, payload_hash FROM futures WHERE model_id = ? AND seq_id = ?",
+                (model_id, seq_id),
+            ).fetchone()
+        finally:
+            conn.close()
+        if row is None:
+            return None
+        return {"request_id": row[0], "operation": row[1], "payload_hash": row[2]}
+
     def save_future(
         self,
         request_id: str,
         operation: str,
         payload: Dict[str, Any],
-        model_id: Optional[str] = None
-    ) -> None:
+        model_id: Optional[str] = None,
+        seq_id: Optional[int] = None,
+    ) -> str:
         """
         Save a new future for an async operation.
 
-        Args:
-            request_id: Unique identifier for the request
-            operation: Type of operation (e.g., "create_model", "forward_backward")
-            payload: Operation payload/parameters
-            model_id: Optional model identifier
+        With a `seq_id`, the pair (model_id, seq_id) is unique: a retry of the
+        same request returns the existing request_id (no new future); a
+        different operation or payload under a reused seq_id raises
+        DuplicateSeqId.
+
+        Returns:
+            The request_id that owns this (model_id, seq_id): the given one, or
+            the earlier one on an idempotent retry.
         """
+        phash = self.payload_hash(payload)
+        if seq_id is not None and model_id is not None:
+            existing = self.find_by_seq_id(model_id, seq_id)
+            if existing is not None:
+                if existing["operation"] == operation and existing["payload_hash"] == phash:
+                    logger.info("[%s] retry of seq_id %s for %s -> %s", request_id, seq_id, model_id, existing["request_id"])
+                    return existing["request_id"]
+                raise DuplicateSeqId(
+                    f"Training request sequence number {seq_id} was reused for {model_id} "
+                    f"with a different {'operation' if existing['operation'] != operation else 'payload'}"
+                )
         future_data = {
             "request_id": request_id,
             "model_id": model_id,
@@ -135,8 +182,8 @@ class FuturesStorage:
             cursor = conn.cursor()
             cursor.execute("""
                 INSERT OR REPLACE INTO futures
-                (request_id, model_id, operation, payload, status, result, created_at, updated_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                (request_id, model_id, operation, payload, status, result, created_at, updated_at, seq_id, payload_hash)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """, (
                 request_id,
                 model_id,
@@ -145,14 +192,25 @@ class FuturesStorage:
                 future_data["status"],
                 None,
                 future_data["created_at"],
-                future_data["updated_at"]
+                future_data["updated_at"],
+                seq_id,
+                phash,
             ))
             conn.commit()
+        except sqlite3.IntegrityError:
+            # lost a race with a concurrent retry of the same seq_id
+            existing = self.find_by_seq_id(model_id, seq_id) if seq_id is not None else None
+            if existing and existing["operation"] == operation and existing["payload_hash"] == phash:
+                with self._lock:
+                    self._memory_store.pop(request_id, None)
+                return existing["request_id"]
+            raise DuplicateSeqId(f"Training request sequence number {seq_id} was reused for {model_id}")
         except Exception as e:
             logger.error(f"Failed to save future {request_id}: {e}")
             raise
         finally:
             conn.close()
+        return request_id
 
     def update_status(
         self,

--- a/training/storage/futures.py
+++ b/training/storage/futures.py
@@ -319,6 +319,21 @@ class FuturesStorage:
         finally:
             conn.close()
 
+    TRAINING_OPERATIONS = ("forward", "forward_backward", "optim_step")
+
+    def has_training_requests(self, model_id: str) -> bool:
+        """True once the model has seen any forward / forward_backward / optim_step."""
+        placeholders = ",".join("?" * len(self.TRAINING_OPERATIONS))
+        conn = sqlite3.connect(str(self.db_path))
+        try:
+            row = conn.execute(
+                f"SELECT 1 FROM futures WHERE model_id = ? AND operation IN ({placeholders}) LIMIT 1",
+                (model_id, *self.TRAINING_OPERATIONS),
+            ).fetchone()
+            return row is not None
+        finally:
+            conn.close()
+
     def cleanup_old_futures(self, max_age_hours: int = 24) -> int:
         """
         Remove futures older than specified age.

--- a/training/utils/helpers.py
+++ b/training/utils/helpers.py
@@ -260,34 +260,3 @@ def extract_learning_rates(optimizer: Optional[Any]) -> Dict[str, float]:
             learning_rates[lr_key] = float(param_group.get('lr', 0.0))
 
     return learning_rates
-
-
-def find_model_with_rollout_manager(training_clients: Dict[str, Dict[str, Any]]) -> Optional[str]:
-    """
-    Find first model capable of serving sampling requests.
-
-    Checks for:
-    1. Miles backend: has 'rollout_manager' (SGLang HTTP sampling)
-    2. NeMo RL backend: has 'backend_handle' with backend_type='nemo_rl' (vLLM Ray sampling)
-
-    Args:
-        training_clients: Dict of training client info
-
-    Returns:
-        Model ID if found, None otherwise
-    """
-    for model_id, client_info in training_clients.items():
-        if "rollout_manager" in client_info and client_info["rollout_manager"] is not None:
-            logger.debug(f"Found model with RolloutManager (Miles): {model_id}")
-            return model_id
-        handle = client_info.get("backend_handle")
-        if handle is not None and getattr(handle, "backend_type", None) == "nemo_rl":
-            logger.debug(f"Found model with NemoRL backend: {model_id}")
-            return model_id
-        # verl M2: handle carries its own rollout state (vLLM server replicas)
-        if handle is not None and getattr(handle, "has_rollout", False):
-            logger.debug(f"Found model with rollout-enabled handle: {model_id}")
-            return model_id
-
-    logger.warning("No model with RolloutManager or NemoRL backend found")
-    return None

--- a/training/utils/sglang_client.py
+++ b/training/utils/sglang_client.py
@@ -50,6 +50,7 @@ class SGLangClient:
                 - temperature: float (default 1.0, matching the API schema default)
                 - top_p: float (default 0.9)
                 - max_tokens: int (default 256)
+                - top_k: int, stop: list[str], stop_token_ids: list[int], seed: int
             prompt_logprobs: Whether to return prompt log probabilities
 
         Returns:
@@ -66,13 +67,23 @@ class SGLangClient:
         """
         # Build request payload
         sampling_params = sampling_params or {}
+        sgl_params: Dict[str, Any] = {
+            "temperature": sampling_params.get("temperature", 1.0),
+            "top_p": sampling_params.get("top_p", 0.9),
+            "max_new_tokens": sampling_params.get("max_tokens", 256),
+        }
+        # Every documented Tinker sampling parameter is forwarded, none dropped.
+        if sampling_params.get("top_k") is not None and int(sampling_params["top_k"]) > 0:
+            sgl_params["top_k"] = int(sampling_params["top_k"])
+        if sampling_params.get("stop"):
+            sgl_params["stop"] = list(sampling_params["stop"])
+        if sampling_params.get("stop_token_ids"):
+            sgl_params["stop_token_ids"] = [int(t) for t in sampling_params["stop_token_ids"]]
+        if sampling_params.get("seed") is not None:
+            sgl_params["sampling_seed"] = int(sampling_params["seed"])
         payload = {
             "input_ids": input_ids,
-            "sampling_params": {
-                "temperature": sampling_params.get("temperature", 1.0),
-                "top_p": sampling_params.get("top_p", 0.9),
-                "max_new_tokens": sampling_params.get("max_tokens", 256),
-            },
+            "sampling_params": sgl_params,
             "return_logprob": True,
         }
 

--- a/training/utils/sglang_client.py
+++ b/training/utils/sglang_client.py
@@ -128,34 +128,28 @@ class SGLangClient:
             output_logprobs = [item[0] for item in token_logprobs]
 
             # Build result
+            # finish_reason lives in meta_info as {"type": "stop"|"length", ...}
+            # (older builds: a top-level string).
+            finish = meta_info.get("finish_reason", sglang_output.get("finish_reason"))
+            finish_type = finish.get("type") if isinstance(finish, dict) else finish
             result = {
                 "tokens": output_tokens,
                 "logprobs": output_logprobs,
                 "text": sglang_output.get("text"),
-                "stop_reason": "stop" if sglang_output.get("finish_reason") == "stop" else "length"
+                "stop_reason": "stop" if finish_type == "stop" else "length",
             }
 
             # Extract prompt logprobs if requested
             if prompt_logprobs:
                 input_logprobs = meta_info.get("input_token_logprobs", [])
 
-                # Defensive handling: SGLang's input_token_logprobs format was undocumented
-                # and had a bug where it already includes None prefix.
-                # See CLAUDE.md -> "Logprobs None Handling" section.
-                #
-                # DPO Fix: train_dpo.py does logprobs[1:] to skip the first element.
-                # To ensure len(logprobs[1:]) == len(weights), we prepend an extra 0.0.
-                # Also replace any None values with 0.0 to avoid tensor creation errors.
-                # This way: SGLang returns N logprobs -> we return N+1 -> after [1:] we get N
-                normalized_logprobs = self._normalize_logprob_entries(input_logprobs)
-
-                # Replace None values with 0.0 to avoid "Could not infer dtype of NoneType"
-                # when train_dpo.py creates tensors from the logprobs
-                sanitized_logprobs = [0.0 if lp is None else lp for lp in normalized_logprobs]
-
-                # Prepend 0.0 for [1:] slice compensation in train_dpo.py
-                result["prompt_logprobs"] = [0.0] + sanitized_logprobs
-                logger.debug(f"Sanitized {len(normalized_logprobs)} logprobs, prepended 0.0 for DPO [1:] slice compensation")
+                # One entry per prompt token, position 0 = None (no logprob for
+                # the first token), matching the NeMo RL backend. SGLang has
+                # emitted the prompt entries with or without a leading None
+                # sentinel; normalise both to the same shape.
+                normalized = self._normalize_logprob_entries(input_logprobs)
+                tail = normalized[1:] if normalized and normalized[0] is None else normalized
+                result["prompt_logprobs"] = [None] + [0.0 if lp is None else lp for lp in tail]
 
             logger.debug(f"Generated {len(output_tokens)} tokens from SGLang")
             return result


### PR DESCRIPTION
Follows #48 (fake backend + `tests/protocol`). Six commits, one per group. Each group's protocol behaviour is covered by `tests/protocol` (34 tests, ~4 s, CPU-only, real `tinker` SDK against the fake backend) and was accepted live on the cluster on both backends where a backend was touched.

## Groups

1. **Loss registry** — `core/loss_registry.py`; unknown `loss_fn` or a `loss_fn_config` key the loss does not take is 400; `loss_fn_config` (previously dropped at the request model) reaches the backends; `TrainingBackend.SUPPORTED_LOSS_FNS` with an `UnsupportedFeatureError` before GPU work; NeMo RL builds its clipped-PG loss per step from the client's clip thresholds and reports them; Miles honours a clip range only when it equals the boot-time pair.
2. **Strict sampler routing** — a sampling request resolves to the model its sampler was minted from or to the `tinker://<model_id>/...` path; no fallback to the first model; `base_model`-only requests are 400.
3. **Sampling params** — Miles forwards `stop`, `stop_token_ids`, `top_k`, `seed` (+i per sample) to SGLang; NeMo RL carries every parameter as a per-row column (requires the paired nemo_rl worker change: GavinZhu-GMI/RL#2).
4. **Checkpoints** — `GET .../checkpoints` in the SDK's list shape; typed `DELETE`; `POST /load_weights` implemented, permitted only as a model's first request.
5. **Ordering + idempotency** — `services/ordering.py`: passes start in program order, barriers (optim_step, saves, load, unload) wait for completion; `seq_id` is unique per model, a retry returns the original request_id, a conflicting reuse is 400 (the SDK retries 409 for hours).
6. **One logprob per target** — Miles' RL and forward-only paths append the final target so both backends return T logprobs, entry k = logprob of target k; the final response token now receives a loss on Miles; SGLang prompt logprobs and `stop_reason` corrected; `SLIME_SGLANG_DETERMINISTIC=1` enables per-request seeds.

## Live acceptance

- nemo_rl (Qwen2.5-0.5B-Instruct, 4 GPUs): loss registry (default ppo reports 0.8/1.2, explicit 0.9/1.1 honoured, `dro` 400); sampling params (seed reproduces, per-row stop string and stop token, heterogeneous `max_tokens` 3/12 in one batch, `top_k=1`); pipelined fb+optim under the ordering layer; alignment probe: T-long logprobs, unshifted alignment beats either shift by 10x.
- miles (Qwen3-8B-Base, 4 GPUs): loss registry (mismatched clip refused naming the boot pair, `dro` 400); sampling params with deterministic inference (seed reproduces, stop string, stop token, heterogeneous batch, `top_k=1`); alignment probe: T-long on fb and forward, p50 3.1e-3 unshifted vs 0.37/0.38 shifted.
