### PR TITLE
Miles load_checkpoint: resolve the tinker:// URI to Megatron's --load directory

### DIFF
--- a/tests/test_miles_load_path.py
+++ b/tests/test_miles_load_path.py
@@ -1,0 +1,24 @@
+"""load_weights on Miles hands the actors a Megatron --load directory, resolved
+from the tinker:// URI the same way create_model(checkpoint_path) resolves it;
+the raw URI used to reach the actors and fail their directory check."""
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from tinkercloud.training.backends.miles.backend import MilesBackend
+from tinkercloud.training.backends.miles.model_setup import parse_checkpoint_uri
+
+
+@pytest.mark.parametrize("optimizer", [False, True])
+def test_load_checkpoint_resolves_uri_and_passes_the_flag(optimizer):
+    backend = MilesBackend()
+    h = SimpleNamespace(
+        adapter_slot=None, lock=asyncio.Lock(), rollout_manager=None, created_from_checkpoint=False,
+        args=SimpleNamespace(save="/tmp/save"), train_group=SimpleNamespace(load_checkpoint=AsyncMock()),
+    )
+    asyncio.run(backend.load_checkpoint(h, "tinker://model_a/weights/resume", optimizer=optimizer))
+    h.train_group.load_checkpoint.assert_awaited_once_with(
+        parse_checkpoint_uri("tinker://model_a/weights/resume", "/tmp/save"), load_optimizer=optimizer)
+    assert h.created_from_checkpoint is True

--- a/training/backends/miles/backend.py
+++ b/training/backends/miles/backend.py
@@ -24,6 +24,7 @@ from ..checkpoint_interchange import (
     export_hf_adapter,
     resolve_checkpoint_root,
 )
+from .model_setup import parse_checkpoint_uri
 
 logger = logging.getLogger(__name__)
 
@@ -1244,7 +1245,10 @@ class MilesBackend(TrainingBackend):
             )
         await h.lock.acquire()
         try:
-            await h.train_group.load_checkpoint(checkpoint_path, load_optimizer=optimizer)
+            # The actors take Megatron's --load directory, not the tinker:// URI;
+            # resolve it the way the builder does for create_model(checkpoint_path).
+            load_dir = parse_checkpoint_uri(checkpoint_path, h.args.save)
+            await h.train_group.load_checkpoint(load_dir, load_optimizer=optimizer)
             h.created_from_checkpoint = True
 
             # Sync loaded weights to inference engine


### PR DESCRIPTION
The actors' `load_checkpoint` takes the directory Megatron loads from, but `load_weights` handed them the raw `tinker://` URI, which their directory check rejected (`args.load='tinker://…' does not exist`); `create_model(checkpoint_path)` never hit this because the builder resolves the URI into `args.load`. Resolve it the same way (`parse_checkpoint_uri` against the model's save root) before the broadcast. `tests/test_miles_load_path.py` pins the resolved path and the optimizer flag reaching the train group. Found by the resume acceptance on `tinkercloud-miles8`.