### PR TITLE
Validate every async result against its response model before it is stored

### DIFF
--- a/scripts/pod_pytest.sh
+++ b/scripts/pod_pytest.sh
@@ -18,7 +18,7 @@ if [ $# -eq 0 ]; then
   set -- tests/protocol tests/test_ordering.py tests/test_backend_interface.py \
          tests/test_loss_registry.py tests/test_e0_registry.py tests/test_checkpoint_interchange.py \
          tests/test_validators.py tests/test_miles_rl_layout.py tests/test_optim_metrics_seam.py \
-         tests/test_miles_padding.py tests/test_futures_storage.py -q -p no:cacheprovider
+         tests/test_miles_padding.py tests/test_futures_storage.py tests/test_result_validation.py -q -p no:cacheprovider
 fi
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 REMOTE="/tmp/pytest-${USER:-u}"

--- a/tests/test_result_validation.py
+++ b/tests/test_result_validation.py
@@ -1,0 +1,64 @@
+"""Every async result is checked against its response model before it is stored."""
+import pytest
+
+from tinkercloud.training.models.responses import RESULT_MODELS, ResultShapeError, validate_result
+
+FB = {
+    "loss_fn_output_type": "cross_entropy",
+    "loss_fn_outputs": [{"logprobs": {"data": [-0.1, -0.2], "shape": [2], "dtype": "float32"}}],
+    "metrics": {"loss:mean": 0.15, "num_tokens:sum": 2},
+    "loss": 0.15,
+    "deferred": False,
+}
+
+
+def test_well_formed_results_round_trip_unchanged():
+    cases = {
+        "forward_backward": FB,
+        "forward": {**FB, "type": "forward"},
+        "optim_step": {"success": True, "grad_norm": 1.5, "learning_rates": [], "model_id": "m",
+                       "metrics": {"grad_norm": 1.5}, "weight_version": 3},
+        "create_model": {"model_id": "m", "base_model": "Qwen/x", "lora_config": {"rank": 8}, "status": "ready"},
+        "save_weights": {"path": "tinker://m/weights/s1", "checkpoint_path": "/data/x", "step_id": 1,
+                         "name": "s1", "type": "save_weights"},
+        "save_weights_for_sampler": {"path": None, "sampling_session_id": "ss1", "type": "save_weights_for_sampler"},
+        "load_weights": {"type": "load_weights", "path": "tinker://m/weights/s1", "model_id": "m"},
+        "sample": {"sequences": [{"stop_reason": "stop", "tokens": [1, 2], "logprobs": [-0.1, -0.2], "text": None}],
+                   "prompt_logprobs": None, "weight_version": None, "latest_weight_version": None},
+        "unload_model": {"model_id": "m", "type": "unload_model"},
+        "create_sampling_client": {"sampling_client_id": "sc", "model_path": "tinker://m", "status": "ready"},
+    }
+    assert set(cases) | {"asample"} == set(RESULT_MODELS)
+    for op, result in cases.items():
+        out = validate_result(op, result)
+        # coercion only: ints become floats in metrics, nothing added or dropped
+        assert set(out) == set(result), op
+        assert out == {**result, **({"metrics": {k: float(v) for k, v in result["metrics"].items()}}
+                                    if "metrics" in result else {})}, op
+
+
+def test_deferred_and_classification_shapes_pass():
+    validate_result("forward_backward", {"loss_fn_output_type": "ppo", "loss_fn_outputs": [],
+                                         "metrics": {}, "deferred": True, "loss": None})
+    validate_result("forward", {"loss_fn_output_type": "classification", "metrics": {},
+                                "loss_fn_outputs": [{"logits": {"data": [0.1, 0.9], "shape": [1, 2], "dtype": "float32"}}]})
+    validate_result("optim_step", {"metrics": {}, "loss_fn_outputs": [{"logprobs": {"data": [], "shape": [0], "dtype": "float32"}}]})
+    validate_result("sample", {"sequences": [{"stop_reason": "length", "tokens": []}]})  # logprobs optional
+
+
+@pytest.mark.parametrize("op,result,loc", [
+    ("forward_backward", {"loss_fn_outputs": [], "metrics": {}}, "loss_fn_output_type"),
+    ("forward_backward", {**FB, "loss_fn_outputs": [{"logprobs": [-0.1]}]}, "loss_fn_outputs.0.logprobs"),
+    ("forward_backward", {**FB, "metrics": {"note": "n/a"}}, "metrics.note"),
+    ("optim_step", {"metrics": {"grad_norm": [1.0]}}, "metrics.grad_norm"),
+    ("save_weights", {"checkpoint_path": "/data/x"}, "path"),
+    ("sample", {"sequences": [{"tokens": [1]}]}, "sequences.0.stop_reason"),
+    ("create_model", {"base_model": "Qwen/x"}, "model_id"),
+])
+def test_malformed_results_fail_naming_the_field(op, result, loc):
+    with pytest.raises(ResultShapeError, match=rf"{op} result does not match \w+: .*{loc}"):
+        validate_result(op, result)
+
+
+def test_unregistered_operation_passes_through():
+    assert validate_result("telemetry", {"anything": 1}) == {"anything": 1}

--- a/training/core/task_manager.py
+++ b/training/core/task_manager.py
@@ -17,6 +17,7 @@ import logging
 from typing import Callable, Dict, Any, Optional, Awaitable
 from ..storage import FuturesStorage
 from ..services import ordering
+from ..models.responses import validate_result
 
 logger = logging.getLogger(__name__)
 
@@ -120,7 +121,10 @@ class TaskManager:
                 else:
                     result = await task_func()
 
-                # Update storage with success
+                # A result that the operation's response model rejects fails
+                # the future here, with the offending field named, instead of
+                # failing inside the SDK's parser on the client.
+                result = validate_result(operation, result)
                 self.futures_storage.update_status(
                     request_id=request_id,
                     status="completed",

--- a/training/models/responses.py
+++ b/training/models/responses.py
@@ -4,9 +4,9 @@ Response models for the training API.
 This module defines Pydantic models for all API response payloads,
 providing structured responses and documentation.
 """
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Literal, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 
 class AsyncOperationResponse(BaseModel):
@@ -63,29 +63,61 @@ class TensorData(BaseModel):
     dtype: str = Field(default="float32", description="Data type")
 
 
-class LossFnOutput(BaseModel):
-    """Loss function output for a single sample."""
-
-    loss: TensorData = Field(..., description="Loss value")
-    logprobs: Optional[TensorData] = Field(default=None, description="Log probabilities")
+# Per-sample loss function output: named tensors ("logprobs", "logits", ...),
+# exactly the SDK's LossFnOutput = Dict[str, TensorData].
+LossFnOutput = Dict[str, TensorData]
 
 
-class ForwardBackwardResult(BaseModel):
-    """Result from forward-backward pass."""
+class _Result(BaseModel):
+    """Base for async-operation results: required fields are what the SDK
+    requires; backend-specific extras (deferred, weight_version, ...) pass through."""
+
+    model_config = ConfigDict(extra="allow")
+
+
+class ForwardBackwardResult(_Result):
+    """Result from forward-backward pass (SDK ForwardBackwardOutput)."""
 
     loss_fn_output_type: str = Field(..., description="Loss function type")
     loss_fn_outputs: List[LossFnOutput] = Field(..., description="Per-sample outputs")
     metrics: Dict[str, float] = Field(default_factory=dict, description="Training metrics")
-    logprobs: Optional[TensorData] = Field(default=None, description="Batch log probabilities")
 
 
-class OptimStepResult(BaseModel):
-    """Result from optimizer step (new format)."""
+class ForwardResult(ForwardBackwardResult):
+    """Forward pass result (same shape, type='forward')."""
+
+    type: str = Field(default="forward", description="Operation type")
+
+
+class OptimStepResult(_Result):
+    """Result from optimizer step (SDK OptimStepResponse)."""
+
+    metrics: Dict[str, float] = Field(default_factory=dict, description="Step metrics (grad_norm mirrored here)")
+    loss_fn_outputs: Optional[List[LossFnOutput]] = Field(
+        default=None, description="Per-sample outputs when the backend defers them to the step")
+    grad_norm: Optional[float] = Field(default=None, description="Gradient norm")
     success: bool = Field(default=True, description="Whether step succeeded")
-    grad_norm: float = Field(..., description="Gradient norm")
-    learning_rates: Dict[str, float] = Field(default_factory=dict, description="Learning rates per param group")
-    status: str = Field(default="completed", description="Operation status")
-    step_num: Optional[int] = Field(default=None, description="Step number")
+
+
+class CreateModelResult(_Result):
+    """Result from create_model (SDK CreateModelResponse)."""
+
+    model_id: str = Field(..., description="Model ID")
+    type: Literal["create_model"] = "create_model"
+
+
+class SaveWeightsResult(_Result):
+    """Result from save_weights (SDK SaveWeightsResponse)."""
+
+    path: str = Field(..., description="tinker:// URI of the checkpoint")
+    type: Literal["save_weights"] = "save_weights"
+
+
+class LoadWeightsResult(_Result):
+    """Result from load_weights (SDK LoadWeightsResponse)."""
+
+    path: Optional[str] = Field(default=None, description="Path that was loaded")
+    type: Literal["load_weights"] = "load_weights"
 
 
 class CheckpointInfo(BaseModel):
@@ -97,17 +129,17 @@ class CheckpointInfo(BaseModel):
     type: str = Field(default="save_weights", description="Checkpoint type")
 
 
-class SamplingSequence(BaseModel):
-    """Generated sequence from sampling."""
+class SamplingSequence(_Result):
+    """Generated sequence from sampling (SDK SampledSequence)."""
 
     stop_reason: str = Field(..., description="Reason for stopping: stop or length")
     tokens: List[int] = Field(..., description="Generated token IDs")
-    logprobs: List[float] = Field(..., description="Log probabilities")
+    logprobs: Optional[List[float]] = Field(default=None, description="Log probabilities")
     text: Optional[str] = Field(default=None, description="Decoded text")
 
 
-class SampleResult(BaseModel):
-    """Result from sampling operation."""
+class SampleResult(_Result):
+    """Result from sampling operation (SDK SampleResponse)."""
 
     sequences: List[SamplingSequence] = Field(..., description="Generated sequences")
     type: str = Field(default="sample", description="Operation type")
@@ -208,7 +240,7 @@ class DeleteModelResponse(BaseModel):
     resources_freed: List[str] = Field(default_factory=list, description="List of freed resources")
 
 
-class UnloadModelResponse(BaseModel):
+class UnloadModelResponse(_Result):
     """Unload model response (Tinker SDK compatible).
 
     This is the Tinker-standard response for releasing model resources.
@@ -240,26 +272,16 @@ class TrainingRunResponse(BaseModel):
     last_sampler_checkpoint: Optional[CheckpointMetadata] = Field(default=None, description="Latest sampler checkpoint")
 
 
-# ============= Forward/Training Responses =============
-
-class ForwardResult(BaseModel):
-    """Forward pass result."""
-    type: str = Field(default="forward", description="Operation type")
-    loss_fn_output_type: str = Field(..., description="Loss function type")
-    loss_fn_outputs: List[LossFnOutput] = Field(..., description="Per-sample outputs")
-    metrics: Dict[str, float] = Field(default_factory=dict, description="Training metrics")
-
-
 # ============= Sampling Responses =============
 
-class CreateSamplingClientResult(BaseModel):
+class CreateSamplingClientResult(_Result):
     """Create sampling client result."""
     sampling_client_id: str = Field(..., description="Sampling client ID")
     model_path: str = Field(..., description="Model path")
     status: str = Field(default="ready", description="Client status")
 
 
-class SaveWeightsForSamplerResult(BaseModel):
+class SaveWeightsForSamplerResult(_Result):
     """Save weights for sampler result."""
     type: str = Field(default="save_weights_for_sampler", description="Response type")
     path: Optional[str] = Field(default=None, description="Tinker URI path (for persistent saves)")
@@ -326,3 +348,41 @@ class WeightsInfoResponse(BaseModel):
     base_model: str = Field(..., description="Base model path")
     is_lora: bool = Field(..., description="Whether LoRA is enabled")
     lora_rank: Optional[int] = Field(default=None, description="LoRA rank if enabled")
+
+
+# ============= Result validation at the futures boundary =============
+
+# operation name (TaskManager) -> model a completed result must satisfy
+RESULT_MODELS: Dict[str, type] = {
+    "create_model": CreateModelResult,
+    "forward": ForwardResult,
+    "forward_backward": ForwardBackwardResult,
+    "optim_step": OptimStepResult,
+    "save_weights": SaveWeightsResult,
+    "save_weights_for_sampler": SaveWeightsForSamplerResult,
+    "load_weights": LoadWeightsResult,
+    "sample": SampleResult,
+    "asample": SampleResult,
+    "create_sampling_client": CreateSamplingClientResult,
+    "unload_model": UnloadModelResponse,
+}
+
+
+class ResultShapeError(ValueError):
+    """A backend/service returned a result the operation's response model rejects."""
+
+
+def validate_result(operation: str, result: Any) -> Dict[str, Any]:
+    """Check `result` against the operation's response model and return it as a
+    plain dict. Only fields present in the input (plus coercions) are emitted,
+    so the wire shape is unchanged for a well-formed result. Operations without
+    a registered model pass through untouched."""
+    model = RESULT_MODELS.get(operation)
+    if model is None:
+        return result
+    try:
+        parsed = model.model_validate(result)
+    except ValidationError as e:
+        errs = "; ".join(f"{'.'.join(str(x) for x in err['loc']) or '<root>'}: {err['msg']}" for err in e.errors()[:5])
+        raise ResultShapeError(f"{operation} result does not match {model.__name__}: {errs}") from None
+    return parsed.model_dump(exclude_unset=True)


### PR DESCRIPTION
The response models were never enforced, and two of them could not have
been: LossFnOutput required a `loss` tensor no backend emits (the SDK's
LossFnOutput is Dict[str, TensorData]), and OptimStepResult typed
learning_rates as a dict where backends return a list. A malformed result
therefore surfaced as a parse error inside the client's SDK.

Now the models mirror what the SDK requires (ForwardBackwardOutput,
OptimStepResponse, SampledSequence with optional logprobs, CreateModel /
SaveWeights / LoadWeights / UnloadModel responses) and allow backend
extras (deferred, weight_version, ...). TaskManager runs
validate_result(operation, result) before marking a future completed; a
rejected result fails the future naming the field
("forward_backward result does not match ForwardBackwardResult:
loss_fn_outputs.0.logprobs: ..."). Dumped with exclude_unset, so a
well-formed result crosses the wire unchanged apart from int->float
coercion in metrics.

Cost (tinkercloud-nemorl pod): 8 ms at 262k logprobs, 38 ms at 1M — about
a quarter of the json.dumps the store already performs on the same result.

tests/test_result_validation.py: round-trip of every registered
operation's shape, deferred / classification shapes, seven malformed cases.
Protocol + unit suites: 179 passed.

Stacked on #51.