### PR TITLE
Futures store: one SQLite connection, payload hash+size instead of the payload, bounded cache

### DIFF
--- a/scripts/pod_pytest.sh
+++ b/scripts/pod_pytest.sh
@@ -18,7 +18,7 @@ if [ $# -eq 0 ]; then
   set -- tests/protocol tests/test_ordering.py tests/test_backend_interface.py \
          tests/test_loss_registry.py tests/test_e0_registry.py tests/test_checkpoint_interchange.py \
          tests/test_validators.py tests/test_miles_rl_layout.py tests/test_optim_metrics_seam.py \
-         tests/test_miles_padding.py -q -p no:cacheprovider
+         tests/test_miles_padding.py tests/test_futures_storage.py -q -p no:cacheprovider
 fi
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 REMOTE="/tmp/pytest-${USER:-u}"

--- a/tests/test_futures_storage.py
+++ b/tests/test_futures_storage.py
@@ -1,0 +1,90 @@
+"""FuturesStorage: one connection, payload never persisted, seq_id idempotency, legacy rebuild."""
+import sqlite3
+
+import pytest
+
+from tinkercloud.training.storage.futures import DuplicateSeqId, FuturesStorage
+
+
+@pytest.fixture
+def store(tmp_path):
+    s = FuturesStorage(tmp_path / "futures.db")
+    yield s
+    s.close()
+
+
+def _payload(n):
+    return {"model_id": "m", "forward_backward_input": {"data": [{"tokens": list(range(n))}]}}
+
+
+def test_payload_not_persisted(store, tmp_path):
+    store.save_future("r1", "forward_backward", _payload(1000), model_id="m", seq_id=1)
+    row = sqlite3.connect(tmp_path / "futures.db").execute(
+        "SELECT payload_hash, payload_bytes FROM futures WHERE request_id='r1'").fetchone()
+    assert row[0] == FuturesStorage.payload_hash(_payload(1000))
+    assert 0 < row[1] < 10_000
+    cols = {r[1] for r in sqlite3.connect(tmp_path / "futures.db").execute("PRAGMA table_info(futures)")}
+    assert "payload" not in cols
+    assert "payload" not in store.get_future("r1")
+
+
+def test_seq_id_retry_and_conflict(store):
+    assert store.save_future("r1", "forward_backward", _payload(3), model_id="m", seq_id=7) == "r1"
+    # identical retry -> the original request_id, no second row
+    assert store.save_future("r2", "forward_backward", _payload(3), model_id="m", seq_id=7) == "r1"
+    assert store.get_future("r2") is None
+    with pytest.raises(DuplicateSeqId, match="different payload"):
+        store.save_future("r3", "forward_backward", _payload(4), model_id="m", seq_id=7)
+    with pytest.raises(DuplicateSeqId, match="different operation"):
+        store.save_future("r4", "optim_step", _payload(3), model_id="m", seq_id=7)
+    # seq_ids are per model
+    assert store.save_future("r5", "forward_backward", _payload(3), model_id="other", seq_id=7) == "r5"
+
+
+def test_status_roundtrip_and_stats(store):
+    store.save_future("r1", "optim_step", {}, model_id="m")
+    assert store.get_future("r1")["status"] == "pending"
+    assert store.update_status("r1", "completed", {"metrics": {"grad_norm": 1.0}})
+    fut = store.get_future("r1")
+    assert fut["status"] == "completed" and fut["result"] == {"metrics": {"grad_norm": 1.0}}
+    assert not store.update_status("nope", "failed", {"error": "x"})
+    assert store.get_stats()["completed"] == 1
+    assert store.has_training_requests("m") and not store.has_training_requests("other")
+
+
+def test_cache_is_bounded_and_falls_back_to_db(tmp_path):
+    s = FuturesStorage(tmp_path / "f.db", cache_size=4)
+    for i in range(10):
+        s.save_future(f"r{i}", "forward", {"i": i}, model_id="m")
+    assert s.get_stats()["in_memory"] == 4
+    assert s.get_future("r0")["status"] == "pending"          # evicted -> reloaded from SQLite
+    assert s.update_status("r1", "failed", {"error": "boom"})  # evicted -> updated via SQLite
+    assert s.get_future("r1")["result"] == {"error": "boom"}
+    s.close()
+
+
+def test_legacy_schema_is_rebuilt(tmp_path):
+    db = tmp_path / "futures.db"
+    conn = sqlite3.connect(db)
+    conn.execute("""CREATE TABLE futures (request_id TEXT PRIMARY KEY, model_id TEXT, operation TEXT NOT NULL,
+                    payload TEXT NOT NULL, status TEXT NOT NULL, result TEXT, created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL)""")
+    conn.execute("INSERT INTO futures VALUES ('old','m','forward','{}','pending',NULL,'t','t')")
+    conn.commit()
+    conn.close()
+    s = FuturesStorage(db)
+    assert s.get_future("old") is None
+    s.save_future("new", "forward", {}, model_id="m", seq_id=1)
+    assert s.get_future("new")["seq_id"] == 1
+    s.close()
+    # a second open of the new schema keeps its rows
+    s2 = FuturesStorage(db)
+    assert s2.get_future("new") is not None
+    s2.close()
+
+
+def test_cleanup(store):
+    store.save_future("r1", "forward", {}, model_id="m")
+    assert store.cleanup_old_futures(max_age_hours=24) == 0
+    assert store.cleanup_old_futures(max_age_hours=0) == 1
+    assert store.get_future("r1") is None

--- a/training/api.py
+++ b/training/api.py
@@ -201,6 +201,7 @@ def create_app(config: Optional[TrainingConfig] = None) -> FastAPI:
             await _free_model(application, model_id, reason="shutdown")
         if ray.is_initialized():
             ray.shutdown()
+        application.state.futures_storage.close()
 
     @application.exception_handler(DuplicateSeqId)
     async def duplicate_seq_id_handler(request: Request, exc: DuplicateSeqId):

--- a/training/storage/futures.py
+++ b/training/storage/futures.py
@@ -1,45 +1,45 @@
 """
-Futures storage module for managing async operations.
+Futures storage: the record of every async operation the server has accepted.
 
-This module provides a storage layer for tracking asynchronous operations
-in the training API, using SQLite for persistence and in-memory caching
-for performance.
+One SQLite connection for the process (WAL, guarded by a lock) instead of a
+fresh connection per call; the request payload is never persisted — only its
+sha256 and byte size, which is all seq_id idempotency needs. A bounded
+in-memory cache keeps the futures being polled cheap to read without
+retaining every result of a long run.
+
+Everything here is synchronous and cheap (point lookups on a warm
+connection); the router's long-poll awaits the operation's asyncio task
+directly, so nothing polls this table.
 """
 import hashlib
 import json
 import logging
 import sqlite3
+from collections import OrderedDict
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Any, Dict, Optional, List
 from threading import Lock
+from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
+_COLUMNS = ("request_id", "model_id", "operation", "status", "result",
+            "created_at", "updated_at", "seq_id", "payload_hash", "payload_bytes")
+
 
 def _serialize_result(result: Any) -> Optional[str]:
-    """
-    Serialize result to JSON, handling Pydantic models.
-
-    Args:
-        result: Result object to serialize (dict, Pydantic model, or None)
-
-    Returns:
-        JSON string or None
-    """
     if result is None:
         return None
+    return json.dumps(_as_plain(result))
 
-    # Handle Pydantic models (have model_dump or dict method)
-    if hasattr(result, 'model_dump'):
-        # Pydantic v2
-        return json.dumps(result.model_dump())
-    elif hasattr(result, 'dict'):
-        # Pydantic v1
-        return json.dumps(result.dict())
-    else:
-        # Plain dict or JSON-serializable object
-        return json.dumps(result)
+
+def _as_plain(result: Any) -> Any:
+    """Pydantic model -> dict; anything else unchanged."""
+    if hasattr(result, "model_dump"):
+        return result.model_dump()
+    if hasattr(result, "dict"):
+        return result.dict()
+    return result
 
 
 class DuplicateSeqId(ValueError):
@@ -47,89 +47,100 @@ class DuplicateSeqId(ValueError):
 
 
 class FuturesStorage:
-    """
-    Manages futures for async operations with SQLite persistence.
+    """Thread-safe futures store: SQLite of record, bounded memory cache in front."""
 
-    This class provides thread-safe storage for tracking async operations,
-    combining in-memory caching with SQLite persistence for reliability.
-    """
+    CACHE_SIZE = 512
+    TRAINING_OPERATIONS = ("forward", "forward_backward", "optim_step")
 
-    def __init__(self, db_path: Path):
-        """
-        Initialize futures storage with SQLite database.
-
-        Args:
-            db_path: Path to SQLite database file
-        """
+    def __init__(self, db_path: Path, cache_size: int = CACHE_SIZE):
         self.db_path = db_path
-        self._memory_store: Dict[str, Dict[str, Any]] = {}
+        self._cache: "OrderedDict[str, Dict[str, Any]]" = OrderedDict()
+        self._cache_size = cache_size
         self._lock = Lock()
+        self._conn = sqlite3.connect(str(db_path), check_same_thread=False, isolation_level=None)
+        self._conn.execute("PRAGMA journal_mode=WAL")
+        self._conn.execute("PRAGMA synchronous=NORMAL")
         self._init_database()
 
+    def close(self) -> None:
+        with self._lock:
+            self._conn.close()
+
+    # ------------------------------------------------------------------ schema
     def _init_database(self) -> None:
-        """Initialize SQLite database schema."""
-        conn = sqlite3.connect(str(self.db_path))
-        try:
-            cursor = conn.cursor()
-            cursor.execute("""
-                CREATE TABLE IF NOT EXISTS futures (
-                    request_id TEXT PRIMARY KEY,
-                    model_id TEXT,
-                    operation TEXT NOT NULL,
-                    payload TEXT NOT NULL,
-                    status TEXT NOT NULL,
-                    result TEXT,
-                    created_at TEXT NOT NULL,
-                    updated_at TEXT NOT NULL
-                )
-            """)
+        cur = self._conn
+        columns = {row[1] for row in cur.execute("PRAGMA table_info(futures)").fetchall()}
+        if columns and ("payload" in columns or "payload_bytes" not in columns):
+            # Legacy layout (full payload column). Rows never survive a server
+            # start (startup purges all futures), so rebuild rather than migrate.
+            logger.info("Rebuilding futures table at %s (legacy schema)", self.db_path)
+            cur.execute("DROP TABLE futures")
+        cur.execute("""
+            CREATE TABLE IF NOT EXISTS futures (
+                request_id TEXT PRIMARY KEY,
+                model_id TEXT,
+                operation TEXT NOT NULL,
+                status TEXT NOT NULL,
+                result TEXT,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                seq_id INTEGER,
+                payload_hash TEXT NOT NULL,
+                payload_bytes INTEGER NOT NULL
+            )
+        """)
+        cur.execute("CREATE INDEX IF NOT EXISTS idx_futures_status ON futures(status)")
+        cur.execute("CREATE INDEX IF NOT EXISTS idx_futures_created ON futures(created_at)")
+        cur.execute("CREATE INDEX IF NOT EXISTS idx_futures_model ON futures(model_id)")
+        cur.execute("""
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_futures_model_seq
+            ON futures(model_id, seq_id) WHERE seq_id IS NOT NULL
+        """)
+        logger.info("Initialized futures database at %s", self.db_path)
 
-            # Create indices for common queries
-            cursor.execute("""
-                CREATE INDEX IF NOT EXISTS idx_futures_status
-                ON futures(status)
-            """)
-            cursor.execute("""
-                CREATE INDEX IF NOT EXISTS idx_futures_created
-                ON futures(created_at)
-            """)
-            cursor.execute("""
-                CREATE INDEX IF NOT EXISTS idx_futures_model
-                ON futures(model_id)
-            """)
-            # seq_id idempotency (added later; migrate older files in place)
-            columns = {row[1] for row in cursor.execute("PRAGMA table_info(futures)").fetchall()}
-            if "seq_id" not in columns:
-                cursor.execute("ALTER TABLE futures ADD COLUMN seq_id INTEGER")
-            if "payload_hash" not in columns:
-                cursor.execute("ALTER TABLE futures ADD COLUMN payload_hash TEXT")
-            cursor.execute("""
-                CREATE UNIQUE INDEX IF NOT EXISTS idx_futures_model_seq
-                ON futures(model_id, seq_id) WHERE seq_id IS NOT NULL
-            """)
+    # ----------------------------------------------------------------- helpers
+    @staticmethod
+    def payload_digest(payload: Dict[str, Any]) -> "tuple[str, int]":
+        """(sha256, byte size) of the canonical JSON form of a request payload."""
+        raw = json.dumps(payload, sort_keys=True, default=str, separators=(",", ":")).encode()
+        return hashlib.sha256(raw).hexdigest(), len(raw)
 
-            conn.commit()
-            logger.info(f"Initialized futures database at {self.db_path}")
-        finally:
-            conn.close()
+    @classmethod
+    def payload_hash(cls, payload: Dict[str, Any]) -> str:
+        return cls.payload_digest(payload)[0]
 
     @staticmethod
-    def payload_hash(payload: Dict[str, Any]) -> str:
-        return hashlib.sha256(json.dumps(payload, sort_keys=True, default=str).encode()).hexdigest()
+    def _row_to_future(row: tuple) -> Dict[str, Any]:
+        fut = dict(zip(_COLUMNS, row))
+        fut["result"] = json.loads(fut["result"]) if fut["result"] else None
+        return fut
+
+    def _cache_put(self, fut: Dict[str, Any]) -> None:
+        # caller holds the lock
+        rid = fut["request_id"]
+        self._cache[rid] = fut
+        self._cache.move_to_end(rid)
+        while len(self._cache) > self._cache_size:
+            self._cache.popitem(last=False)
+
+    def _load(self, request_id: str) -> Optional[Dict[str, Any]]:
+        # caller holds the lock
+        row = self._conn.execute(
+            f"SELECT {', '.join(_COLUMNS)} FROM futures WHERE request_id = ?", (request_id,)
+        ).fetchone()
+        return self._row_to_future(row) if row else None
 
     def find_by_seq_id(self, model_id: str, seq_id: int) -> Optional[Dict[str, Any]]:
-        conn = sqlite3.connect(str(self.db_path))
-        try:
-            row = conn.execute(
+        with self._lock:
+            row = self._conn.execute(
                 "SELECT request_id, operation, payload_hash FROM futures WHERE model_id = ? AND seq_id = ?",
                 (model_id, seq_id),
             ).fetchone()
-        finally:
-            conn.close()
         if row is None:
             return None
         return {"request_id": row[0], "operation": row[1], "payload_hash": row[2]}
 
+    # --------------------------------------------------------------- lifecycle
     def save_future(
         self,
         request_id: str,
@@ -139,332 +150,115 @@ class FuturesStorage:
         seq_id: Optional[int] = None,
     ) -> str:
         """
-        Save a new future for an async operation.
+        Register a pending future.
 
-        With a `seq_id`, the pair (model_id, seq_id) is unique: a retry of the
-        same request returns the existing request_id (no new future); a
-        different operation or payload under a reused seq_id raises
-        DuplicateSeqId.
+        With a `seq_id`, (model_id, seq_id) is unique: a retry carrying the same
+        operation and payload returns the existing request_id; a different
+        operation or payload under a reused seq_id raises DuplicateSeqId.
 
-        Returns:
-            The request_id that owns this (model_id, seq_id): the given one, or
-            the earlier one on an idempotent retry.
+        Returns the request_id that owns this (model_id, seq_id).
         """
-        phash = self.payload_hash(payload)
-        if seq_id is not None and model_id is not None:
-            existing = self.find_by_seq_id(model_id, seq_id)
-            if existing is not None:
-                if existing["operation"] == operation and existing["payload_hash"] == phash:
-                    logger.info("[%s] retry of seq_id %s for %s -> %s", request_id, seq_id, model_id, existing["request_id"])
-                    return existing["request_id"]
-                raise DuplicateSeqId(
-                    f"Training request sequence number {seq_id} was reused for {model_id} "
-                    f"with a different {'operation' if existing['operation'] != operation else 'payload'}"
-                )
-        future_data = {
-            "request_id": request_id,
-            "model_id": model_id,
-            "operation": operation,
-            "payload": payload,
-            "status": "pending",
-            "result": None,
-            "created_at": datetime.utcnow().isoformat(),
-            "updated_at": datetime.utcnow().isoformat()
+        phash, pbytes = self.payload_digest(payload)
+        now = datetime.utcnow().isoformat()
+        fut = {
+            "request_id": request_id, "model_id": model_id, "operation": operation,
+            "status": "pending", "result": None, "created_at": now, "updated_at": now,
+            "seq_id": seq_id, "payload_hash": phash, "payload_bytes": pbytes,
         }
-
-        # Save to memory with thread safety
         with self._lock:
-            self._memory_store[request_id] = future_data
-
-        # Persist to SQLite
-        conn = sqlite3.connect(str(self.db_path))
-        try:
-            cursor = conn.cursor()
-            cursor.execute("""
-                INSERT OR REPLACE INTO futures
-                (request_id, model_id, operation, payload, status, result, created_at, updated_at, seq_id, payload_hash)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """, (
-                request_id,
-                model_id,
-                operation,
-                json.dumps(payload),
-                future_data["status"],
-                None,
-                future_data["created_at"],
-                future_data["updated_at"],
-                seq_id,
-                phash,
-            ))
-            conn.commit()
-        except sqlite3.IntegrityError:
-            # lost a race with a concurrent retry of the same seq_id
-            existing = self.find_by_seq_id(model_id, seq_id) if seq_id is not None else None
-            if existing and existing["operation"] == operation and existing["payload_hash"] == phash:
-                with self._lock:
-                    self._memory_store.pop(request_id, None)
-                return existing["request_id"]
-            raise DuplicateSeqId(f"Training request sequence number {seq_id} was reused for {model_id}")
-        except Exception as e:
-            logger.error(f"Failed to save future {request_id}: {e}")
-            raise
-        finally:
-            conn.close()
+            try:
+                self._conn.execute(
+                    f"INSERT INTO futures ({', '.join(_COLUMNS)}) VALUES ({', '.join('?' * len(_COLUMNS))})",
+                    tuple(fut[c] for c in _COLUMNS),
+                )
+            except sqlite3.IntegrityError:
+                row = None
+                if seq_id is not None and model_id is not None:
+                    row = self._conn.execute(
+                        "SELECT request_id, operation, payload_hash FROM futures WHERE model_id = ? AND seq_id = ?",
+                        (model_id, seq_id),
+                    ).fetchone()
+                if row and row[1] == operation and row[2] == phash:
+                    logger.info("[%s] retry of seq_id %s for %s -> %s", request_id, seq_id, model_id, row[0])
+                    return row[0]
+                if row:
+                    raise DuplicateSeqId(
+                        f"Training request sequence number {seq_id} was reused for {model_id} "
+                        f"with a different {'operation' if row[1] != operation else 'payload'}"
+                    ) from None
+                raise
+            self._cache_put(fut)
         return request_id
 
-    def update_status(
-        self,
-        request_id: str,
-        status: str,
-        result: Optional[Dict[str, Any]] = None
-    ) -> bool:
-        """
-        Update the status of an existing future.
-
-        Args:
-            request_id: Future identifier
-            status: New status ("pending", "completed", "failed")
-            result: Optional result data
-
-        Returns:
-            True if update successful, False if future not found
-        """
-        # Update in memory
+    def update_status(self, request_id: str, status: str, result: Optional[Any] = None) -> bool:
+        """Set a future's status (and result). False if the future is unknown."""
+        plain = _as_plain(result) if result is not None else None
+        now = datetime.utcnow().isoformat()
         with self._lock:
-            if request_id not in self._memory_store:
-                # Try to load from database
-                future = self._load_from_db(request_id)
-                if not future:
-                    logger.warning(f"Future {request_id} not found for update")
-                    return False
-                self._memory_store[request_id] = future
-
-            self._memory_store[request_id]["status"] = status
-            self._memory_store[request_id]["updated_at"] = datetime.utcnow().isoformat()
-            if result is not None:
-                # Convert Pydantic models to dict before storing in memory
-                if hasattr(result, 'model_dump'):
-                    self._memory_store[request_id]["result"] = result.model_dump()
-                elif hasattr(result, 'dict'):
-                    self._memory_store[request_id]["result"] = result.dict()
-                else:
-                    self._memory_store[request_id]["result"] = result
-
-            updated_at = self._memory_store[request_id]["updated_at"]
-
-        # Persist to SQLite
-        conn = sqlite3.connect(str(self.db_path))
-        try:
-            cursor = conn.cursor()
-            cursor.execute("""
-                UPDATE futures
-                SET status = ?, result = ?, updated_at = ?
-                WHERE request_id = ?
-            """, (
-                status,
-                _serialize_result(result),
-                updated_at,
-                request_id
-            ))
-            conn.commit()
-            return cursor.rowcount > 0
-        except Exception as e:
-            logger.error(f"Failed to update future {request_id}: {e}")
-            raise
-        finally:
-            conn.close()
+            cur = self._conn.execute(
+                "UPDATE futures SET status = ?, result = ?, updated_at = ? WHERE request_id = ?",
+                (status, json.dumps(plain) if plain is not None else None, now, request_id),
+            )
+            if cur.rowcount == 0:
+                logger.warning("Future %s not found for update", request_id)
+                return False
+            fut = self._cache.get(request_id) or self._load(request_id)
+            if fut is not None:
+                fut.update(status=status, updated_at=now)
+                if plain is not None:
+                    fut["result"] = plain
+                self._cache_put(fut)
+        return True
 
     def get_future(self, request_id: str) -> Optional[Dict[str, Any]]:
-        """
-        Retrieve a future by request ID.
-
-        Args:
-            request_id: Future identifier
-
-        Returns:
-            Future data dict or None if not found
-        """
-        # Check memory first
         with self._lock:
-            if request_id in self._memory_store:
-                return self._memory_store[request_id].copy()
+            fut = self._cache.get(request_id)
+            if fut is None:
+                fut = self._load(request_id)
+                if fut is not None:
+                    self._cache_put(fut)
+            return dict(fut) if fut is not None else None
 
-        # Fallback to database
-        future = self._load_from_db(request_id)
-        if future:
-            # Cache in memory for future access
-            with self._lock:
-                self._memory_store[request_id] = future
-        return future
-
-    def _load_from_db(self, request_id: str) -> Optional[Dict[str, Any]]:
-        """Load a future from the database."""
-        conn = sqlite3.connect(str(self.db_path))
-        try:
-            cursor = conn.cursor()
-            cursor.execute("""
-                SELECT request_id, model_id, operation, payload,
-                       status, result, created_at, updated_at
-                FROM futures
-                WHERE request_id = ?
-            """, (request_id,))
-            row = cursor.fetchone()
-
-            if row:
-                return {
-                    "request_id": row[0],
-                    "model_id": row[1],
-                    "operation": row[2],
-                    "payload": json.loads(row[3]),
-                    "status": row[4],
-                    "result": json.loads(row[5]) if row[5] else None,
-                    "created_at": row[6],
-                    "updated_at": row[7]
-                }
-            return None
-        finally:
-            conn.close()
-
-    def list_futures(
-        self,
-        model_id: Optional[str] = None,
-        status: Optional[str] = None,
-        limit: int = 100
-    ) -> List[Dict[str, Any]]:
-        """
-        List futures with optional filters.
-
-        Args:
-            model_id: Filter by model ID
-            status: Filter by status
-            limit: Maximum number of results
-
-        Returns:
-            List of future data dicts
-        """
-        query = "SELECT * FROM futures WHERE 1=1"
-        params = []
-
+    def list_futures(self, model_id: Optional[str] = None, status: Optional[str] = None,
+                     limit: int = 100) -> List[Dict[str, Any]]:
+        query = f"SELECT {', '.join(_COLUMNS)} FROM futures WHERE 1=1"
+        params: List[Any] = []
         if model_id:
             query += " AND model_id = ?"
             params.append(model_id)
-
         if status:
             query += " AND status = ?"
             params.append(status)
-
         query += " ORDER BY created_at DESC LIMIT ?"
         params.append(limit)
-
-        conn = sqlite3.connect(str(self.db_path))
-        try:
-            cursor = conn.cursor()
-            cursor.execute(query, params)
-
-            futures = []
-            for row in cursor.fetchall():
-                futures.append({
-                    "request_id": row[0],
-                    "model_id": row[1],
-                    "operation": row[2],
-                    "payload": json.loads(row[3]),
-                    "status": row[4],
-                    "result": json.loads(row[5]) if row[5] else None,
-                    "created_at": row[6],
-                    "updated_at": row[7]
-                })
-            return futures
-        finally:
-            conn.close()
-
-    TRAINING_OPERATIONS = ("forward", "forward_backward", "optim_step")
+        with self._lock:
+            rows = self._conn.execute(query, params).fetchall()
+        return [self._row_to_future(r) for r in rows]
 
     def has_training_requests(self, model_id: str) -> bool:
         """True once the model has seen any forward / forward_backward / optim_step."""
         placeholders = ",".join("?" * len(self.TRAINING_OPERATIONS))
-        conn = sqlite3.connect(str(self.db_path))
-        try:
-            row = conn.execute(
+        with self._lock:
+            row = self._conn.execute(
                 f"SELECT 1 FROM futures WHERE model_id = ? AND operation IN ({placeholders}) LIMIT 1",
                 (model_id, *self.TRAINING_OPERATIONS),
             ).fetchone()
-            return row is not None
-        finally:
-            conn.close()
+        return row is not None
 
     def cleanup_old_futures(self, max_age_hours: int = 24) -> int:
-        """
-        Remove futures older than specified age.
-
-        Args:
-            max_age_hours: Maximum age in hours
-
-        Returns:
-            Number of futures removed
-        """
-        cutoff_time = datetime.utcnow() - timedelta(hours=max_age_hours)
-        cutoff_str = cutoff_time.isoformat()
-
-        # Clean memory store
+        """Delete futures created more than `max_age_hours` ago; returns the count."""
+        cutoff = (datetime.utcnow() - timedelta(hours=max_age_hours)).isoformat()
         with self._lock:
-            to_remove = [
-                request_id
-                for request_id, future in self._memory_store.items()
-                if future["created_at"] < cutoff_str
-            ]
-            for request_id in to_remove:
-                del self._memory_store[request_id]
-            memory_removed = len(to_remove)
-
-        # Clean database
-        conn = sqlite3.connect(str(self.db_path))
-        try:
-            cursor = conn.cursor()
-            cursor.execute(
-                "DELETE FROM futures WHERE created_at < ?",
-                (cutoff_str,)
-            )
-            db_removed = cursor.rowcount
-            conn.commit()
-        finally:
-            conn.close()
-
-        total_removed = memory_removed + db_removed
-        if total_removed > 0:
-            logger.info(
-                f"Cleaned up {memory_removed} futures from memory "
-                f"and {db_removed} from database (older than {max_age_hours}h)"
-            )
-
-        return total_removed
+            for rid in [r for r, f in self._cache.items() if f["created_at"] < cutoff]:
+                del self._cache[rid]
+            removed = self._conn.execute("DELETE FROM futures WHERE created_at < ?", (cutoff,)).rowcount
+        if removed:
+            logger.info("Cleaned up %d futures older than %dh", removed, max_age_hours)
+        return removed
 
     def get_stats(self) -> Dict[str, int]:
-        """
-        Get storage statistics.
-
-        Returns:
-            Dict with counts by status and totals
-        """
-        conn = sqlite3.connect(str(self.db_path))
-        try:
-            cursor = conn.cursor()
-
-            # Count by status
-            cursor.execute("""
-                SELECT status, COUNT(*)
-                FROM futures
-                GROUP BY status
-            """)
-            stats = dict(cursor.fetchall())
-
-            # Total count
-            cursor.execute("SELECT COUNT(*) FROM futures")
-            stats["total"] = cursor.fetchone()[0]
-
-            # Memory store size
-            with self._lock:
-                stats["in_memory"] = len(self._memory_store)
-
-            return stats
-        finally:
-            conn.close()
+        with self._lock:
+            stats = dict(self._conn.execute("SELECT status, COUNT(*) FROM futures GROUP BY status").fetchall())
+            stats["total"] = self._conn.execute("SELECT COUNT(*) FROM futures").fetchone()[0]
+            stats["in_memory"] = len(self._cache)
+        return stats


### PR DESCRIPTION
FuturesStorage opened a fresh sqlite3 connection for every call, ran it on
the event loop, persisted the full request payload (the forward_backward
batch, serialized twice: once for the seq_id hash, once for the row) and
kept every future — payload and result — in an unbounded dict for the life
of the process.

Now: one connection per process (WAL, synchronous=NORMAL, lock-guarded),
the row stores payload_hash + payload_bytes only (all that idempotent
seq_id retries need), and the memory cache in front of SQLite is a bounded
LRU (512) so a long run's results are not retained twice. A legacy-layout
futures.db (payload column) is rebuilt at open; rows never survive a server
start anyway (startup purges all futures). The connection is closed at
shutdown.

The retrieve long-poll is unchanged: it awaits the operation's asyncio task
directly, so nothing polls this table; a poller would only add latency.

tests/test_futures_storage.py covers payload non-persistence, retry /
conflict semantics, cache bound with SQLite fallback, legacy rebuild, and
cleanup. Protocol + unit suites: 169 passed (tinkercloud-nemorl pod).

Stacked on #50; retarget to main once that merges.