### PR TITLE
Honour weights-only vs with-optimizer resume on every backend

### DIFF
--- a/tests/protocol/test_checkpoints.py
+++ b/tests/protocol/test_checkpoints.py
@@ -62,3 +62,47 @@ def test_load_weights_first_request_rule(service_client, server):
     assert r.status_code in (400, 404)
     r = server.post("/api/v1/load_weights", {"model_id": "model_missing", "path": p, "optimizer": False})
     assert r.status_code == 404
+
+
+def test_load_weights_honours_the_optimizer_flag(service_client, server):
+    """weights-only leaves the optimizer fresh; with-optimizer restores it; a
+    checkpoint without optimizer state refuses rather than partially resumes.
+    The fake backend's optimizer state is its step counter, reported as grad_norm."""
+    src = service_client.create_lora_training_client(base_model="fake/tiny", rank=2)
+    for _ in range(2):
+        src.forward_backward([make_datum([1, 2, 3])], "cross_entropy")
+        src.optim_step(types.AdamParams(learning_rate=0.5)).result()
+    p = src.save_state("opt").result().path  # w = 1.0, step_count = 2
+
+    def load(model_id, optimizer, seq_id=1001):  # clear of the SDK's own seq_ids
+        r = server.post("/api/v1/load_weights", {"model_id": model_id, "path": p, "optimizer": optimizer, "seq_id": seq_id})
+        assert r.status_code == 200, r.text
+        return server.post("/api/v1/retrieve_future", {"request_id": r.json()["request_id"]}, timeout=60)
+
+    weights_only = service_client.create_lora_training_client(base_model="fake/tiny", rank=2)
+    assert load(weights_only.model_id, False).status_code == 200
+    op = weights_only.optim_step(types.AdamParams(learning_rate=0.0)).result()
+    assert op.metrics["fake_w"] == 1.0 and op.metrics["grad_norm"] == 1.0  # first step of a fresh optimizer
+
+    resumed = service_client.create_lora_training_client(base_model="fake/tiny", rank=2)
+    assert load(resumed.model_id, True).status_code == 200
+    op = resumed.optim_step(types.AdamParams(learning_rate=0.0)).result()
+    assert op.metrics["fake_w"] == 1.0 and op.metrics["grad_norm"] == 3.0  # continues from step 2
+
+    # the SDK's two resume constructors map onto the two flags
+    assert service_client.create_training_client_from_state(p).optim_step(
+        types.AdamParams(learning_rate=0.0)).result().metrics["grad_norm"] == 1.0
+    assert service_client.create_training_client_from_state_with_optimizer(p).optim_step(
+        types.AdamParams(learning_rate=0.0)).result().metrics["grad_norm"] == 3.0
+
+    # a checkpoint that carries no optimizer state: weights-only fine, with-optimizer refused
+    import json
+    state = server.checkpoint_base / src.model_id / "opt" / "fake_state.json"
+    st = json.loads(state.read_text())
+    st.pop("optimizer")
+    state.write_text(json.dumps(st))
+    fresh = service_client.create_lora_training_client(base_model="fake/tiny", rank=2)
+    fut = load(fresh.model_id, True)
+    assert fut.status_code == 400 and "no optimizer state" in fut.text, fut.text
+    fresh2 = service_client.create_lora_training_client(base_model="fake/tiny", rank=2)
+    assert load(fresh2.model_id, False).status_code == 200

--- a/tests/test_miles_resume_args.py
+++ b/tests/test_miles_resume_args.py
@@ -1,0 +1,34 @@
+"""create_model(checkpoint_path) on Miles is a weights-only load: the builder
+must pair Megatron's --load with --no-load-optim / --no-load-rng / --finetune,
+or the resume silently restores optimizer state (a full resume is
+load_weights(optimizer=true), which goes through the train group instead)."""
+from argparse import Namespace
+
+import pytest
+
+from test_miles_pack_length import MODEL_CONFIG, _load_builder_module
+
+
+@pytest.fixture(scope="module")
+def builder_mod():
+    return _load_builder_module()
+
+
+def _configure(builder_mod, checkpoint_path):
+    b = builder_mod.MilesArgumentBuilder(default_save_dir="/tmp/ckpt")
+    return b._configure_model_args(
+        Namespace(), base_model="/tmp/model", megatron_checkpoint_path="/tmp/mcore",
+        lora_config={"rank": 8}, debug_train_only=False, checkpoint_path=checkpoint_path,
+        model_config=MODEL_CONFIG, parallel_config={"tp": 1, "pp": 1, "cp": 1},
+    )
+
+
+def test_checkpoint_path_at_create_is_weights_only(builder_mod):
+    args = _configure(builder_mod, "/tmp/ckpt/run/weights/x")
+    assert args.load == "/tmp/ckpt/run/weights/x"
+    assert args.no_load_optim is True and args.no_load_rng is True and args.finetune is True
+
+
+def test_no_checkpoint_path_sets_no_load(builder_mod):
+    args = _configure(builder_mod, None)
+    assert not getattr(args, "load", None)

--- a/training/backends/automodel/backend.py
+++ b/training/backends/automodel/backend.py
@@ -325,10 +325,13 @@ class AutomodelBackend(TrainingBackend):
         return path
 
     async def load_checkpoint(
-        self, handle: BackendHandle, checkpoint_path: str,
+        self, handle: BackendHandle, checkpoint_path: str, optimizer: bool = False,
     ) -> None:
         import asyncio
         h: AutomodelHandle = handle  # type: ignore[assignment]
+        if optimizer:
+            raise BackendError("automodel restores adapter weights only; optimizer state is not restored",
+                               backend="automodel", operation="load_checkpoint")
         await asyncio.to_thread(self._load_adapter, h, checkpoint_path)
         logger.info("Automodel checkpoint loaded: %s", checkpoint_path)
 

--- a/training/backends/base.py
+++ b/training/backends/base.py
@@ -240,9 +240,18 @@ class TrainingBackend(ABC):
         self,
         handle: BackendHandle,
         checkpoint_path: str,
+        optimizer: bool = False,
     ) -> None:
         """
-        Load model weights from a checkpoint.
+        Load a checkpoint into a live model.
+
+        `optimizer=False` restores weights only and leaves the model's optimizer
+        state as it is (fresh on a model that has not trained). `optimizer=True`
+        also restores the optimizer state the checkpoint carries, and MUST raise
+        BackendError when the checkpoint has none or the backend cannot restore
+        it: never a silent partial resume. create_model(checkpoint_path=...) is
+        the weights-only load; save_checkpoint writes optimizer state wherever
+        the backend can.
 
         After loading, syncs weights to the inference engine via
         update_inference_weights / refit_policy_generation.
@@ -250,9 +259,11 @@ class TrainingBackend(ABC):
         Args:
             handle: Backend handle returned by create_model.
             checkpoint_path: Path to the checkpoint directory.
+            optimizer: Also restore optimizer state.
 
         Raises:
-            BackendError: If checkpoint loading fails.
+            BackendError: If checkpoint loading fails, or optimizer state was
+                requested and is unavailable.
         """
         ...
 

--- a/training/backends/fake/backend.py
+++ b/training/backends/fake/backend.py
@@ -218,11 +218,12 @@ class FakeBackend(TrainingBackend):
         root = resolve_checkpoint_root(checkpoint_path, create=True)
         with open(os.path.join(root, STATE_FILE), "w") as f:
             json.dump({"w": h.w, "weight_version": h.weight_version, "base_model": h.base_model,
-                       "lora_config": h.lora_config, "step_id": step_id}, f)
+                       "lora_config": h.lora_config, "step_id": step_id,
+                       "optimizer": {"step_count": h.step_count}}, f)
         self._trace("save_checkpoint", h.model_id, checkpoint_path=checkpoint_path, root=root, step_id=step_id)
         return checkpoint_path
 
-    def _load_into(self, h: FakeHandle, checkpoint_path: str) -> None:
+    def _load_into(self, h: FakeHandle, checkpoint_path: str, optimizer: bool = False) -> None:
         root = resolve_checkpoint_root(checkpoint_path)
         path = os.path.join(root, STATE_FILE)
         if not os.path.exists(path):
@@ -230,10 +231,16 @@ class FakeBackend(TrainingBackend):
                                backend="fake", operation="load_checkpoint")
         with open(path) as f:
             st = json.load(f)
+        if optimizer and "optimizer" not in st:
+            raise BackendError(f"Checkpoint {checkpoint_path} carries no optimizer state",
+                               backend="fake", operation="load_checkpoint")
         h.w = st["w"]
         h.weight_version = st["weight_version"]
+        if optimizer:
+            h.step_count = st["optimizer"]["step_count"]
 
-    async def load_checkpoint(self, handle: BackendHandle, checkpoint_path: str) -> None:
+    async def load_checkpoint(self, handle: BackendHandle, checkpoint_path: str,
+                              optimizer: bool = False) -> None:
         h = self._handle(handle, "load_checkpoint")
-        self._load_into(h, checkpoint_path)
-        self._trace("load_checkpoint", h.model_id, checkpoint_path=checkpoint_path)
+        self._load_into(h, checkpoint_path, optimizer=optimizer)
+        self._trace("load_checkpoint", h.model_id, checkpoint_path=checkpoint_path, optimizer=optimizer)

--- a/training/backends/megatron_bridge/backend.py
+++ b/training/backends/megatron_bridge/backend.py
@@ -185,10 +185,11 @@ class MegatronBridgeBackend(TrainingBackend):
             raise BackendError(f"save_checkpoint failed: {e!r}",
                                backend="megatron_bridge", operation="save_checkpoint")
 
-    async def load_checkpoint(self, handle: BackendHandle, checkpoint_path: str) -> None:
+    async def load_checkpoint(self, handle: BackendHandle, checkpoint_path: str,
+                              optimizer: bool = False) -> None:
         h: MegatronBridgeHandle = handle  # type: ignore[assignment]
         try:
-            await _get(h.worker.load_checkpoint.remote(checkpoint_path))
+            await _get(h.worker.load_checkpoint.remote(checkpoint_path, optimizer))
         except Exception as e:
             raise BackendError(f"load_checkpoint failed: {e!r}",
                                backend="megatron_bridge", operation="load_checkpoint")

--- a/training/backends/megatron_bridge/worker.py
+++ b/training/backends/megatron_bridge/worker.py
@@ -148,7 +148,9 @@ class MegatronBridgeWorker:
               opt_param_scheduler=self.scheduler, num_floating_point_operations_so_far=0)
         return checkpoint_path
 
-    def load_checkpoint(self, checkpoint_path: str) -> None:
+    def load_checkpoint(self, checkpoint_path: str, optimizer: bool = False) -> None:
         from megatron.bridge.training.checkpointing import load_checkpoint as _load
-        _load(state=self.state, model=self.model, optimizer=self.optimizer,
-              opt_param_scheduler=self.scheduler, checkpoint_path=checkpoint_path)
+        _load(state=self.state, model=self.model,
+              optimizer=self.optimizer if optimizer else None,
+              opt_param_scheduler=self.scheduler if optimizer else None,
+              checkpoint_path=checkpoint_path)

--- a/training/backends/miles/backend.py
+++ b/training/backends/miles/backend.py
@@ -1231,6 +1231,7 @@ class MilesBackend(TrainingBackend):
         self,
         handle: BackendHandle,
         checkpoint_path: str,
+        optimizer: bool = False,
     ) -> None:
         h: MilesHandle = handle  # type: ignore[assignment]
         if h.adapter_slot is not None:
@@ -1243,7 +1244,7 @@ class MilesBackend(TrainingBackend):
             )
         await h.lock.acquire()
         try:
-            await h.train_group.load_checkpoint(checkpoint_path)
+            await h.train_group.load_checkpoint(checkpoint_path, load_optimizer=optimizer)
             h.created_from_checkpoint = True
 
             # Sync loaded weights to inference engine

--- a/training/backends/miles/builder.py
+++ b/training/backends/miles/builder.py
@@ -414,9 +414,14 @@ class MilesArgumentBuilder(ArgumentBuilder):
         args.ref_load = megatron_checkpoint_path
         args.save = self.default_save_dir
 
-        # Handle checkpoint resume
+        # create_model(checkpoint_path) is a weights-only load by contract: a
+        # fresh optimizer, RNG and iteration count. Without these Megatron's
+        # --load is a full resume. load_weights(optimizer=true) is the resume path.
         if checkpoint_path:
             args.load = parse_checkpoint_uri(checkpoint_path, args.save)
+            args.no_load_optim = True
+            args.no_load_rng = True
+            args.finetune = True
 
         # LoRA configuration. alpha defaults to rank per the API schema
         # (requests.py LoraConfig); alpha=0 zeroes LoRA scaling and gradients

--- a/training/backends/nemo_rl/backend.py
+++ b/training/backends/nemo_rl/backend.py
@@ -759,10 +759,12 @@ class NemoRLBackend(TrainingBackend):
                 "save_consolidated": False,
             })
 
+            # Optimizer state rides beside the weights so load_weights(optimizer=true)
+            # can restore it; LoRA moments are small.
             await asyncio.to_thread(
                 h.policy.save_checkpoint,
                 weights_path=weights_path,
-                optimizer_path=None,
+                optimizer_path=f"{local_path}/optimizer",
                 checkpointing_cfg=checkpointing_cfg,
             )
 
@@ -784,23 +786,27 @@ class NemoRLBackend(TrainingBackend):
         self,
         handle: BackendHandle,
         checkpoint_path: str,
+        optimizer: bool = False,
     ) -> None:
-        """Load checkpoint weights into policy, then sync to inference engine."""
+        """Load checkpoint weights (and, on request, optimizer state) into the
+        policy workers, then sync to the inference engine."""
         import os
 
         h: NemoRLHandle = handle  # type: ignore[assignment]
         try:
             local_path = _resolve_checkpoint_path(checkpoint_path)
             weights_path = _stage_foreign_adapter(local_path)
-            optimizer_path = f"{local_path}/optimizer"
-            # Only load optimizer state if it exists (checkpoint may be weights-only)
-            if not os.path.exists(optimizer_path):
-                optimizer_path = None
+            optimizer_path = None
+            if optimizer:
+                optimizer_path = f"{local_path}/optimizer"
+                if not os.path.isdir(optimizer_path):
+                    raise BackendError(
+                        f"Checkpoint {checkpoint_path} carries no optimizer state",
+                        backend="nemo_rl", operation="load_checkpoint",
+                    )
 
             await asyncio.to_thread(
-                h.policy.load_checkpoint,
-                weights_path=weights_path,
-                optimizer_path=optimizer_path,
+                _policy_load_checkpoint, h.policy, weights_path, optimizer_path,
             )
             h.training_resident = False  # loaded state may not be GPU-resident
 
@@ -818,6 +824,8 @@ class NemoRLBackend(TrainingBackend):
 
             logger.info("NeMo RL checkpoint loaded from %s", checkpoint_path)
 
+        except BackendError:
+            raise
         except Exception as e:
             raise BackendError(
                 str(e), backend="nemo_rl", operation="load_checkpoint", original_error=e,
@@ -1088,6 +1096,15 @@ def _resolve_checkpoint_path(path: str) -> str:
     """tinker://<run_id>/weights/<name> -> /data/checkpoints/<run_id>/<name>."""
     return resolve_checkpoint_root(path, create=True)
 
+
+
+def _policy_load_checkpoint(policy, weights_path: str, optimizer_path: Optional[str]) -> None:
+    """Policy exposes save_checkpoint but no load; fan the workers' load_checkpoint
+    out the same way (optimizer_path None = weights only)."""
+    import ray
+    ray.get(policy.worker_group.run_all_workers_single_data(
+        "load_checkpoint", weights_path=weights_path, optimizer_path=optimizer_path,
+    ))
 
 def _stage_foreign_adapter(local_path: str) -> str:
     """Return the weights_path to load, materializing an interchange adapter

--- a/training/backends/verl/backend.py
+++ b/training/backends/verl/backend.py
@@ -325,8 +325,12 @@ class VerlBackend(TrainingBackend):
             except Exception as e:
                 raise BackendError(str(e), backend="verl", operation="save_checkpoint", original_error=e) from e
 
-    async def load_checkpoint(self, handle: BackendHandle, checkpoint_path: str) -> None:
+    async def load_checkpoint(self, handle: BackendHandle, checkpoint_path: str,
+                              optimizer: bool = False) -> None:
         h: VerlHandle = handle  # type: ignore[assignment]
+        if optimizer:
+            raise BackendError("verl restores weights only; optimizer state is not restored",
+                               backend="verl", operation="load_checkpoint")
         async with h._lock:
             try:
                 await self._quiesce_samplers(h)

--- a/training/models/requests.py
+++ b/training/models/requests.py
@@ -162,7 +162,7 @@ class LoadWeightsRequest(BaseModel):
 
     model_id: str = Field(..., description="Model ID")
     path: str = Field(..., description="tinker://<run>/weights/<name> to load from")
-    optimizer: bool = Field(default=False, description="Also restore optimizer state (not supported; must be false)")
+    optimizer: bool = Field(default=False, description="Also restore optimizer state (the checkpoint must carry it)")
     seq_id: Optional[int] = Field(default=None, description="Sequence ID for ordering")
 
 

--- a/training/routers/checkpoints.py
+++ b/training/routers/checkpoints.py
@@ -218,12 +218,12 @@ async def load_weights(
 
     Permitted only as the model's first request (before any forward /
     forward_backward / optim_step), matching the Tinker service; later loads
-    belong in a fresh model created with checkpoint_path.
+    belong in a fresh model created with checkpoint_path. `optimizer=false`
+    restores weights only; `optimizer=true` also restores optimizer state and
+    fails the future when the checkpoint or backend cannot provide it.
     """
     if request.model_id not in training_clients:
         raise HTTPException(status_code=404, detail=f"Model {request.model_id} not found")
-    if request.optimizer:
-        raise HTTPException(status_code=400, detail="load_weights with optimizer=true is not supported")
     if futures_storage.has_training_requests(request.model_id):
         raise HTTPException(
             status_code=400,
@@ -240,6 +240,7 @@ async def load_weights(
     async def execute():
         return await service.load_weights(
             model_id=request.model_id, request_id=request_id, path=request.path,
+            optimizer=request.optimizer,
             training_clients=training_clients, metadata_storage=metadata_storage,
         )
 

--- a/training/services/checkpoint_service.py
+++ b/training/services/checkpoint_service.py
@@ -92,13 +92,16 @@ class CheckpointService:
         path: str,
         training_clients: Dict[str, Dict[str, Any]],
         metadata_storage: MetadataStorage,
+        optimizer: bool = False,
     ) -> Dict[str, Any]:
-        """Load a training checkpoint into a live model (weights only)."""
+        """Load a training checkpoint into a live model: weights, plus optimizer
+        state when asked (the backend refuses rather than partially resumes)."""
         if model_id not in training_clients:
             raise KeyError(f"Model {model_id} not found")
         handle = training_clients[model_id]["backend_handle"]
-        logger.info("[%s] Loading weights for %s from %s", request_id, model_id, path)
-        await self.backend.load_checkpoint(handle, path)
+        logger.info("[%s] Loading %s for %s from %s", request_id,
+                    "weights + optimizer state" if optimizer else "weights", model_id, path)
+        await self.backend.load_checkpoint(handle, path, optimizer=optimizer)
         metadata_storage.update_training_run(
             training_clients[model_id].get("training_run_id", model_id),
             {"loaded_from": path, "last_request_time": datetime.now().isoformat()},


### PR DESCRIPTION
`load_weights(optimizer=false)` restores weights only; `optimizer=true` also restores the optimizer state the checkpoint carries and **fails the future** when the checkpoint has none or the backend cannot restore it, instead of resuming partially. `create_model(checkpoint_path)` is the weights-only load. `save_weights` writes optimizer state wherever the backend can.

Before this the distinction held nowhere: Miles' create-with-checkpoint set Megatron `--load` without `--no-load-optim`, so a "weights-only" resume restored Adam moments; NeMo RL never saved optimizer state, and its loader called a `Policy.load_checkpoint` that does not exist; `load_weights` with `optimizer=true` was a 400 on every backend, so the SDK's with-optimizer constructor was quietly the same call as the weights-only one.

- `TrainingBackend.load_checkpoint(handle, path, optimizer=False)` carries the contract in its docstring.
- Fake: the step counter is the optimizer state (`grad_norm` reports it), saved beside `w`, restored only on request.
- NeMo RL: save passes `optimizer_path=<ckpt>/optimizer`; load fans the workers' `load_checkpoint` out through the worker group (weights only, or with the optimizer dir, which must exist).
- Miles: the builder pairs `--load` with `--no-load-optim` / `--no-load-rng` / `--finetune` at create; load passes `load_optimizer` to `TinkerTrainGroup.load_checkpoint` (miles fork main 1ee8c51, GavinZhu-GMI/miles#8).
- verl and automodel refuse `optimizer=true`; megatron_bridge passes the optimizer and scheduler to the bridge loader only when asked.
- Router: the 400 on `optimizer=true` is gone; the flag reaches the service and the backend.

Tests: `tests/protocol/test_checkpoints.py` exercises both flags, the refusal on a checkpoint without optimizer state, and both SDK resume constructors (`grad_norm` 1.0 after weights-only, 3.0 after a full resume); `tests/test_miles_resume_args.py` pins the builder's no-load flags. On the pod: 93 unit tests and 44 protocol tests pass with an SDK that uses upstream's create + `load_state` flow (GMISWE/tinker_gmi#4); with the previous fork SDK the with-optimizer assertion fails (1.0 == 3.0), which is the defect this fixes.
