### PR TITLE
Resume on live backends: GPU-resident policy before the refit; Miles resolves the recorded native checkpoint dir

### DIFF
--- a/tests/test_miles_load_path.py
+++ b/tests/test_miles_load_path.py
@@ -1,24 +1,64 @@
-"""load_weights on Miles hands the actors a Megatron --load directory, resolved
-from the tinker:// URI the same way create_model(checkpoint_path) resolves it;
-the raw URI used to reach the actors and fail their directory check."""
+"""Miles resumes from the Megatron iter_* directory a checkpoint was published
+from. The iter number is miles' own save counter, so it is recorded beside the
+interchange adapter at publish time and resolved through that record — both
+for load_weights (the train group) and create_model(checkpoint_path) (the
+builder); the legacy hash-derived name is only a fallback for old checkpoints."""
 import asyncio
+import os
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
 
+from tinkercloud.training.backends import checkpoint_interchange
+from tinkercloud.training.backends.miles import backend as miles_backend, model_setup
 from tinkercloud.training.backends.miles.backend import MilesBackend
-from tinkercloud.training.backends.miles.model_setup import parse_checkpoint_uri
+
+URI = "tinker://model_a/weights/resume"
 
 
-@pytest.mark.parametrize("optimizer", [False, True])
-def test_load_checkpoint_resolves_uri_and_passes_the_flag(optimizer):
-    backend = MilesBackend()
-    h = SimpleNamespace(
+@pytest.fixture
+def ckpt_base(tmp_path, monkeypatch):
+    monkeypatch.setattr(checkpoint_interchange, "CHECKPOINT_BASE", str(tmp_path / "ckpt"))
+    return tmp_path
+
+
+def _handle():
+    return SimpleNamespace(
         adapter_slot=None, lock=asyncio.Lock(), rollout_manager=None, created_from_checkpoint=False,
         args=SimpleNamespace(save="/tmp/save"), train_group=SimpleNamespace(load_checkpoint=AsyncMock()),
     )
-    asyncio.run(backend.load_checkpoint(h, "tinker://model_a/weights/resume", optimizer=optimizer))
-    h.train_group.load_checkpoint.assert_awaited_once_with(
-        parse_checkpoint_uri("tinker://model_a/weights/resume", "/tmp/save"), load_optimizer=optimizer)
+
+
+def test_publish_records_the_native_dir(ckpt_base, monkeypatch):
+    save = ckpt_base / "save"
+    old, new = save / "iter_0000001" / "adapter", save / "iter_0000002" / "adapter"
+    for d in (old, new):
+        d.mkdir(parents=True)
+    os.utime(old, (1, 1))
+    monkeypatch.setattr(miles_backend, "export_hf_adapter", lambda src, dst: None)
+    miles_backend._publish_native_adapter(SimpleNamespace(save=str(save)), URI)
+    root = checkpoint_interchange.resolve_checkpoint_root(URI)
+    assert open(os.path.join(root, model_setup.NATIVE_CHECKPOINT_POINTER)).read() == str(new.parent)
+    assert model_setup.resolve_native_checkpoint(URI, "/tmp/save") == str(new.parent)
+
+
+@pytest.mark.parametrize("optimizer", [False, True])
+def test_load_checkpoint_uses_the_record_and_passes_the_flag(ckpt_base, optimizer):
+    native = ckpt_base / "save" / "iter_0000007"
+    native.mkdir(parents=True)
+    model_setup.record_native_checkpoint(URI, str(native))
+    h = _handle()
+    asyncio.run(MilesBackend().load_checkpoint(h, URI, optimizer=optimizer))
+    h.train_group.load_checkpoint.assert_awaited_once_with(str(native), load_optimizer=optimizer)
     assert h.created_from_checkpoint is True
+
+
+def test_missing_native_dir_is_an_error_not_a_guess(ckpt_base):
+    model_setup.record_native_checkpoint(URI, str(ckpt_base / "gone"))
+    with pytest.raises(Exception, match="is gone"):
+        asyncio.run(MilesBackend().load_checkpoint(_handle(), URI))
+
+
+def test_legacy_checkpoint_without_record_falls_back(ckpt_base):
+    assert model_setup.resolve_native_checkpoint(URI, "/tmp/save") == model_setup.parse_checkpoint_uri(URI, "/tmp/save")

--- a/training/backends/miles/backend.py
+++ b/training/backends/miles/backend.py
@@ -24,7 +24,7 @@ from ..checkpoint_interchange import (
     export_hf_adapter,
     resolve_checkpoint_root,
 )
-from .model_setup import parse_checkpoint_uri
+from .model_setup import record_native_checkpoint, resolve_native_checkpoint
 
 logger = logging.getLogger(__name__)
 
@@ -88,6 +88,8 @@ def _publish_native_adapter(args, checkpoint_path: str) -> None:
         return
     latest = max(candidates, key=os.path.getmtime)
     export_hf_adapter(latest, resolve_checkpoint_root(checkpoint_path, create=True))
+    # the iter_* dir this adapter came from is what a resume must hand Megatron
+    record_native_checkpoint(checkpoint_path, os.path.dirname(latest))
 
 
 def _model_input_lens(data: List[Any]) -> List[int]:
@@ -1247,7 +1249,7 @@ class MilesBackend(TrainingBackend):
         try:
             # The actors take Megatron's --load directory, not the tinker:// URI;
             # resolve it the way the builder does for create_model(checkpoint_path).
-            load_dir = parse_checkpoint_uri(checkpoint_path, h.args.save)
+            load_dir = resolve_native_checkpoint(checkpoint_path, h.args.save)
             await h.train_group.load_checkpoint(load_dir, load_optimizer=optimizer)
             h.created_from_checkpoint = True
 

--- a/training/backends/miles/builder.py
+++ b/training/backends/miles/builder.py
@@ -14,7 +14,7 @@ from .model_setup import (
     auto_detect_all_parallelism,
     compute_sglang_mem_fraction,
     detect_torch_dist_path,
-    parse_checkpoint_uri,
+    resolve_native_checkpoint,
 )
 
 logger = logging.getLogger(__name__)
@@ -418,7 +418,7 @@ class MilesArgumentBuilder(ArgumentBuilder):
         # fresh optimizer, RNG and iteration count. Without these Megatron's
         # --load is a full resume. load_weights(optimizer=true) is the resume path.
         if checkpoint_path:
-            args.load = parse_checkpoint_uri(checkpoint_path, args.save)
+            args.load = resolve_native_checkpoint(checkpoint_path, args.save)
             args.no_load_optim = True
             args.no_load_rng = True
             args.finetune = True

--- a/training/backends/miles/model_setup.py
+++ b/training/backends/miles/model_setup.py
@@ -149,6 +149,37 @@ def detect_torch_dist_path(base_model: str) -> tuple[str, str]:
         return base_model, hf_path
 
 
+NATIVE_CHECKPOINT_POINTER = "miles_native_checkpoint"
+
+
+def record_native_checkpoint(checkpoint_path: str, native_dir: str) -> None:
+    """Remember which Megatron iter_* directory a tinker:// checkpoint was
+    published from, beside its interchange adapter, so a later resume can find
+    it. The iter number is miles' own save counter, not derivable from the URI."""
+    from ..checkpoint_interchange import resolve_checkpoint_root
+    root = resolve_checkpoint_root(checkpoint_path, create=True)
+    with open(os.path.join(root, NATIVE_CHECKPOINT_POINTER), "w") as f:
+        f.write(native_dir)
+
+
+def resolve_native_checkpoint(checkpoint_path: str, save_dir: str = "/data/checkpoints/tinker") -> str:
+    """The directory Megatron loads a tinker:// checkpoint from: the iter_*
+    directory recorded at publish time, or (checkpoints published before the
+    record existed) the legacy hash-derived name."""
+    from ..checkpoint_interchange import resolve_checkpoint_root
+    if checkpoint_path.startswith("tinker://"):
+        pointer = os.path.join(resolve_checkpoint_root(checkpoint_path), NATIVE_CHECKPOINT_POINTER)
+        if os.path.exists(pointer):
+            with open(pointer) as f:
+                native = f.read().strip()
+            if native and os.path.isdir(native):
+                logger.info("Checkpoint resume: %s → %s (recorded at publish)", checkpoint_path, native)
+                return native
+            raise FileNotFoundError(
+                f"Native Miles checkpoint recorded for {checkpoint_path} is gone: {native!r}")
+    return parse_checkpoint_uri(checkpoint_path, save_dir)
+
+
 def parse_checkpoint_uri(checkpoint_path: str, save_dir: str = "/data/checkpoints/tinker") -> str:
     """
     Parse tinker:// URI to filesystem checkpoint path.

--- a/training/backends/nemo_rl/backend.py
+++ b/training/backends/nemo_rl/backend.py
@@ -808,9 +808,15 @@ class NemoRLBackend(TrainingBackend):
             await asyncio.to_thread(
                 _policy_load_checkpoint, h.policy, weights_path, optimizer_path,
             )
-            h.training_resident = False  # loaded state may not be GPU-resident
 
             if h.policy_generation is not None and not h.debug_train_only:
+                # The policy was offloaded after the last refit, so the loaded
+                # parameters sit on CPU; the refit streams DTensors and needs
+                # them on GPU (all_gather has no CPU backend). Same sequence as
+                # after an optimizer step: prepare_for_training, refit, offload.
+                if not h.training_resident:
+                    await asyncio.to_thread(h.policy.prepare_for_training)
+                    h.training_resident = True
                 logger.info("Refitting policy generation after checkpoint load for %s", h.model_id)
                 await asyncio.to_thread(
                     _refit_policy_generation,
@@ -819,6 +825,9 @@ class NemoRLBackend(TrainingBackend):
                     h.colocated_inference,
                     h.refit_memory_ratio,
                 )
+                h.training_resident = False  # the refit offloaded the policy
+            else:
+                h.training_resident = False  # loaded state may not be GPU-resident
                 async with h._generation_state_lock:
                     h.generation_state = "generation_ready"
 


### PR DESCRIPTION
Both found by the three-phase resume acceptance (train + save, weights-only resume, full resume) on the pods; neither path had run before.

**NeMo RL**: `load_checkpoint` loaded into a policy the previous refit had offloaded, then the refit streamed DTensors from CPU (`No backend type associated with device type cpu` in `all_gather`). `prepare_for_training` first, refit, offload: the sequence the optimizer step already uses.

**Miles**: `parse_checkpoint_uri` derives the `iter_*` number from a hash of the checkpoint name, but `save_weights` numbers iterations with a per-model counter, so the resolved directory never existed, for `load_weights` and for `create_model(checkpoint_path)` alike. The publish step now records the `iter_*` directory the adapter came from beside the interchange adapter (`miles_native_checkpoint`), and both resume paths resolve through that record; a recorded directory that is gone is an error, not a guess; the hash-derived name remains the fallback for checkpoints published before the record existed. `tests/test_miles_load_path.py` covers publish, resolve, both flags reaching the train group, the missing-dir error, and the fallback.

Acceptance (candidate server on :8001, one server per phase, the pod's installed SDK): nemo_rl on Qwen2.5-0.5B-Instruct and miles on Qwen3-8B-Base pass all three phases, 0 tracebacks; the nemo_rl checkpoint carries `optimizer/optim` DCP shards (51 MB beside 32 MB of weights).
