### PR TITLE
Checkpoint store: one module owns URI, layout, counter and records; backends get directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Server-wide settings (`training/config.py`):
 | `TINKER_API_KEY` | API auth key | `tml-dev-key` |
 | `RAY_ADDRESS` / `RAY_NAMESPACE` | Ray cluster endpoint / namespace | auto (local head) / `default` |
 | `METADATA_DIR` | Futures DB, sessions DB, checkpoint metadata | `/data/metadata` |
-| `TINKERCLOUD_CHECKPOINT_BASE` | Root the `tinker://` checkpoint URIs resolve under | `/data/checkpoints` |
+| `TINKERCLOUD_CHECKPOINT_BASE` | Root of every model's checkpoints (`<model>/{weights,sampler_weights}/<name>/`) and native area (`<model>/native/`) | `/data/checkpoints` |
 | `SESSION_TIMEOUT_S` / `SESSION_REAP_INTERVAL_S` | Expire silent sessions and free their models (`-1` disables) | `600` / `60` |
 | `ALLOW_PARTIAL_BATCHES` | Pad batches smaller than the DP size | `false` |
 | `KGATEWAY_LOG_LEVEL` / `KGATEWAY_ACCESS_LOG` | Log level / HTTP access log | `INFO` / `false` |

--- a/scripts/gates/g9_adapter_interchange.py
+++ b/scripts/gates/g9_adapter_interchange.py
@@ -174,9 +174,11 @@ def _offline_adapter_logprobs(adapter_dir: str, probe: list[list[int]]) -> list[
 
 def _resolve_local(path: str) -> str:
     sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
-    from training.backends.checkpoint_interchange import find_hf_adapter, resolve_checkpoint_root
+    from training.checkpoints import CheckpointRef, CheckpointStore
+    from training.checkpoints.interchange import find_hf_adapter
+    from training.config import get_config
 
-    root = resolve_checkpoint_root(path)
+    root = str(CheckpointStore(get_config().storage.checkpoint_base, metadata=None).root(CheckpointRef.parse(path)))
     adapter = find_hf_adapter(root)
     if adapter is None:
         raise SystemExit(

--- a/scripts/pod_pytest.sh
+++ b/scripts/pod_pytest.sh
@@ -17,6 +17,7 @@ POD="${1:-tinkercloud-nemorl}"; shift || true
 if [ $# -eq 0 ]; then
   set -- tests/protocol tests/test_ordering.py tests/test_backend_interface.py \
          tests/test_loss_registry.py tests/test_e0_registry.py tests/test_checkpoint_interchange.py \
+         tests/test_checkpoint_store.py tests/test_miles_resume_args.py \
          tests/test_validators.py tests/test_miles_rl_layout.py tests/test_optim_metrics_seam.py \
          tests/test_miles_padding.py tests/test_futures_storage.py tests/test_result_validation.py tests/test_backend_config.py tests/test_miles_pack_length.py tests/test_miles_dp_reduction.py -q -p no:cacheprovider
 fi

--- a/tests/README.md
+++ b/tests/README.md
@@ -133,7 +133,8 @@ PYTHONPATH=/root/gavin/miles:/root/gavin/tinker-cookbook pytest tests/test_advan
 | `test_ordering.py` | Per-model program order and barrier semantics (unit) |
 | `test_backend_interface.py` | Backend ABC signature contract for every `SUPPORTED_BACKENDS` entry |
 | `test_loss_registry.py` | `loss_fn` / `loss_fn_config` validation |
-| `test_checkpoint_interchange.py` | Checkpoint URI <-> root resolution |
+| `test_checkpoint_store.py` | Checkpoint identity <-> directory, save counter, pending/completed/failed records |
+| `test_checkpoint_interchange.py` | Cross-backend HF PEFT adapter publish/stage |
 | `cleanup_test_env.py` | Cleanup script to free GPUs before tests |
 | `test_e2e_nemo_rl.sh` | Bash smoke test of the seven core operations against a live server |
 | `test_classification_backend_harness.py` | Classification backends (004) harness, GPU-free |

--- a/tests/protocol/test_baseline.py
+++ b/tests/protocol/test_baseline.py
@@ -51,7 +51,8 @@ def test_load_from_state_round_trips_weights(service_client, server):
     # the fork SDK creates with checkpoint_path; upstream creates, then load_weights
     mine = [t for t in server.trace() if t["model_id"] == tc2.model_id]
     created = [t for t in mine if t["op"] == "create_model"]
-    assert created and (created[0]["checkpoint_path"] == path or "load_checkpoint" in [t["op"] for t in mine])
+    root = str(server.checkpoint_base / tc.model_id / "weights" / "rt")
+    assert created and (created[0]["resume_from"] == root or "load_checkpoint" in [t["op"] for t in mine])
     # the loaded model continues from the saved weights: w = 0.25 * 1 pending microbatch
     op = tc2.optim_step(types.AdamParams(learning_rate=0.0)).result()
     assert op.metrics["fake_w"] == 0.25

--- a/tests/protocol/test_checkpoints.py
+++ b/tests/protocol/test_checkpoints.py
@@ -29,7 +29,7 @@ def test_list_and_delete(service_client, server):
     assert server.post("/api/v1/weights_info", {"tinker_path": p}).status_code == 200
     # bytes are gone for the deleted kind only
     assert not (server.checkpoint_base / tc.model_id / "sampler_weights" / "c1").exists()
-    assert (server.checkpoint_base / tc.model_id / "c1").exists()
+    assert (server.checkpoint_base / tc.model_id / "weights" / "c1").exists()
 
     assert _delete(server, tc.model_id, "c1", checkpoint_type="training").status_code == 204
     assert rest.list_checkpoints(tc.model_id).result().checkpoints == []
@@ -97,7 +97,7 @@ def test_load_weights_honours_the_optimizer_flag(service_client, server):
 
     # a checkpoint that carries no optimizer state: weights-only fine, with-optimizer refused
     import json
-    state = server.checkpoint_base / src.model_id / "opt" / "fake_state.json"
+    state = server.checkpoint_base / src.model_id / "weights" / "opt" / "fake_state.json"
     st = json.loads(state.read_text())
     st.pop("optimizer")
     state.write_text(json.dumps(st))
@@ -106,3 +106,52 @@ def test_load_weights_honours_the_optimizer_flag(service_client, server):
     assert fut.status_code == 400 and "no optimizer state" in fut.text, fut.text
     fresh2 = service_client.create_lora_training_client(base_model="fake/tiny", rank=2)
     assert load(fresh2.model_id, False).status_code == 200
+
+
+def test_a_save_in_flight_is_pending_not_missing(service_client, server):
+    """weights_info / load_weights on a checkpoint whose save has not returned
+    answer 425, never 404; the record exists before the bytes do."""
+    import time
+    tc = service_client.create_lora_training_client(base_model="fake/tiny", rank=2)
+    fut = tc.save_state("slow-one")                       # the fake writes slow-* after a delay
+    p = f"tinker://{tc.model_id}/weights/slow-one"
+    seen = None
+    for _ in range(40):
+        seen = server.post("/api/v1/weights_info", {"tinker_path": p}).status_code
+        if seen == 425:
+            break
+        time.sleep(0.05)
+    assert seen == 425
+    assert fut.result().path == p
+    assert server.post("/api/v1/weights_info", {"tinker_path": p}).status_code == 200
+
+
+def test_kind_and_shape_are_checked_at_admission(service_client, server):
+    tc = service_client.create_lora_training_client(base_model="fake/tiny", rank=2)
+    sp = tc.save_weights_for_sampler("k1").result().path
+    fresh = service_client.create_lora_training_client(base_model="fake/tiny", rank=2)
+    # a sampler checkpoint is not a training resume
+    r = server.post("/api/v1/load_weights", {"model_id": fresh.model_id, "path": sp, "optimizer": False, "seq_id": 1001})
+    assert r.status_code == 400 and "weights required" in r.json()["error"], r.text
+    # only the tinker://<model>/<kind>/<name> grammar exists
+    for bad in ("/data/checkpoints/x", f"tinker://{tc.model_id}", f"tinker://{tc.model_id}/weights/a/b",
+                f"tinker://{tc.model_id}/native/x"):
+        assert server.post("/api/v1/weights_info", {"tinker_path": bad}).status_code == 400, bad
+        r = server.post("/api/v1/load_weights", {"model_id": fresh.model_id, "path": bad, "optimizer": False})
+        assert r.status_code == 400, (bad, r.text)
+
+
+def test_sampler_from_a_checkpoint_path_is_pinned_to_its_version(service_client, server):
+    """A sampling client built from a sampler_weights path serves the weight
+    version that checkpoint was saved at, not the live weights."""
+    tc = service_client.create_lora_training_client(base_model="fake/tiny", rank=2)
+    tc.forward_backward([make_datum([1, 2, 3])], "cross_entropy")
+    tc.optim_step(types.AdamParams(learning_rate=0.5)).result()          # version 1
+    sp = tc.save_weights_for_sampler("v1").result().path
+    tc.forward_backward([make_datum([1, 2, 3])], "cross_entropy")
+    tc.optim_step(types.AdamParams(learning_rate=0.5)).result()          # live is version 2
+    sc = service_client.create_sampling_client(model_path=sp)
+    sc.sample(prompt=types.ModelInput.from_ints([1, 2]), num_samples=1,
+              sampling_params=types.SamplingParams(max_tokens=2)).result()
+    pinned = [t["pinned_version"] for t in server.trace() if t["op"] == "sample" and t["model_id"] == tc.model_id]
+    assert pinned and pinned[-1] == 1, pinned

--- a/tests/protocol/test_model_info.py
+++ b/tests/protocol/test_model_info.py
@@ -19,8 +19,9 @@ def test_get_info_and_weights_info_report_lora(service_client, server):
     assert spath == f"tinker://{tc.model_id}/sampler_weights/sinfo"
     wi = server.post("/api/v1/weights_info", {"tinker_path": spath}).json()
     assert wi["is_lora"] is True and wi["lora_rank"] == 16
-    saved = [t for t in server.trace() if t["op"] == "save_checkpoint" and t["checkpoint_path"] == spath]
-    assert saved and saved[0]["root"].endswith(f"/{tc.model_id}/sampler_weights/sinfo")
+    saved = [t for t in server.trace() if t["op"] == "save_checkpoint" and t["model_id"] == tc.model_id
+             and t["root"].endswith(f"/{tc.model_id}/sampler_weights/sinfo")]
+    assert saved and saved[0]["persist"] is True and saved[0]["step"] == 2
 
 
 def test_full_param_model_reports_no_lora(service_client, server):

--- a/tests/test_backend_interface.py
+++ b/tests/test_backend_interface.py
@@ -179,6 +179,33 @@ class TestBackendSignatureContract:
             BackendFactory.backend_class("nope")
 
 
+class TestCheckpointRootContract:
+    """save_checkpoint writes only under the root it is handed; persist=False
+    writes nothing; load_checkpoint reads the same root back. The CPU adapter
+    is the one that runs here; the GPU adapters share the signature (above)."""
+
+    def test_fake_writes_under_root_and_round_trips(self, tmp_path):
+        from tinkercloud.training.backends.fake.backend import FakeBackend
+        b = FakeBackend()
+        h = asyncio.run(b.create_model("m", "r", "fake/tiny", 0, native_root=tmp_path / "native"))
+        h.w = 0.75
+        root = tmp_path / "weights" / "c1"
+        root.mkdir(parents=True)
+        asyncio.run(b.save_checkpoint(h, root, step=3, persist=True))
+        written = {p.relative_to(tmp_path) for p in tmp_path.rglob("*") if p.is_file()}
+        assert written == {root.relative_to(tmp_path) / "fake_state.json"}
+        h2 = asyncio.run(b.create_model("m2", "r", "fake/tiny", 0, resume_from=root, native_root=tmp_path / "n2"))
+        assert h2.w == 0.75
+
+    def test_persist_false_writes_nothing(self, tmp_path):
+        from tinkercloud.training.backends.fake.backend import FakeBackend
+        b = FakeBackend()
+        h = asyncio.run(b.create_model("m", "r", "fake/tiny", 0, native_root=tmp_path / "native"))
+        root = tmp_path / "sampler_weights" / "e1"
+        asyncio.run(b.save_checkpoint(h, root, step=None, persist=False))
+        assert not root.exists()
+
+
 class TestSamplingContract:
     """Test sample()/prepare_for_generation() error contracts (no GPU needed)."""
 

--- a/tests/test_checkpoint_interchange.py
+++ b/tests/test_checkpoint_interchange.py
@@ -1,8 +1,9 @@
 """Unit tests for the cross-backend HF PEFT adapter interchange.
 
-Filesystem-level contract only (no engine): URI resolution, publish/stage
-round-trip, atomicity of publish, PEFT key normalization, and the "native
-artifact wins" rule. Design: specs/007-q5-migration/HANDOFF.md §2.1.
+Filesystem-level contract only (no engine): publish/stage round-trip,
+atomicity of publish, PEFT key normalization, and the "native artifact wins"
+rule. Where a root lives is the store's (test_checkpoint_store.py).
+Design: specs/007-q5-migration/HANDOFF.md §2.1.
 """
 import json
 import os
@@ -11,7 +12,7 @@ import pytest
 import torch
 from safetensors.torch import load_file, save_file
 
-from tinkercloud.training.backends import checkpoint_interchange as ci
+from tinkercloud.training.checkpoints import interchange as ci
 
 BARE_KEY = "model.layers.0.self_attn.q_proj.lora_A.weight"
 
@@ -27,130 +28,6 @@ def _write_adapter(d, r=32, alpha=32, key=BARE_KEY, value=1.0):
     with open(os.path.join(d, ci.ADAPTER_CONFIG_FILE), "w") as f:
         json.dump({"peft_type": "LORA", "r": r, "lora_alpha": alpha}, f)
     return d
-
-
-class TestResolveCheckpointRoot:
-    def test_tinker_uri_maps_to_run_and_name(self):
-        assert ci.resolve_checkpoint_root("tinker://run-abc/weights/ckpt-1") == (
-            f"{ci.CHECKPOINT_BASE}/run-abc/ckpt-1"
-        )
-
-    def test_filesystem_path_passes_through(self, tmp_path):
-        assert ci.resolve_checkpoint_root(str(tmp_path)) == str(tmp_path)
-
-    def test_create_makes_the_directory(self, tmp_path):
-        target = str(tmp_path / "nested" / "root")
-        ci.resolve_checkpoint_root(target, create=True)
-        assert os.path.isdir(target)
-
-
-class TestPublishAndStage:
-    def test_round_trip(self, tmp_path):
-        src = _write_adapter(str(tmp_path / "native" / "model"))
-        root = str(tmp_path / "ckpt")
-        os.makedirs(root)
-
-        published = ci.export_hf_adapter(src, root)
-        assert published == os.path.join(root, ci.HF_ADAPTER_DIRNAME)
-        assert ci.find_hf_adapter(root) == published
-        assert ci.read_adapter_config(root)["r"] == 32
-
-        dest = str(tmp_path / "other_backend" / "weights" / "model")
-        assert ci.stage_hf_adapter(root, dest) == dest
-        staged = load_file(os.path.join(dest, ci.ADAPTER_WEIGHTS_FILE))
-        assert list(staged) == [ci.PEFT_PREFIX + BARE_KEY]
-
-    def test_publish_without_adapter_is_a_no_op(self, tmp_path):
-        src = str(tmp_path / "full_finetune")
-        os.makedirs(src)
-        root = str(tmp_path / "ckpt")
-        os.makedirs(root)
-        assert ci.export_hf_adapter(src, root) is None
-        assert ci.find_hf_adapter(root) is None
-        assert ci.read_adapter_config(root) is None
-
-    def test_publish_replaces_a_previous_adapter(self, tmp_path):
-        root = str(tmp_path / "ckpt")
-        os.makedirs(root)
-        ci.export_hf_adapter(_write_adapter(str(tmp_path / "s1"), value=1.0), root)
-        ci.export_hf_adapter(_write_adapter(str(tmp_path / "s2"), value=2.0), root)
-        published = load_file(os.path.join(root, ci.HF_ADAPTER_DIRNAME, ci.ADAPTER_WEIGHTS_FILE))
-        assert float(next(iter(published.values()))[0, 0]) == 2.0
-        # no staging tmp left behind for a cross-pod reader to trip on
-        assert not os.path.exists(os.path.join(root, ci.HF_ADAPTER_DIRNAME + ".tmp"))
-
-    def test_native_artifact_wins_over_interchange_copy(self, tmp_path):
-        root = str(tmp_path / "ckpt")
-        os.makedirs(root)
-        ci.export_hf_adapter(_write_adapter(str(tmp_path / "src"), value=1.0), root)
-
-        dest = _write_adapter(str(tmp_path / "native"), value=7.0)
-        assert ci.stage_hf_adapter(root, dest) is None
-        native = load_file(os.path.join(dest, ci.ADAPTER_WEIGHTS_FILE))
-        assert float(next(iter(native.values()))[0, 0]) == 7.0
-
-    def test_stage_without_published_adapter_is_a_no_op(self, tmp_path):
-        root = str(tmp_path / "ckpt")
-        os.makedirs(root)
-        assert ci.stage_hf_adapter(root, str(tmp_path / "dest")) is None
-
-    def test_missing_adapter_config_still_publishes_weights(self, tmp_path):
-        src = _write_adapter(str(tmp_path / "src"))
-        os.remove(os.path.join(src, ci.ADAPTER_CONFIG_FILE))
-        root = str(tmp_path / "ckpt")
-        os.makedirs(root)
-        assert ci.export_hf_adapter(src, root) is not None
-        assert ci.read_adapter_config(root) is None
-
-
-class TestTorchBinFallback:
-    """Miles' native export is `adapter_model.bin` (its fused-QKV lora_A is
-    aliased across q/k/v and safetensors refuses shared storage). The publish
-    path must convert it, cloning the aliased storages en route — regression
-    for the conv_mig_main relay failure (2026-08-17)."""
-
-    def _write_bin_adapter(self, d, aliased=True):
-        os.makedirs(d, exist_ok=True)
-        shared = torch.full((2, 2), 3.0)
-        state = {
-            "model.layers.0.self_attn.q_proj.lora_A.weight": shared,
-            "model.layers.0.self_attn.k_proj.lora_A.weight": shared if aliased else shared.clone(),
-            "model.layers.0.self_attn.q_proj.lora_B.weight": torch.full((2, 2), 4.0),
-        }
-        torch.save(state, os.path.join(d, ci.ADAPTER_WEIGHTS_TORCH_FILE))
-        with open(os.path.join(d, ci.ADAPTER_CONFIG_FILE), "w") as f:
-            json.dump({"peft_type": "LORA", "r": 32, "lora_alpha": 32}, f)
-        return d
-
-    def test_bin_with_aliased_tensors_publishes_as_safetensors(self, tmp_path):
-        src = self._write_bin_adapter(str(tmp_path / "iter" / "adapter"))
-        root = str(tmp_path / "ckpt")
-        os.makedirs(root)
-        published = ci.export_hf_adapter(src, root)
-        assert published == os.path.join(root, ci.HF_ADAPTER_DIRNAME)
-        out = load_file(os.path.join(published, ci.ADAPTER_WEIGHTS_FILE))
-        assert sorted(out) == [
-            ci.PEFT_PREFIX + "model.layers.0.self_attn.k_proj.lora_A.weight",
-            ci.PEFT_PREFIX + "model.layers.0.self_attn.q_proj.lora_A.weight",
-            ci.PEFT_PREFIX + "model.layers.0.self_attn.q_proj.lora_B.weight",
-        ]
-        assert float(out[ci.PEFT_PREFIX + "model.layers.0.self_attn.q_proj.lora_A.weight"][0, 0]) == 3.0
-        # the interchange copy is now loadable by find/stage like any other
-        assert ci.find_hf_adapter(root) == published
-
-    def test_safetensors_still_wins_when_both_exist(self, tmp_path):
-        src = self._write_bin_adapter(str(tmp_path / "src"))
-        save_file(
-            {BARE_KEY: torch.full((2, 2), 9.0)},
-            os.path.join(src, ci.ADAPTER_WEIGHTS_FILE),
-            metadata={"format": "pt"},
-        )
-        root = str(tmp_path / "ckpt")
-        os.makedirs(root)
-        ci.export_hf_adapter(src, root)
-        out = load_file(os.path.join(root, ci.HF_ADAPTER_DIRNAME, ci.ADAPTER_WEIGHTS_FILE))
-        assert list(out) == [ci.PEFT_PREFIX + BARE_KEY]
-        assert float(out[ci.PEFT_PREFIX + BARE_KEY][0, 0]) == 9.0
 
 
 class TestSingleTenantNativePublish:

--- a/tests/test_checkpoint_store.py
+++ b/tests/test_checkpoint_store.py
@@ -1,0 +1,165 @@
+"""The checkpoint store: identity <-> directory, the per-model counter, the
+pending/completed/failed record and what a reader is allowed to see.
+
+Pure filesystem tests; no backend, no server."""
+import json
+import os
+
+import pytest
+
+from tinkercloud.training.checkpoints import (
+    CheckpointFailed,
+    CheckpointKind,
+    CheckpointKindMismatch,
+    CheckpointNotFound,
+    CheckpointPending,
+    CheckpointRef,
+    CheckpointStore,
+    InvalidCheckpointPath,
+)
+from tinkercloud.training.storage.metadata import MetadataStorage
+
+W, S = CheckpointKind.WEIGHTS, CheckpointKind.SAMPLER_WEIGHTS
+
+
+@pytest.fixture
+def store(tmp_path):
+    return CheckpointStore(tmp_path / "ckpt", MetadataStorage(tmp_path / "meta"))
+
+
+class TestRef:
+    def test_round_trip(self):
+        ref = CheckpointRef.parse("tinker://model_a/weights/step-3")
+        assert (ref.model_id, ref.kind, ref.name) == ("model_a", W, "step-3")
+        assert ref.uri == "tinker://model_a/weights/step-3"
+        assert CheckpointRef.parse("tinker://m/sampler_weights/final").kind is S
+
+    @pytest.mark.parametrize("bad", [
+        "/data/checkpoints/m/x", "tinker://m", "tinker://m/x", "tinker://m/weights",
+        "tinker://m/weights/a/b", "tinker://m/native/x", "tinker://m/weights/..", "tinker:///weights/x",
+        "", None,
+    ])
+    def test_everything_else_is_refused(self, bad):
+        with pytest.raises(InvalidCheckpointPath):
+            CheckpointRef.parse(bad)
+
+    def test_make_validates_segments(self):
+        with pytest.raises(InvalidCheckpointPath):
+            CheckpointRef.make("m", W, "a/b")
+
+
+class TestLayout:
+    def test_roots_by_kind_and_native_area(self, store):
+        assert store.root(CheckpointRef.make("m", W, "c1")) == store.base / "m" / "weights" / "c1"
+        assert store.root(CheckpointRef.make("m", S, "c1")) == store.base / "m" / "sampler_weights" / "c1"
+        native = store.native_root("m")
+        assert native == store.base / "m" / "native" and native.is_dir()
+
+
+class TestSaveLifecycle:
+    def test_begin_creates_an_empty_root_and_a_pending_record(self, store):
+        t = store.begin_save("m", W, "c1", weight_version=4)
+        assert t.root.is_dir() and not any(t.root.iterdir()) and t.step == 1
+        rec = store.get(t.ref)
+        assert rec["status"] == "pending" and rec["weight_version"] == 4 and rec["ephemeral"] is False
+        with pytest.raises(CheckpointPending):
+            store.require(t.ref)
+        store.complete(t.ref)
+        assert store.require(t.ref) == t.root
+        assert store.get(t.ref)["completed_at"]
+
+    def test_failed_save_is_visible_as_failed(self, store):
+        t = store.begin_save("m", W, "c1")
+        store.fail(t.ref, "disk full")
+        with pytest.raises(CheckpointFailed, match="disk full"):
+            store.require(t.ref)
+
+    def test_counter_is_monotonic_across_failures_deletes_and_overwrites(self, store):
+        a = store.begin_save("m", W, "a"); store.complete(a.ref)
+        b = store.begin_save("m", W, "b"); store.fail(b.ref, "x")
+        assert (a.step, b.step) == (1, 2)
+        store.delete(a.ref)
+        c = store.begin_save("m", W, "c"); store.complete(c.ref)
+        assert c.step == 3                      # deleted a's 1 and failed b's 2 are never reused
+        again = store.begin_save("m", W, "c")   # same name saved twice: new counter, old bytes gone
+        assert again.step == 4 and again.root == c.root and not any(again.root.iterdir())
+        s = store.begin_save("m", S, "c"); store.complete(s.ref)
+        assert s.step == 5                      # one counter per model, both kinds
+        assert store.next_step("other") == 1    # per model
+
+    def test_begin_replaces_stale_bytes_under_the_same_name(self, store):
+        t = store.begin_save("m", W, "c1")
+        (t.root / "old").write_text("x")
+        store.complete(t.ref)
+        t2 = store.begin_save("m", W, "c1")
+        assert not (t2.root / "old").exists()
+
+    def test_ephemeral_save_has_no_step_no_root_and_is_not_listed(self, store):
+        t = store.begin_save("m", S, "m_1_abcd", persist=False, weight_version=2)
+        assert t.step is None and not t.root.exists()
+        store.complete(t.ref)
+        assert store.get(t.ref)["ephemeral"] is True
+        assert store.list("m") == []
+        assert store.next_step("m") == 1        # consumed nothing
+
+
+class TestReads:
+    def test_require_checks_kind(self, store):
+        t = store.begin_save("m", S, "s1"); store.complete(t.ref)
+        with pytest.raises(CheckpointKindMismatch):
+            store.require(t.ref, kind=W)
+        with pytest.raises(CheckpointKindMismatch):
+            store.resolve_resume(t.ref.uri)
+        assert store.require(t.ref, kind=S) == t.root
+
+    def test_unknown_is_not_found(self, store):
+        with pytest.raises(CheckpointNotFound):
+            store.require(CheckpointRef.make("m", W, "nope"))
+        assert store.delete(CheckpointRef.make("m", W, "nope")) is False
+
+    def test_list_reports_uri_status_and_size(self, store):
+        t = store.begin_save("m", W, "c1")
+        (t.root / "blob").write_bytes(b"12345")
+        store.complete(t.ref)
+        p = store.begin_save("m", W, "c2")      # still pending: listed, marked
+        [c2, c1] = store.list("m")
+        assert c1["uri"] == t.ref.uri and c1["size_bytes"] == 5 and c1["status"] == "completed"
+        assert c2["uri"] == p.ref.uri and c2["status"] == "pending"
+
+
+class TestDeletion:
+    def test_delete_removes_record_and_bytes_but_not_native(self, store):
+        native = store.native_root("m")
+        (native / "iter_0000001").mkdir()
+        t = store.begin_save("m", W, "c1")
+        (t.root / "blob").write_text("x")
+        store.complete(t.ref)
+        assert store.delete(t.ref) is True
+        assert not t.root.exists() and store.get(t.ref) is None
+        assert (native / "iter_0000001").is_dir()
+
+    def test_release_model_drops_only_ephemeral_records(self, store):
+        keep = store.begin_save("m", W, "c1"); store.complete(keep.ref)
+        eph = store.begin_save("m", S, "m_1_x", persist=False); store.complete(eph.ref)
+        assert store.release_model("m") == 1
+        assert store.get(keep.ref) and store.get(eph.ref) is None
+        assert store.native_root("m").is_dir()
+
+
+class TestBootSweep:
+    def test_pending_rows_become_failed(self, store, tmp_path):
+        t = store.begin_save("m", W, "c1")
+        done = store.begin_save("m", W, "c2"); store.complete(done.ref)
+        fresh = CheckpointStore(store.base, MetadataStorage(tmp_path / "meta"))  # a restart
+        assert fresh.sweep_pending() == 1
+        with pytest.raises(CheckpointFailed, match="restarted"):
+            fresh.require(t.ref)
+        assert fresh.require(done.ref) == done.root
+        assert fresh.sweep_pending() == 0
+
+    def test_records_of_other_shapes_are_ignored(self, store):
+        # a foreign json under the model's metadata dir is not a checkpoint record
+        d = store.metadata.checkpoints_dir / "m"
+        d.mkdir(parents=True)
+        (d / "stray.json").write_text(json.dumps({"path": "tinker://m/weights/x"}))
+        assert store.records("m") == [] and store.sweep_pending() == 0

--- a/tests/test_miles_load_path.py
+++ b/tests/test_miles_load_path.py
@@ -1,8 +1,9 @@
 """Miles resumes from the Megatron iter_* directory a checkpoint was published
-from. The iter number is miles' own save counter, so it is recorded beside the
-interchange adapter at publish time and resolved through that record — both
-for load_weights (the train group) and create_model(checkpoint_path) (the
-builder); the legacy hash-derived name is only a fallback for old checkpoints."""
+from. The iter number is the store's per-model save counter, so the directory
+is recorded beside the interchange adapter at publish time and resolved
+through that record -- for load_weights (the train group) and for
+create_model(resume_from) (the builder's --load). A root without the record
+is not a Miles-native checkpoint, never a guess."""
 import asyncio
 import os
 from types import SimpleNamespace
@@ -10,17 +11,8 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from tinkercloud.training.backends import checkpoint_interchange
 from tinkercloud.training.backends.miles import backend as miles_backend, model_setup
 from tinkercloud.training.backends.miles.backend import MilesBackend
-
-URI = "tinker://model_a/weights/resume"
-
-
-@pytest.fixture
-def ckpt_base(tmp_path, monkeypatch):
-    monkeypatch.setattr(checkpoint_interchange, "CHECKPOINT_BASE", str(tmp_path / "ckpt"))
-    return tmp_path
 
 
 def _handle():
@@ -30,35 +22,43 @@ def _handle():
     )
 
 
-def test_publish_records_the_native_dir(ckpt_base, monkeypatch):
-    save = ckpt_base / "save"
+def test_publish_records_the_native_dir(tmp_path, monkeypatch):
+    save = tmp_path / "native"
     old, new = save / "iter_0000001" / "adapter", save / "iter_0000002" / "adapter"
     for d in (old, new):
         d.mkdir(parents=True)
     os.utime(old, (1, 1))
     monkeypatch.setattr(miles_backend, "export_hf_adapter", lambda src, dst: None)
-    miles_backend._publish_native_adapter(SimpleNamespace(save=str(save)), URI)
-    root = checkpoint_interchange.resolve_checkpoint_root(URI)
-    assert open(os.path.join(root, model_setup.NATIVE_CHECKPOINT_POINTER)).read() == str(new.parent)
-    assert model_setup.resolve_native_checkpoint(URI, "/tmp/save") == str(new.parent)
+    root = tmp_path / "ckpt" / "m" / "weights" / "resume"
+    root.mkdir(parents=True)
+    miles_backend._publish_native_adapter(SimpleNamespace(save=str(save)), str(root))
+    assert (root / model_setup.NATIVE_CHECKPOINT_POINTER).read_text() == str(new.parent)
+    assert model_setup.resolve_native_checkpoint(str(root)) == str(new.parent)
 
 
 @pytest.mark.parametrize("optimizer", [False, True])
-def test_load_checkpoint_uses_the_record_and_passes_the_flag(ckpt_base, optimizer):
-    native = ckpt_base / "save" / "iter_0000007"
+def test_load_checkpoint_uses_the_record_and_passes_the_flag(tmp_path, optimizer):
+    native = tmp_path / "native" / "iter_0000007"
     native.mkdir(parents=True)
-    model_setup.record_native_checkpoint(URI, str(native))
+    root = tmp_path / "ckpt" / "resume"
+    root.mkdir(parents=True)
+    model_setup.record_native_checkpoint(str(root), str(native))
     h = _handle()
-    asyncio.run(MilesBackend().load_checkpoint(h, URI, optimizer=optimizer))
+    asyncio.run(MilesBackend().load_checkpoint(h, root, optimizer=optimizer))
     h.train_group.load_checkpoint.assert_awaited_once_with(str(native), load_optimizer=optimizer)
     assert h.created_from_checkpoint is True
 
 
-def test_missing_native_dir_is_an_error_not_a_guess(ckpt_base):
-    model_setup.record_native_checkpoint(URI, str(ckpt_base / "gone"))
+def test_missing_native_dir_is_an_error_not_a_guess(tmp_path):
+    root = tmp_path / "ckpt" / "resume"
+    root.mkdir(parents=True)
+    model_setup.record_native_checkpoint(str(root), str(tmp_path / "gone"))
     with pytest.raises(Exception, match="is gone"):
-        asyncio.run(MilesBackend().load_checkpoint(_handle(), URI))
+        asyncio.run(MilesBackend().load_checkpoint(_handle(), root))
 
 
-def test_legacy_checkpoint_without_record_falls_back(ckpt_base):
-    assert model_setup.resolve_native_checkpoint(URI, "/tmp/save") == model_setup.parse_checkpoint_uri(URI, "/tmp/save")
+def test_root_without_record_is_not_miles_native(tmp_path):
+    root = tmp_path / "ckpt" / "foreign"
+    root.mkdir(parents=True)
+    with pytest.raises(Exception, match="not a Miles-native checkpoint"):
+        asyncio.run(MilesBackend().load_checkpoint(_handle(), root))

--- a/tests/test_miles_resume_args.py
+++ b/tests/test_miles_resume_args.py
@@ -1,7 +1,8 @@
-"""create_model(checkpoint_path) on Miles is a weights-only load: the builder
+"""create_model(resume_from) on Miles is a weights-only load: the builder
 must pair Megatron's --load with --no-load-optim / --no-load-rng / --finetune,
 or the resume silently restores optimizer state (a full resume is
-load_weights(optimizer=true), which goes through the train group instead)."""
+load_weights(optimizer=true), which goes through the train group instead).
+--save is the model's own native area, never the shared default."""
 from argparse import Namespace
 
 import pytest
@@ -14,21 +15,26 @@ def builder_mod():
     return _load_builder_module()
 
 
-def _configure(builder_mod, checkpoint_path):
+def _configure(builder_mod, load_dir, save_dir=None):
     b = builder_mod.MilesArgumentBuilder(default_save_dir="/tmp/ckpt")
     return b._configure_model_args(
         Namespace(), base_model="/tmp/model", megatron_checkpoint_path="/tmp/mcore",
-        lora_config={"rank": 8}, debug_train_only=False, checkpoint_path=checkpoint_path,
-        model_config=MODEL_CONFIG, parallel_config={"tp": 1, "pp": 1, "cp": 1},
+        lora_config={"rank": 8}, debug_train_only=False, load_dir=load_dir,
+        model_config=MODEL_CONFIG, parallel_config={"tp": 1, "pp": 1, "cp": 1}, save_dir=save_dir,
     )
 
 
-def test_checkpoint_path_at_create_is_weights_only(builder_mod):
-    args = _configure(builder_mod, "/tmp/ckpt/run/weights/x")
-    assert args.load == "/tmp/ckpt/run/weights/x"
+def test_resume_at_create_is_weights_only(builder_mod):
+    args = _configure(builder_mod, "/data/ckpt/m/native/iter_0000003")
+    assert args.load == "/data/ckpt/m/native/iter_0000003"
     assert args.no_load_optim is True and args.no_load_rng is True and args.finetune is True
 
 
-def test_no_checkpoint_path_sets_no_load(builder_mod):
+def test_no_resume_sets_no_load(builder_mod):
     args = _configure(builder_mod, None)
     assert not getattr(args, "load", None)
+
+
+def test_save_is_the_models_native_area(builder_mod):
+    assert _configure(builder_mod, None, save_dir="/data/ckpt/m/native").save == "/data/ckpt/m/native"
+    assert _configure(builder_mod, None).save == "/tmp/ckpt"

--- a/training/api.py
+++ b/training/api.py
@@ -21,6 +21,7 @@ from fastapi.responses import JSONResponse
 
 # Import modules
 from .storage import FuturesStorage, MetadataStorage, SessionStorage
+from .checkpoints import CheckpointError, CheckpointStore
 from .storage.futures import DuplicateSeqId
 from .config import get_config, TrainingConfig
 from .utils import APIKeyAuth
@@ -96,6 +97,12 @@ def create_app(config: Optional[TrainingConfig] = None) -> FastAPI:
             d.mkdir(parents=True, exist_ok=True)
         futures_storage = FuturesStorage(config_obj.storage.futures_db_path)
         metadata_storage = MetadataStorage(config_obj.storage.metadata_dir)
+        config_obj.storage.checkpoint_base.mkdir(parents=True, exist_ok=True)
+        checkpoint_store = CheckpointStore(config_obj.storage.checkpoint_base, metadata_storage)
+        swept = checkpoint_store.sweep_pending()
+        if swept:
+            logger.warning("Marked %d checkpoint save(s) interrupted by the last shutdown as failed", swept)
+        logger.info("Checkpoint base: %s", config_obj.storage.checkpoint_base)
 
         # Initialize session storage (separate DB file for sessions/samplers)
         session_db_path = config_obj.storage.metadata_dir / "sessions.db"
@@ -137,6 +144,7 @@ def create_app(config: Optional[TrainingConfig] = None) -> FastAPI:
         # Store in app state for dependency injection
         application.state.futures_storage = futures_storage
         application.state.metadata_storage = metadata_storage
+        application.state.checkpoint_store = checkpoint_store
         application.state.session_storage = session_storage
         application.state.auth = auth
         application.state.backend = backend
@@ -149,9 +157,9 @@ def create_app(config: Optional[TrainingConfig] = None) -> FastAPI:
         from .services.sampling_service import SamplingService
         from .services.session_service import SessionService
 
-        application.state.model_service = ModelService(backend=backend)
+        application.state.model_service = ModelService(backend=backend, store=checkpoint_store)
         application.state.training_service = TrainingService(backend=backend)
-        application.state.checkpoint_service = CheckpointService(backend=backend)
+        application.state.checkpoint_service = CheckpointService(backend=backend, store=checkpoint_store)
         application.state.sampling_service = SamplingService(backend=backend)
         # Initialize SessionService with storage for persistence
         application.state.session_service = SessionService(storage=session_storage)
@@ -212,6 +220,13 @@ def create_app(config: Optional[TrainingConfig] = None) -> FastAPI:
         conflict can never succeed on retry."""
         return JSONResponse(status_code=400, content={"error": str(exc), "status_code": 400,
                                                       "path": str(request.url.path)})
+
+    @application.exception_handler(CheckpointError)
+    async def checkpoint_error_handler(request: Request, exc: CheckpointError):
+        """Store verdicts on a checkpoint identity: 400 malformed / wrong kind,
+        404 unknown, 425 still being written, 500 the save failed."""
+        return JSONResponse(status_code=exc.status_code, content={"error": str(exc), "status_code": exc.status_code,
+                                                                  "path": str(request.url.path)})
 
     @application.exception_handler(HTTPException)
     async def http_exception_handler(request: Request, exc: HTTPException):

--- a/training/backends/automodel/backend.py
+++ b/training/backends/automodel/backend.py
@@ -10,6 +10,7 @@ language_modeling objective.
 """
 import asyncio
 import logging
+from pathlib import Path
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any, Dict, List, Optional
@@ -79,7 +80,7 @@ class AutomodelBackend(TrainingBackend):
         rl_config: Optional[Dict[str, Any]] = None,
         rollout_config: Optional[Dict[str, Any]] = None,
         debug_train_only: bool = False,
-        checkpoint_path: Optional[str] = None,
+        resume_from: Optional[Path] = None,
         max_batch_size: int = 4096,
         max_seq_len: int = 2048,
         rlve_config: Optional[Dict[str, Any]] = None,
@@ -88,6 +89,7 @@ class AutomodelBackend(TrainingBackend):
         objective: str = Objective.SEQUENCE_CLASSIFICATION.value,
         num_labels: Optional[int] = None,
         head_config: Optional[Dict[str, Any]] = None,
+        native_root: Optional[Path] = None,
     ) -> AutomodelHandle:
         """Load an HF classification model + PEFT LoRA (no generation engine)."""
         if not is_classification(objective):
@@ -121,7 +123,7 @@ class AutomodelBackend(TrainingBackend):
         import asyncio
         await asyncio.to_thread(
             self._build_model, handle, base_model, objective, num_labels,
-            lora_config, head_config, checkpoint_path,
+            lora_config, head_config, str(resume_from) if resume_from else None,
         )
         return handle
 
@@ -303,37 +305,35 @@ class AutomodelBackend(TrainingBackend):
     # --- checkpoint / teardown ---
 
     async def save_checkpoint(
-        self, handle: BackendHandle, checkpoint_path: str,
-        step_id: Optional[int] = None,
-    ) -> str:
+        self, handle: BackendHandle, root: Path,
+        step: Optional[int] = None, persist: bool = True,
+    ) -> None:
         """Save the LoRA adapter + classification head (HF safetensors)."""
         import asyncio
         h: AutomodelHandle = handle  # type: ignore[assignment]
+        if not persist:
+            return  # no generation engine: an ephemeral sampler save has nothing to deliver
 
-        def _save() -> str:
-            import os
-            os.makedirs(checkpoint_path, exist_ok=True)
+        def _save() -> None:
             # PeftModel.save_pretrained writes the adapter; task_type SEQ_CLS/
             # TOKEN_CLS keeps the classifier in modules_to_save so it is saved too.
-            h.model.save_pretrained(checkpoint_path)
+            h.model.save_pretrained(str(root))
             if h.tokenizer is not None:
-                h.tokenizer.save_pretrained(checkpoint_path)
-            return checkpoint_path
+                h.tokenizer.save_pretrained(str(root))
 
-        path = await asyncio.to_thread(_save)
-        logger.info("Automodel checkpoint saved: %s (step=%s)", path, step_id)
-        return path
+        await asyncio.to_thread(_save)
+        logger.info("Automodel checkpoint saved: %s (step=%s)", root, step)
 
     async def load_checkpoint(
-        self, handle: BackendHandle, checkpoint_path: str, optimizer: bool = False,
+        self, handle: BackendHandle, root: Path, optimizer: bool = False,
     ) -> None:
         import asyncio
         h: AutomodelHandle = handle  # type: ignore[assignment]
         if optimizer:
             raise BackendError("automodel restores adapter weights only; optimizer state is not restored",
                                backend="automodel", operation="load_checkpoint")
-        await asyncio.to_thread(self._load_adapter, h, checkpoint_path)
-        logger.info("Automodel checkpoint loaded: %s", checkpoint_path)
+        await asyncio.to_thread(self._load_adapter, h, str(root))
+        logger.info("Automodel checkpoint loaded: %s", root)
 
     def _load_adapter(self, h: AutomodelHandle, checkpoint_path: str) -> None:
         """Load adapter weights into the existing PeftModel."""

--- a/training/backends/base.py
+++ b/training/backends/base.py
@@ -6,6 +6,7 @@ and BackendError — the contracts that Miles and NeMo RL implementations
 must satisfy.
 """
 from abc import ABC, abstractmethod
+from pathlib import Path
 from dataclasses import dataclass, field
 from typing import Any, Dict, FrozenSet, List, Optional
 
@@ -63,7 +64,7 @@ class TrainingBackend(ABC):
         rl_config: Optional[Dict[str, Any]] = None,
         rollout_config: Optional[Dict[str, Any]] = None,
         debug_train_only: bool = False,
-        checkpoint_path: Optional[str] = None,
+        resume_from: Optional[Path] = None,
         max_batch_size: int = 4096,
         max_seq_len: int = 2048,
         rlve_config: Optional[Dict[str, Any]] = None,
@@ -72,9 +73,20 @@ class TrainingBackend(ABC):
         objective: str = "language_modeling",
         num_labels: Optional[int] = None,
         head_config: Optional[Dict[str, Any]] = None,
+        native_root: Optional[Path] = None,
     ) -> BackendHandle:
         """
         Initialize training actors and inference engine.
+
+        Checkpoint directories come resolved from the checkpoint store
+        (training/checkpoints); a backend never sees a tinker:// URI.
+        `resume_from` is the root of a completed `weights` checkpoint to load
+        weights-only from (fresh optimizer, RNG and iteration count).
+        `native_root` is this model's private directory under the checkpoint
+        base -- the place for anything the engine writes on its own terms
+        (Megatron --save, per-adapter step checkpoints); the service always
+        passes it, and it outlives the model so a later resume can find what
+        was written there.
 
         The objective axis (feature 004) is additive: language_modeling is the
         default and leaves the existing causal path unchanged. LM-only backends
@@ -224,14 +236,24 @@ class TrainingBackend(ABC):
     async def save_checkpoint(
         self,
         handle: BackendHandle,
-        checkpoint_path: str,
-        step_id: Optional[int] = None,
-    ) -> str:
+        root: Path,
+        step: Optional[int] = None,
+        persist: bool = True,
+    ) -> None:
         """
-        Save model checkpoint.
+        Write a checkpoint under `root` (an existing, empty directory the store
+        created). What goes inside is the backend's: its native format wherever
+        the engine can write one, optimizer state wherever it can be restored,
+        and the cross-backend interchange adapter (training/checkpoints/
+        interchange.py) so another engine can import it. `step` is the store's
+        per-model counter for this save, unique for the life of the model --
+        the label for counter-named native artifacts (Megatron iter_*). It is
+        None, and `persist` False, for an ephemeral sampler save: the weights
+        already reached the inference engine and nothing need be written.
 
-        Returns:
-            Actual path where checkpoint was saved.
+        Raises:
+            BackendError: If the checkpoint cannot be written; the store then
+                marks the save failed and nothing under `root` is trusted.
         """
         ...
 
@@ -239,11 +261,12 @@ class TrainingBackend(ABC):
     async def load_checkpoint(
         self,
         handle: BackendHandle,
-        checkpoint_path: str,
+        root: Path,
         optimizer: bool = False,
     ) -> None:
         """
-        Load a checkpoint into a live model.
+        Load the checkpoint under `root` (a completed `weights` checkpoint, as
+        resolved by the store) into a live model.
 
         `optimizer=False` restores weights only and leaves the model's optimizer
         state as it is (fresh on a model that has not trained). `optimizer=True`
@@ -258,7 +281,7 @@ class TrainingBackend(ABC):
 
         Args:
             handle: Backend handle returned by create_model.
-            checkpoint_path: Path to the checkpoint directory.
+            root: The checkpoint directory.
             optimizer: Also restore optimizer state.
 
         Raises:

--- a/training/backends/fake/backend.py
+++ b/training/backends/fake/backend.py
@@ -15,15 +15,16 @@ function of the inputs:
 Set FAKE_BACKEND_TRACE=<path> to append one JSON line per backend call
 ({"op", "model_id", ...args}) — tests read this instead of poking internals.
 """
+import asyncio
 import json
 import logging
 import os
 import random
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from ..base import BackendError, BackendHandle, TrainingBackend
-from ..checkpoint_interchange import resolve_checkpoint_root
 from ...core.loss_registry import LOSS_FNS
 
 logger = logging.getLogger(__name__)
@@ -94,21 +95,22 @@ class FakeBackend(TrainingBackend):
         self, model_id: str, request_id: str, base_model: str, num_gpus: int,
         lora_config: Optional[Dict[str, Any]] = None, parallelism: Optional[Dict[str, Any]] = None,
         rl_config: Optional[Dict[str, Any]] = None, rollout_config: Optional[Dict[str, Any]] = None,
-        debug_train_only: bool = False, checkpoint_path: Optional[str] = None,
+        debug_train_only: bool = False, resume_from: Optional[Path] = None,
         max_batch_size: int = 4096, max_seq_len: int = 2048,
         rlve_config: Optional[Dict[str, Any]] = None, wandb_config: Optional[Dict[str, Any]] = None,
         staleness_k: int = 0, objective: str = "language_modeling",
         num_labels: Optional[int] = None, head_config: Optional[Dict[str, Any]] = None,
+        native_root: Optional[Path] = None,
     ) -> BackendHandle:
         if objective != "language_modeling":
             raise BackendError(f"objective {objective!r} unsupported", backend="fake", operation="create_model")
         h = FakeHandle(model_id=model_id, backend_type="fake", base_model=base_model,
                        lora_config=lora_config, hf_path=base_model)
-        if checkpoint_path:
-            self._load_into(h, checkpoint_path)
+        if resume_from:
+            self._load_into(h, resume_from)
         self._models[model_id] = h
         self._trace("create_model", model_id, base_model=base_model, lora_config=lora_config,
-                    checkpoint_path=checkpoint_path)
+                    resume_from=resume_from, native_root=native_root)
         return h
 
     async def delete_model(self, handle: BackendHandle) -> None:
@@ -213,34 +215,37 @@ class FakeBackend(TrainingBackend):
         return out
 
     # --- checkpoints -----------------------------------------------------
-    async def save_checkpoint(self, handle: BackendHandle, checkpoint_path: str, step_id: Optional[int] = None) -> str:
+    async def save_checkpoint(self, handle: BackendHandle, root: Path, step: Optional[int] = None,
+                              persist: bool = True) -> None:
         h = self._handle(handle, "save_checkpoint")
-        root = resolve_checkpoint_root(checkpoint_path, create=True)
-        with open(os.path.join(root, STATE_FILE), "w") as f:
-            json.dump({"w": h.w, "weight_version": h.weight_version, "base_model": h.base_model,
-                       "lora_config": h.lora_config, "step_id": step_id,
-                       "optimizer": {"step_count": h.step_count}}, f)
-        self._trace("save_checkpoint", h.model_id, checkpoint_path=checkpoint_path, root=root, step_id=step_id)
-        return checkpoint_path
+        if persist:
+            # a name starting with "slow-" writes slowly, so the protocol suite
+            # can observe the store's pending state (overrides: save_delay_s)
+            if root.name.startswith("slow-"):
+                await asyncio.sleep(float(self.overrides.get("save_delay_s", 1.0)))
+            with open(os.path.join(root, STATE_FILE), "w") as f:
+                json.dump({"w": h.w, "weight_version": h.weight_version, "base_model": h.base_model,
+                           "lora_config": h.lora_config, "step": step,
+                           "optimizer": {"step_count": h.step_count}}, f)
+        self._trace("save_checkpoint", h.model_id, root=str(root), step=step, persist=persist)
 
-    def _load_into(self, h: FakeHandle, checkpoint_path: str, optimizer: bool = False) -> None:
-        root = resolve_checkpoint_root(checkpoint_path)
+    def _load_into(self, h: FakeHandle, root: Path, optimizer: bool = False) -> None:
         path = os.path.join(root, STATE_FILE)
         if not os.path.exists(path):
-            raise BackendError(f"Checkpoint {checkpoint_path} not found at {path}",
+            raise BackendError(f"Checkpoint {root} holds no {STATE_FILE}",
                                backend="fake", operation="load_checkpoint")
         with open(path) as f:
             st = json.load(f)
         if optimizer and "optimizer" not in st:
-            raise BackendError(f"Checkpoint {checkpoint_path} carries no optimizer state",
+            raise BackendError(f"Checkpoint {root} carries no optimizer state",
                                backend="fake", operation="load_checkpoint")
         h.w = st["w"]
         h.weight_version = st["weight_version"]
         if optimizer:
             h.step_count = st["optimizer"]["step_count"]
 
-    async def load_checkpoint(self, handle: BackendHandle, checkpoint_path: str,
+    async def load_checkpoint(self, handle: BackendHandle, root: Path,
                               optimizer: bool = False) -> None:
         h = self._handle(handle, "load_checkpoint")
-        self._load_into(h, checkpoint_path, optimizer=optimizer)
-        self._trace("load_checkpoint", h.model_id, checkpoint_path=checkpoint_path, optimizer=optimizer)
+        self._load_into(h, root, optimizer=optimizer)
+        self._trace("load_checkpoint", h.model_id, root=str(root), optimizer=optimizer)

--- a/training/backends/megatron_bridge/backend.py
+++ b/training/backends/megatron_bridge/backend.py
@@ -4,6 +4,7 @@ ray + megatron.bridge
 """
 import asyncio
 import logging
+from pathlib import Path
 import os
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -68,7 +69,7 @@ class MegatronBridgeBackend(TrainingBackend):
         rl_config: Optional[Dict[str, Any]] = None,
         rollout_config: Optional[Dict[str, Any]] = None,
         debug_train_only: bool = False,
-        checkpoint_path: Optional[str] = None,
+        resume_from: Optional[Path] = None,
         max_batch_size: int = 4096,
         max_seq_len: int = 2048,
         rlve_config: Optional[Dict[str, Any]] = None,
@@ -77,6 +78,7 @@ class MegatronBridgeBackend(TrainingBackend):
         objective: str = Objective.SEQUENCE_CLASSIFICATION.value,
         num_labels: Optional[int] = None,
         head_config: Optional[Dict[str, Any]] = None,
+        native_root: Optional[Path] = None,
     ) -> MegatronBridgeHandle:
         """Spawn a GPU worker actor that builds the classifier + LoRA + optimizer."""
         if not is_classification(objective):
@@ -96,7 +98,9 @@ class MegatronBridgeBackend(TrainingBackend):
             base_ckpt_dir=hc.get("base_ckpt_dir", base_model),
             train_jsonl=hc.get("train_jsonl"), val_jsonl=hc.get("val_jsonl"),
             test_jsonl=hc.get("test_jsonl"), num_classes=num_labels,
-            result_dir=checkpoint_path or hc.get("result_dir", f"/data/{model_id}"),
+            # the recipe writes its own checkpoints under result_dir: the
+            # model's private area, so nothing lands outside the checkpoint base
+            result_dir=hc.get("result_dir", str(native_root) if native_root else f"/data/{model_id}"),
             experiment_name=model_id, model_size=hc.get("model_size", "evo2_1b_base"),
             tensor_model_parallel_size=(parallelism or {}).get("tp", 1),
             seq_length_tokens=seq_length, backbone_seq_length=seq_length,
@@ -124,6 +128,8 @@ class MegatronBridgeBackend(TrainingBackend):
 
         worker = MegatronBridgeWorker.remote(cfg_kwargs, _RECIPE_EXAMPLES)
         await _get(worker.ready.remote())   # blocks (in a thread) until setup() done
+        if resume_from:
+            await _get(worker.load_checkpoint.remote(str(resume_from), False))
 
         handle = MegatronBridgeHandle(
             model_id=model_id, backend_type="megatron_bridge", base_model=base_model,
@@ -176,20 +182,22 @@ class MegatronBridgeBackend(TrainingBackend):
 
     # --- checkpoint / teardown ---
 
-    async def save_checkpoint(self, handle: BackendHandle, checkpoint_path: str,
-                              step_id: Optional[int] = None) -> str:
+    async def save_checkpoint(self, handle: BackendHandle, root: Path,
+                              step: Optional[int] = None, persist: bool = True) -> None:
         h: MegatronBridgeHandle = handle  # type: ignore[assignment]
+        if not persist:
+            return
         try:
-            return await _get(h.worker.save_checkpoint.remote(checkpoint_path))
+            await _get(h.worker.save_checkpoint.remote(str(root)))
         except Exception as e:
             raise BackendError(f"save_checkpoint failed: {e!r}",
                                backend="megatron_bridge", operation="save_checkpoint")
 
-    async def load_checkpoint(self, handle: BackendHandle, checkpoint_path: str,
+    async def load_checkpoint(self, handle: BackendHandle, root: Path,
                               optimizer: bool = False) -> None:
         h: MegatronBridgeHandle = handle  # type: ignore[assignment]
         try:
-            await _get(h.worker.load_checkpoint.remote(checkpoint_path, optimizer))
+            await _get(h.worker.load_checkpoint.remote(str(root), optimizer))
         except Exception as e:
             raise BackendError(f"load_checkpoint failed: {e!r}",
                                backend="megatron_bridge", operation="load_checkpoint")

--- a/training/backends/miles/backend.py
+++ b/training/backends/miles/backend.py
@@ -19,37 +19,34 @@ import ray
 from ..base import BackendError, BackendHandle, TrainingBackend, UnsupportedFeatureError
 from .config import MilesConfig
 from ...core.loss_registry import clip_thresholds
-from ..checkpoint_interchange import (
-    CHECKPOINT_BASE,
-    export_hf_adapter,
-    resolve_checkpoint_root,
-)
+from ...checkpoints.interchange import export_hf_adapter
 from .model_setup import record_native_checkpoint, resolve_native_checkpoint
 
 logger = logging.getLogger(__name__)
-
-_ADAPTER_CHECKPOINT_BASE = os.path.join(CHECKPOINT_BASE, "adapters")
-
 
 def _dp_size(args: Any) -> int:
     """Data-parallel width the actors will split a batch across."""
     return int(getattr(args, "data_parallel_size", 1) or 1)
 
 
-def _adapter_save_dir(adapter_name: str) -> Path:
-    """Per-tenant dir miles writes adapter checkpoints into. Without it
-    (config.save=None) miles skips per-adapter checkpoints entirely.
+def _adapter_save_dir(native_root: Optional[Path], adapter_name: str) -> Path:
+    """Per-tenant dir miles writes adapter checkpoints into, under the model's
+    own native area. Without it (config.save=None) miles skips per-adapter
+    checkpoints entirely.
 
     Path, not str: TinkerAdapterConfig.save is annotated `str | Path | None`
     but miles only ever does `config.save / "checkpoints"` — a str explodes
     at adapter registration (declared type wider than the honored one).
     """
-    return Path(_ADAPTER_CHECKPOINT_BASE) / adapter_name
+    if native_root is None:
+        raise BackendError("create_model needs native_root for the adapter save dir",
+                           backend="miles", operation="create_model")
+    return Path(native_root) / "adapters" / adapter_name
 
 
-def _publish_adapter(adapter_save_dir: Path, checkpoint_path: str, adapter_name: Optional[str]) -> None:
+def _publish_adapter(adapter_save_dir: Path, root: str, adapter_name: Optional[str]) -> None:
     """Copy the newest per-adapter HF PEFT pair miles wrote into the
-    cross-backend interchange dir (specs/007 §2.1)."""
+    cross-backend interchange dir under the checkpoint root (specs/007 §2.1)."""
     ckpt_root = os.path.join(adapter_save_dir, "checkpoints")
     if not os.path.isdir(ckpt_root):
         logger.warning("Adapter %s: no checkpoints under %s to publish", adapter_name, ckpt_root)
@@ -59,12 +56,10 @@ def _publish_adapter(adapter_save_dir: Path, checkpoint_path: str, adapter_name:
         logger.warning("Adapter %s: no step_* checkpoint in %s", adapter_name, ckpt_root)
         return
     latest = max(steps, key=lambda d: int(d[5:]))
-    export_hf_adapter(
-        os.path.join(ckpt_root, latest), resolve_checkpoint_root(checkpoint_path, create=True),
-    )
+    export_hf_adapter(os.path.join(ckpt_root, latest), root)
 
 
-def _publish_native_adapter(args, checkpoint_path: str) -> None:
+def _publish_native_adapter(args, root: str) -> None:
     """Single-tenant publish: miles' save_model writes the PEFT pair only into
     its native `<args.save>/iter_*/adapter` dir (as `adapter_model.bin` — the
     fused-QKV lora_A aliasing makes safetensors refuse), and nothing exported
@@ -87,9 +82,9 @@ def _publish_native_adapter(args, checkpoint_path: str) -> None:
         logger.warning("No iter_*/adapter under %s; nothing to publish", save_root)
         return
     latest = max(candidates, key=os.path.getmtime)
-    export_hf_adapter(latest, resolve_checkpoint_root(checkpoint_path, create=True))
+    export_hf_adapter(latest, root)
     # the iter_* dir this adapter came from is what a resume must hand Megatron
-    record_native_checkpoint(checkpoint_path, os.path.dirname(latest))
+    record_native_checkpoint(root, os.path.dirname(latest))
 
 
 def _model_input_lens(data: List[Any]) -> List[int]:
@@ -259,7 +254,7 @@ class MilesBackend(TrainingBackend):
         rl_config: Optional[Dict[str, Any]] = None,
         rollout_config: Optional[Dict[str, Any]] = None,
         debug_train_only: bool = False,
-        checkpoint_path: Optional[str] = None,
+        resume_from: Optional[Path] = None,
         max_batch_size: int = 4096,
         max_seq_len: int = 2048,
         rlve_config: Optional[Dict[str, Any]] = None,
@@ -268,6 +263,7 @@ class MilesBackend(TrainingBackend):
         staleness_k: int = 0,
         num_labels: Optional[int] = None,
         head_config: Optional[Dict[str, Any]] = None,
+        native_root: Optional[Path] = None,
     ) -> MilesHandle:
         if staleness_k > 0:
             # A staleness declaration is a permission (served staleness <= k), so
@@ -281,10 +277,11 @@ class MilesBackend(TrainingBackend):
             model_id=model_id, request_id=request_id, base_model=base_model,
             num_gpus=num_gpus, lora_config=lora_config, parallelism=parallelism,
             rl_config=rl_config, rollout_config=rollout_config,
-            debug_train_only=debug_train_only, checkpoint_path=checkpoint_path,
+            debug_train_only=debug_train_only, resume_from=resume_from,
             max_batch_size=max_batch_size, max_seq_len=max_seq_len,
             rlve_config=rlve_config, wandb_config=wandb_config,
             objective=objective, num_labels=num_labels, head_config=head_config,
+            native_root=native_root,
         )
         # Mirror the builder's pool gate (configured slots + LoRA rank).
         slots = self.config.multilora_slots
@@ -297,7 +294,8 @@ class MilesBackend(TrainingBackend):
                     model_id=model_id, request_id=request_id,
                     base_model=base_model, lora_config=lora_config,
                     debug_train_only=debug_train_only,
-                    checkpoint_path=checkpoint_path, rlve_config=rlve_config,
+                    resume_from=resume_from, rlve_config=rlve_config,
+                    native_root=native_root,
                     objective=objective,
                 )
             return await self._boot_model(**boot_kwargs)
@@ -309,9 +307,10 @@ class MilesBackend(TrainingBackend):
         base_model: str,
         lora_config: Dict[str, Any],
         debug_train_only: bool,
-        checkpoint_path: Optional[str],
+        resume_from: Optional[Path],
         rlve_config: Optional[Dict[str, Any]],
         objective: str,
+        native_root: Optional[Path] = None,
     ) -> MilesHandle:
         """Register a new tenant adapter into the live pool (caller holds
         _pool_admin). The pool's boot args govern parallelism/batch shape;
@@ -334,7 +333,7 @@ class MilesBackend(TrainingBackend):
                 "Multi-LoRA pool mode supports neither debug_train_only nor RLVE",
                 backend="miles", operation="create_model",
             )
-        if checkpoint_path:
+        if resume_from:
             raise BackendError(
                 "Resuming from a checkpoint into a multi-LoRA pool is not "
                 "supported yet (adapter-scoped resume unimplemented)",
@@ -347,7 +346,7 @@ class MilesBackend(TrainingBackend):
         rank = int(lora_config.get("rank", 0))
         alpha = int(lora_config.get("alpha") or rank)
         adapter_name = re.sub(r"[^A-Za-z0-9._-]", "-", model_id)
-        adapter_save_dir = _adapter_save_dir(adapter_name)
+        adapter_save_dir = _adapter_save_dir(native_root, adapter_name)
         try:
             registration = await pool.controller.register_adapter.remote(
                 adapter_name,
@@ -421,7 +420,7 @@ class MilesBackend(TrainingBackend):
         rl_config: Optional[Dict[str, Any]] = None,
         rollout_config: Optional[Dict[str, Any]] = None,
         debug_train_only: bool = False,
-        checkpoint_path: Optional[str] = None,
+        resume_from: Optional[Path] = None,
         max_batch_size: int = 4096,
         max_seq_len: int = 2048,
         rlve_config: Optional[Dict[str, Any]] = None,
@@ -429,6 +428,7 @@ class MilesBackend(TrainingBackend):
         objective: str = "language_modeling",
         num_labels: Optional[int] = None,
         head_config: Optional[Dict[str, Any]] = None,
+        native_root: Optional[Path] = None,
     ) -> MilesHandle:
         if objective != "language_modeling":
             raise BackendError(
@@ -440,13 +440,21 @@ class MilesBackend(TrainingBackend):
         try:
             logger.info("[%s] Creating Miles model %s", request_id, model_id)
 
+            # The actors take Megatron directories: --load is the iter_* dir
+            # recorded when the checkpoint was published; --save is this
+            # model's own native area, so two models' iter_* never collide.
+            load_dir = resolve_native_checkpoint(str(resume_from)) if resume_from else None
+            if native_root is None:
+                raise BackendError("create_model needs native_root for Megatron --save",
+                                   backend="miles", operation="create_model")
             # Build Slime arguments (blocking — run in thread pool)
             args, hf_path = await asyncio.to_thread(
                 self.builder.build_args,
                 base_model=base_model,
                 lora_config=lora_config,
                 debug_train_only=debug_train_only,
-                checkpoint_path=checkpoint_path,
+                load_dir=load_dir,
+                save_dir=str(native_root),
                 parallelism_config=parallelism,
                 max_batch_size=max_batch_size,
                 max_seq_len=max_seq_len,
@@ -504,7 +512,7 @@ class MilesBackend(TrainingBackend):
                 await controller.start.remote()
 
                 adapter_name = re.sub(r"[^A-Za-z0-9._-]", "-", model_id)
-                adapter_save_dir = _adapter_save_dir(adapter_name)
+                adapter_save_dir = _adapter_save_dir(native_root, adapter_name)
                 registration = await controller.register_adapter.remote(
                     adapter_name,
                     TinkerAdapterConfig(
@@ -588,7 +596,7 @@ class MilesBackend(TrainingBackend):
                 adapter_name=adapter_name,
                 adapter_slot=adapter_slot,
                 adapter_save_dir=adapter_save_dir,
-                created_from_checkpoint=bool(checkpoint_path),
+                created_from_checkpoint=bool(resume_from),
             )
 
             if multi_lora:
@@ -1177,12 +1185,15 @@ class MilesBackend(TrainingBackend):
     async def save_checkpoint(
         self,
         handle: BackendHandle,
-        checkpoint_path: str,
-        step_id: Optional[int] = None,
-    ) -> str:
+        root: Path,
+        step: Optional[int] = None,
+        persist: bool = True,
+    ) -> None:
         h: MilesHandle = handle  # type: ignore[assignment]
+        if not persist:
+            return  # ephemeral sampler save: update_weights already delivered them to SGLang
 
-        async def _run() -> str:
+        async def _run() -> None:
             offload_train = h.args.offload_train if h.args else False
             if offload_train:
                 # Never return a path nothing was written to.
@@ -1203,28 +1214,30 @@ class MilesBackend(TrainingBackend):
                         "Adapter %s has taken no optimizer step; nothing to checkpoint",
                         h.adapter_name,
                     )
-                    return checkpoint_path
+                    return
                 await h.controller.set_adapter_step.remote(h.adapter_name, h.weight_version)
 
-            await h.train_group.save_model(step_id if step_id is not None else 0)
+            await h.train_group.save_model(step if step is not None else 0)
 
             if h.adapter_save_dir:
                 await asyncio.to_thread(
-                    _publish_adapter, h.adapter_save_dir, checkpoint_path, h.adapter_name,
+                    _publish_adapter, h.adapter_save_dir, str(root), h.adapter_name,
                 )
             else:
-                await asyncio.to_thread(_publish_native_adapter, h.args, checkpoint_path)
-            return checkpoint_path
+                await asyncio.to_thread(_publish_native_adapter, h.args, str(root))
 
         try:
             pool = self._pool
             if h.adapter_slot is not None and pool is not None:
-                return await self._pool_run(pool, _run, tenant=h.model_id)
+                await self._pool_run(pool, _run, tenant=h.model_id)
+                return
             await h.lock.acquire()
             try:
-                return await _run()
+                await _run()
             finally:
                 h.lock.release()
+        except BackendError:
+            raise
         except Exception as e:
             raise BackendError(
                 str(e), backend="miles", operation="save_checkpoint", original_error=e,
@@ -1233,7 +1246,7 @@ class MilesBackend(TrainingBackend):
     async def load_checkpoint(
         self,
         handle: BackendHandle,
-        checkpoint_path: str,
+        root: Path,
         optimizer: bool = False,
     ) -> None:
         h: MilesHandle = handle  # type: ignore[assignment]
@@ -1247,9 +1260,9 @@ class MilesBackend(TrainingBackend):
             )
         await h.lock.acquire()
         try:
-            # The actors take Megatron's --load directory, not the tinker:// URI;
-            # resolve it the way the builder does for create_model(checkpoint_path).
-            load_dir = resolve_native_checkpoint(checkpoint_path, h.args.save)
+            # The actors take Megatron's --load directory: the iter_* dir
+            # recorded under the checkpoint root when it was published.
+            load_dir = resolve_native_checkpoint(str(root))
             await h.train_group.load_checkpoint(load_dir, load_optimizer=optimizer)
             h.created_from_checkpoint = True
 
@@ -1257,7 +1270,7 @@ class MilesBackend(TrainingBackend):
             if h.rollout_manager is not None:
                 await h.train_group.update_weights()
 
-            logger.info("Miles checkpoint loaded from %s", checkpoint_path)
+            logger.info("Miles checkpoint loaded from %s", root)
 
         except Exception as e:
             raise BackendError(

--- a/training/backends/miles/builder.py
+++ b/training/backends/miles/builder.py
@@ -14,7 +14,6 @@ from .model_setup import (
     auto_detect_all_parallelism,
     compute_sglang_mem_fraction,
     detect_torch_dist_path,
-    resolve_native_checkpoint,
 )
 
 logger = logging.getLogger(__name__)
@@ -39,7 +38,8 @@ class MilesArgumentBuilder(ArgumentBuilder):
         base_model: str,
         lora_config: Optional[Dict[str, Any]] = None,
         debug_train_only: bool = False,
-        checkpoint_path: Optional[str] = None,
+        load_dir: Optional[str] = None,
+        save_dir: Optional[str] = None,
         parallelism_config: Optional[Dict] = None,
         max_batch_size: int = 4096,
         max_seq_len: int = 2048,
@@ -56,7 +56,9 @@ class MilesArgumentBuilder(ArgumentBuilder):
             base_model: Path to model (can be torch_dist format)
             lora_config: LoRA configuration dict
             debug_train_only: If True, skip update_weights() to avoid SGLang cache flush
-            checkpoint_path: If provided, load from this checkpoint
+            load_dir: Megatron directory to load weights (only) from at create
+            save_dir: Megatron --save root for this model (its native area);
+                default_save_dir when not given
             parallelism_config: Optional parallelism config (TP, PP, num_gpus)
             max_batch_size: Max batch size for forward_backward (avoids gradient accumulation)
             rlve_config: Optional RLVE configuration (enables server-side RLVE)
@@ -142,6 +144,7 @@ class MilesArgumentBuilder(ArgumentBuilder):
             rlve_config=rlve_config,
             multi_lora_slots=multi_lora_slots,
             lora_config=lora_config,
+            save_dir=save_dir,
         )
 
         # Parse args to get Slime defaults
@@ -154,9 +157,10 @@ class MilesArgumentBuilder(ArgumentBuilder):
             megatron_checkpoint_path,
             lora_config,
             debug_train_only,
-            checkpoint_path,
+            load_dir,
             model_config,
             parallel_config,
+            save_dir=save_dir,
             rlve_config=rlve_config,
             wandb_config=wandb_config,
             multi_lora_slots=multi_lora_slots,
@@ -179,6 +183,7 @@ class MilesArgumentBuilder(ArgumentBuilder):
         rlve_config: Optional[Dict[str, Any]] = None,
         multi_lora_slots: int = 0,
         lora_config: Optional[Dict[str, Any]] = None,
+        save_dir: Optional[str] = None,
     ) -> list:
         """Build minimal CLI arguments for Slime's parse_args."""
         # Check if RLVE mode is enabled
@@ -271,7 +276,7 @@ class MilesArgumentBuilder(ArgumentBuilder):
             # the fallback logic can set args.load = args.ref_load when no
             # checkpoint resume is specified (see miles/utils/arguments.py:1452-1460)
             '--ref-load', megatron_checkpoint_path,
-            '--save', self.default_save_dir,
+            '--save', save_dir or self.default_save_dir,
             # Pool mode: save_due_adapter_checkpoints only writes adapters at a
             # save-interval multiple, and the interval lives on the ACTORS' args
             # copy — interval 1 makes the client's save_state the trigger (saves
@@ -387,9 +392,10 @@ class MilesArgumentBuilder(ArgumentBuilder):
         megatron_checkpoint_path: str,
         lora_config: Dict,
         debug_train_only: bool,
-        checkpoint_path: Optional[str],
+        load_dir: Optional[str],
         model_config: Dict[str, Any],
         parallel_config: Dict[str, int],
+        save_dir: Optional[str] = None,
         rlve_config: Optional[Dict[str, Any]] = None,
         wandb_config: Optional[Dict[str, Any]] = None,
         multi_lora_slots: int = 0,
@@ -412,13 +418,15 @@ class MilesArgumentBuilder(ArgumentBuilder):
         # Checkpoint paths
         args.pretrained_checkpoint = megatron_checkpoint_path
         args.ref_load = megatron_checkpoint_path
-        args.save = self.default_save_dir
+        # every model saves under its own root (the store's native area for
+        # it), so counter-numbered iter_* dirs of different models never collide
+        args.save = save_dir or self.default_save_dir
 
-        # create_model(checkpoint_path) is a weights-only load by contract: a
+        # create_model(resume_from) is a weights-only load by contract: a
         # fresh optimizer, RNG and iteration count. Without these Megatron's
         # --load is a full resume. load_weights(optimizer=true) is the resume path.
-        if checkpoint_path:
-            args.load = resolve_native_checkpoint(checkpoint_path, args.save)
+        if load_dir:
+            args.load = load_dir
             args.no_load_optim = True
             args.no_load_rng = True
             args.finetune = True

--- a/training/backends/miles/model_setup.py
+++ b/training/backends/miles/model_setup.py
@@ -152,70 +152,29 @@ def detect_torch_dist_path(base_model: str) -> tuple[str, str]:
 NATIVE_CHECKPOINT_POINTER = "miles_native_checkpoint"
 
 
-def record_native_checkpoint(checkpoint_path: str, native_dir: str) -> None:
-    """Remember which Megatron iter_* directory a tinker:// checkpoint was
+def record_native_checkpoint(root: str, native_dir: str) -> None:
+    """Remember which Megatron iter_* directory the checkpoint under `root` was
     published from, beside its interchange adapter, so a later resume can find
-    it. The iter number is miles' own save counter, not derivable from the URI."""
-    from ..checkpoint_interchange import resolve_checkpoint_root
-    root = resolve_checkpoint_root(checkpoint_path, create=True)
+    it. The iter number is the store's per-model save counter, which the URI
+    does not carry."""
     with open(os.path.join(root, NATIVE_CHECKPOINT_POINTER), "w") as f:
         f.write(native_dir)
 
 
-def resolve_native_checkpoint(checkpoint_path: str, save_dir: str = "/data/checkpoints/tinker") -> str:
-    """The directory Megatron loads a tinker:// checkpoint from: the iter_*
-    directory recorded at publish time, or (checkpoints published before the
-    record existed) the legacy hash-derived name."""
-    from ..checkpoint_interchange import resolve_checkpoint_root
-    if checkpoint_path.startswith("tinker://"):
-        pointer = os.path.join(resolve_checkpoint_root(checkpoint_path), NATIVE_CHECKPOINT_POINTER)
-        if os.path.exists(pointer):
-            with open(pointer) as f:
-                native = f.read().strip()
-            if native and os.path.isdir(native):
-                logger.info("Checkpoint resume: %s → %s (recorded at publish)", checkpoint_path, native)
-                return native
-            raise FileNotFoundError(
-                f"Native Miles checkpoint recorded for {checkpoint_path} is gone: {native!r}")
-    return parse_checkpoint_uri(checkpoint_path, save_dir)
-
-
-def parse_checkpoint_uri(checkpoint_path: str, save_dir: str = "/data/checkpoints/tinker") -> str:
-    """
-    Parse tinker:// URI to filesystem checkpoint path.
-
-    Args:
-        checkpoint_path: Checkpoint path (tinker:// URI or filesystem path)
-        save_dir: Base directory for checkpoints
-
-    Returns:
-        Filesystem checkpoint path
-
-    Raises:
-        ValueError: If tinker:// URI format is invalid
-    """
-    if checkpoint_path.startswith("tinker://"):
-        import hashlib
-
-        uri_parts = checkpoint_path.replace("tinker://", "").split("/")
-        if len(uri_parts) >= 3 and uri_parts[1] == "weights":
-            checkpoint_name = uri_parts[2]
-            # Use same step_id calculation as save_weights
-            step_id = int(
-                hashlib.md5(checkpoint_name.encode()).hexdigest()[:8], 16
-            ) % 100000
-            filesystem_path = f"{save_dir}/iter_{step_id:07d}"
-            logger.info(
-                f"Checkpoint resume: {checkpoint_path} → {filesystem_path} "
-                f"(step_id={step_id})"
-            )
-            return filesystem_path
-        else:
-            raise ValueError(f"Invalid tinker:// URI format: {checkpoint_path}")
-    else:
-        # Direct filesystem path
-        logger.info(f"Checkpoint resume: loading from {checkpoint_path}")
-        return checkpoint_path
+def resolve_native_checkpoint(root: str) -> str:
+    """The directory Megatron loads the checkpoint under `root` from: the
+    iter_* directory recorded at publish time. A checkpoint without the record
+    (written by another backend) has no Megatron-native state to load."""
+    pointer = os.path.join(root, NATIVE_CHECKPOINT_POINTER)
+    if not os.path.exists(pointer):
+        raise FileNotFoundError(
+            f"{root} carries no {NATIVE_CHECKPOINT_POINTER}: not a Miles-native checkpoint")
+    with open(pointer) as f:
+        native = f.read().strip()
+    if not native or not os.path.isdir(native):
+        raise FileNotFoundError(f"Native Miles checkpoint recorded for {root} is gone: {native!r}")
+    logger.info("Checkpoint resume: %s -> %s (recorded at publish)", root, native)
+    return native
 
 
 def compute_sglang_mem_fraction(model_config: Dict[str, Any], model_name: str = "") -> float:

--- a/training/backends/nemo_rl/backend.py
+++ b/training/backends/nemo_rl/backend.py
@@ -13,6 +13,7 @@ forward + backward + optimizer.step() in a single call.
 """
 import asyncio
 import logging
+from pathlib import Path
 import time
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -21,11 +22,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional
 from ..base import BackendError, BackendHandle, TrainingBackend
 from .config import NemoRLConfig
 from ...core.loss_registry import clip_thresholds
-from ..checkpoint_interchange import (
-    export_hf_adapter,
-    resolve_checkpoint_root,
-    stage_hf_adapter,
-)
+from ...checkpoints.interchange import export_hf_adapter, stage_hf_adapter
 
 if TYPE_CHECKING:
     from .generation import NemoRLBatchAccumulator
@@ -119,7 +116,7 @@ class NemoRLBackend(TrainingBackend):
         rl_config: Optional[Dict[str, Any]] = None,
         rollout_config: Optional[Dict[str, Any]] = None,
         debug_train_only: bool = False,
-        checkpoint_path: Optional[str] = None,
+        resume_from: Optional[Path] = None,
         max_batch_size: int = 4096,
         max_seq_len: int = 2048,
         rlve_config: Optional[Dict[str, Any]] = None,
@@ -128,6 +125,7 @@ class NemoRLBackend(TrainingBackend):
         objective: str = "language_modeling",
         num_labels: Optional[int] = None,
         head_config: Optional[Dict[str, Any]] = None,
+        native_root: Optional[Path] = None,
     ) -> NemoRLHandle:
         if objective != "language_modeling":
             raise BackendError(
@@ -147,7 +145,6 @@ class NemoRLBackend(TrainingBackend):
                 rl_config=rl_config,
                 rollout_config=rollout_config,
                 debug_train_only=debug_train_only,
-                checkpoint_path=checkpoint_path,
                 max_batch_size=max_batch_size,
                 max_seq_len=max_seq_len,
                 rlve_config=rlve_config,
@@ -156,13 +153,9 @@ class NemoRLBackend(TrainingBackend):
             logger.info("[%s] NeMo RL config built, hf_path=%s", request_id, hf_path)
 
             # Policy(weights_path=...) goes straight to the checkpoint
-            # manager's load_checkpoint, so it needs the resolved <root>/weights
-            # dir — not the tinker:// URI — and a foreign adapter staged into
-            # the layout that loader sniffs.
-            init_weights_path = (
-                _stage_foreign_adapter(_resolve_checkpoint_path(checkpoint_path))
-                if checkpoint_path else None
-            )
+            # manager's load_checkpoint, so it needs the <root>/weights dir,
+            # with a foreign adapter staged into the layout that loader sniffs.
+            init_weights_path = _stage_foreign_adapter(str(resume_from)) if resume_from else None
 
             policy, policy_generation, cluster, tokenizer, loss_fn = await asyncio.to_thread(
                 _init_nemo_rl_components,
@@ -745,13 +738,16 @@ class NemoRLBackend(TrainingBackend):
     async def save_checkpoint(
         self,
         handle: BackendHandle,
-        checkpoint_path: str,
-        step_id: Optional[int] = None,
-    ) -> str:
+        root: Path,
+        step: Optional[int] = None,
+        persist: bool = True,
+    ) -> None:
         """Save model checkpoint via policy.save_checkpoint()."""
         h: NemoRLHandle = handle  # type: ignore[assignment]
+        if not persist:
+            return  # ephemeral sampler save: the refit already delivered the weights
         try:
-            local_path = _resolve_checkpoint_path(checkpoint_path)
+            local_path = str(root)
 
             weights_path = f"{local_path}/weights"
             checkpointing_cfg = h.config.get("checkpointing", {
@@ -774,8 +770,7 @@ class NemoRLBackend(TrainingBackend):
                 export_hf_adapter, f"{weights_path}/model", local_path,
             )
 
-            logger.info("NeMo RL checkpoint saved to %s", local_path)
-            return checkpoint_path  # Return original URI for metadata consistency
+            logger.info("NeMo RL checkpoint saved to %s (step %s)", local_path, step)
 
         except Exception as e:
             raise BackendError(
@@ -785,7 +780,7 @@ class NemoRLBackend(TrainingBackend):
     async def load_checkpoint(
         self,
         handle: BackendHandle,
-        checkpoint_path: str,
+        root: Path,
         optimizer: bool = False,
     ) -> None:
         """Load checkpoint weights (and, on request, optimizer state) into the
@@ -794,14 +789,14 @@ class NemoRLBackend(TrainingBackend):
 
         h: NemoRLHandle = handle  # type: ignore[assignment]
         try:
-            local_path = _resolve_checkpoint_path(checkpoint_path)
+            local_path = str(root)
             weights_path = _stage_foreign_adapter(local_path)
             optimizer_path = None
             if optimizer:
                 optimizer_path = f"{local_path}/optimizer"
                 if not os.path.isdir(optimizer_path):
                     raise BackendError(
-                        f"Checkpoint {checkpoint_path} carries no optimizer state",
+                        f"Checkpoint {root} carries no optimizer state",
                         backend="nemo_rl", operation="load_checkpoint",
                     )
 
@@ -831,7 +826,7 @@ class NemoRLBackend(TrainingBackend):
                 async with h._generation_state_lock:
                     h.generation_state = "generation_ready"
 
-            logger.info("NeMo RL checkpoint loaded from %s", checkpoint_path)
+            logger.info("NeMo RL checkpoint loaded from %s", root)
 
         except BackendError:
             raise
@@ -1100,12 +1095,6 @@ async def _ensure_generation_ready(handle) -> None:
 # ---------------------------------------------------------------------------
 # Internal helper functions (called via asyncio.to_thread)
 # ---------------------------------------------------------------------------
-
-def _resolve_checkpoint_path(path: str) -> str:
-    """tinker://<run_id>/weights/<name> -> /data/checkpoints/<run_id>/<name>."""
-    return resolve_checkpoint_root(path, create=True)
-
-
 
 def _policy_load_checkpoint(policy, weights_path: str, optimizer_path: Optional[str]) -> None:
     """Policy exposes save_checkpoint but no load; fan the workers' load_checkpoint

--- a/training/backends/verl/backend.py
+++ b/training/backends/verl/backend.py
@@ -19,6 +19,7 @@ Narrative: specs/006-verl-backend/design.md.
 """
 import asyncio
 import logging
+from pathlib import Path
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any, Dict, List, Optional
@@ -26,11 +27,10 @@ from typing import Any, Dict, List, Optional
 import torch
 
 from ..base import BackendError, BackendHandle, TrainingBackend, UnsupportedFeatureError
-from ..checkpoint_interchange import (
+from ...checkpoints.interchange import (
     HF_ADAPTER_DIRNAME,
     find_hf_adapter,
     read_adapter_config,
-    resolve_checkpoint_root,
 )
 
 logger = logging.getLogger(__name__)
@@ -105,7 +105,7 @@ class VerlBackend(TrainingBackend):
         rl_config: Optional[Dict[str, Any]] = None,
         rollout_config: Optional[Dict[str, Any]] = None,
         debug_train_only: bool = False,
-        checkpoint_path: Optional[str] = None,
+        resume_from: Optional[Path] = None,
         max_batch_size: int = 4096,
         max_seq_len: int = 2048,
         rlve_config: Optional[Dict[str, Any]] = None,
@@ -114,6 +114,7 @@ class VerlBackend(TrainingBackend):
         objective: str = "language_modeling",
         num_labels: Optional[int] = None,
         head_config: Optional[Dict[str, Any]] = None,
+        native_root: Optional[Path] = None,
     ) -> VerlHandle:
         if staleness_k > 0:
             # verl's sync is already lazy but version-gated to staleness 0 at
@@ -140,8 +141,8 @@ class VerlBackend(TrainingBackend):
             # path wraps the module BEFORE FSDP, so it cannot be a post-boot
             # load_checkpoint. Native verl shards still resume that way.
             adapter_dir = None
-            if checkpoint_path:
-                ckpt_root = resolve_checkpoint_root(checkpoint_path)
+            if resume_from:
+                ckpt_root = str(resume_from)
                 adapter_dir = find_hf_adapter(ckpt_root)
                 if adapter_dir:
                     cfg["model"]["lora_adapter_path"] = adapter_dir
@@ -169,8 +170,8 @@ class VerlBackend(TrainingBackend):
                 rollout_synced_version=0 if enable_rollout else -1,
                 lora_rank=int(cfg["model"]["lora_rank"] or 0),
             )
-            if checkpoint_path and adapter_dir is None:
-                await self.load_checkpoint(handle, checkpoint_path)
+            if resume_from and adapter_dir is None:
+                await self.load_checkpoint(handle, resume_from)
             logger.info(
                 "[%s] verl model %s created (dp=%d, rollout=%s, adapter=%s)",
                 request_id, model_id, handle.dp_size, enable_rollout, adapter_dir,
@@ -301,16 +302,19 @@ class VerlBackend(TrainingBackend):
     async def save_checkpoint(
         self,
         handle: BackendHandle,
-        checkpoint_path: str,
-        step_id: Optional[int] = None,
-    ) -> str:
+        root: Path,
+        step: Optional[int] = None,
+        persist: bool = True,
+    ) -> None:
         h: VerlHandle = handle  # type: ignore[assignment]
+        if not persist:
+            return  # ephemeral sampler save: the engines already hold the weights
         async with h._lock:
             try:
                 await self._quiesce_samplers(h)
-                local_path = resolve_checkpoint_root(checkpoint_path, create=True)
+                local_path = str(root)
                 await asyncio.to_thread(
-                    h.worker_group.save_checkpoint, local_path, None, step_id or h.weight_version,
+                    h.worker_group.save_checkpoint, local_path, None, step or h.weight_version,
                 )
                 if h.lora_rank > 0:
                     # verl writes FSDP-sharded .pt only; no PEFT export path
@@ -321,11 +325,10 @@ class VerlBackend(TrainingBackend):
                         "usable for verl resume, not for cross-backend migration",
                         local_path, HF_ADAPTER_DIRNAME,
                     )
-                return checkpoint_path
             except Exception as e:
                 raise BackendError(str(e), backend="verl", operation="save_checkpoint", original_error=e) from e
 
-    async def load_checkpoint(self, handle: BackendHandle, checkpoint_path: str,
+    async def load_checkpoint(self, handle: BackendHandle, root: Path,
                               optimizer: bool = False) -> None:
         h: VerlHandle = handle  # type: ignore[assignment]
         if optimizer:
@@ -334,7 +337,7 @@ class VerlBackend(TrainingBackend):
         async with h._lock:
             try:
                 await self._quiesce_samplers(h)
-                local_path = resolve_checkpoint_root(checkpoint_path)
+                local_path = str(root)
                 if find_hf_adapter(local_path):
                     # PeftModel.from_pretrained wraps pre-FSDP: only create_model
                     # can attach an interchange adapter.

--- a/training/checkpoints/__init__.py
+++ b/training/checkpoints/__init__.py
@@ -1,0 +1,22 @@
+"""Checkpoint identity, location and records (store) and the cross-backend
+adapter interchange format. Backends receive resolved directories from the
+store and never parse a tinker:// URI themselves."""
+from .store import (
+    CheckpointError,
+    CheckpointFailed,
+    CheckpointKind,
+    CheckpointKindMismatch,
+    CheckpointNotFound,
+    CheckpointPending,
+    CheckpointRef,
+    CheckpointStatus,
+    CheckpointStore,
+    InvalidCheckpointPath,
+    SaveTicket,
+)
+
+__all__ = [
+    "CheckpointError", "CheckpointFailed", "CheckpointKind", "CheckpointKindMismatch",
+    "CheckpointNotFound", "CheckpointPending", "CheckpointRef", "CheckpointStatus",
+    "CheckpointStore", "InvalidCheckpointPath", "SaveTicket",
+]

--- a/training/checkpoints/interchange.py
+++ b/training/checkpoints/interchange.py
@@ -9,7 +9,9 @@ checkpoint::
 
 Every backend writes it on save_checkpoint and reads it on resume, so a
 program can move between engines; native formats stay for same-backend
-fast resume. Design + measured seam gates: specs/007-q5-migration/HANDOFF.md.
+fast resume. Where a checkpoint root lives is the store's business
+(training/checkpoints/store.py); this module only knows the adapter's shape
+inside a root. Design + measured seam gates: specs/007-q5-migration/HANDOFF.md.
 """
 import json
 import logging
@@ -19,33 +21,10 @@ from typing import Optional
 
 logger = logging.getLogger(__name__)
 
-CHECKPOINT_BASE = os.getenv("TINKERCLOUD_CHECKPOINT_BASE", "/data/checkpoints")
 HF_ADAPTER_DIRNAME = "hf_adapter"
 ADAPTER_WEIGHTS_FILE = "adapter_model.safetensors"
 ADAPTER_WEIGHTS_TORCH_FILE = "adapter_model.bin"
 ADAPTER_CONFIG_FILE = "adapter_config.json"
-
-
-def resolve_checkpoint_root(path: str, create: bool = False) -> str:
-    """tinker://<run_id>/weights/<name> -> <CHECKPOINT_BASE>/<run_id>/<name>;
-    tinker://<run_id>/sampler_weights/<name> -> <CHECKPOINT_BASE>/<run_id>/sampler_weights/<name>.
-
-    Filesystem paths pass through. Mirrors the URI shapes minted by
-    CheckpointService.save_weights / save_weights_for_sampler.
-    """
-    if path.startswith("tinker://"):
-        parts = path[len("tinker://"):].split("/")
-        run_id = parts[0]
-        name = parts[-1] if len(parts) > 2 else "default"
-        if len(parts) > 2 and parts[1] == "sampler_weights":
-            local = os.path.join(CHECKPOINT_BASE, run_id, "sampler_weights", name)
-        else:
-            local = os.path.join(CHECKPOINT_BASE, run_id, name)
-    else:
-        local = path
-    if create:
-        os.makedirs(local, exist_ok=True)
-    return local
 
 
 def hf_adapter_dir(checkpoint_root: str) -> str:

--- a/training/checkpoints/store.py
+++ b/training/checkpoints/store.py
@@ -1,0 +1,305 @@
+"""Where a checkpoint lives, and what the server knows about it.
+
+A ``tinker://<model_id>/<kind>/<name>`` URI is an identity, never a location.
+The store is the only module that turns that identity into a directory, mints
+the per-model save counter, and records what happened to each save:
+
+    <checkpoint_base>/<model_id>/weights/<name>/           kind=weights
+    <checkpoint_base>/<model_id>/sampler_weights/<name>/   kind=sampler_weights
+    <checkpoint_base>/<model_id>/native/                   the backend's private
+                                                           per-model area
+                                                           (Megatron --save, ...)
+
+Backends receive resolved directories (``root``, ``native_root``) and own what
+goes inside them; they never see a URI. Records hold identity, status, the
+counter value and the served weight version -- not a path -- so a record and
+the bytes can never disagree about where the bytes are.
+
+Records live under MetadataStorage as ``<kind>--<name>.json`` per model. A
+save is ``pending`` between ``begin_save`` and ``complete``/``fail``; a read
+through ``require`` refuses anything but ``completed``. Pending rows left
+behind by a crash are marked failed at boot (``sweep_pending``).
+"""
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from ..storage.metadata import MetadataStorage
+
+logger = logging.getLogger(__name__)
+
+SCHEME = "tinker://"
+NATIVE_DIRNAME = "native"
+
+
+class CheckpointKind(str, Enum):
+    WEIGHTS = "weights"
+    SAMPLER_WEIGHTS = "sampler_weights"
+
+
+class CheckpointStatus(str, Enum):
+    PENDING = "pending"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+# --- errors: routers map these to status codes in one place (api.py) ---------
+
+class CheckpointError(Exception):
+    status_code = 500
+
+
+class InvalidCheckpointPath(CheckpointError, ValueError):
+    status_code = 400
+
+
+class CheckpointNotFound(CheckpointError):
+    status_code = 404
+
+
+class CheckpointPending(CheckpointError):
+    status_code = 425
+
+
+class CheckpointFailed(CheckpointError):
+    status_code = 500
+
+
+class CheckpointKindMismatch(CheckpointError):
+    status_code = 400
+
+
+# --- identity ----------------------------------------------------------------
+
+def _segment(value: str, what: str) -> str:
+    if not value or "/" in value or value in (".", "..") or "\x00" in value:
+        raise InvalidCheckpointPath(f"invalid {what} {value!r}: one non-empty path segment")
+    return value
+
+
+@dataclass(frozen=True)
+class CheckpointRef:
+    """Identity of a checkpoint: which model, which kind, which name."""
+
+    model_id: str
+    kind: CheckpointKind
+    name: str
+
+    @classmethod
+    def parse(cls, uri: str) -> "CheckpointRef":
+        """``tinker://<model_id>/<weights|sampler_weights>/<name>`` -> ref.
+
+        Anything else -- a filesystem path, a bare ``tinker://<model>``, an
+        unknown kind, extra segments -- is InvalidCheckpointPath."""
+        if not isinstance(uri, str) or not uri.startswith(SCHEME):
+            raise InvalidCheckpointPath(
+                f"checkpoint path must be {SCHEME}<model_id>/<weights|sampler_weights>/<name>, got {uri!r}")
+        parts = uri[len(SCHEME):].split("/")
+        if len(parts) != 3:
+            raise InvalidCheckpointPath(
+                f"checkpoint path must be {SCHEME}<model_id>/<weights|sampler_weights>/<name>, got {uri!r}")
+        model_id, kind, name = parts
+        try:
+            kind_v = CheckpointKind(kind)
+        except ValueError:
+            raise InvalidCheckpointPath(
+                f"checkpoint kind must be weights or sampler_weights, got {kind!r} in {uri!r}") from None
+        return cls(_segment(model_id, "model_id"), kind_v, _segment(name, "checkpoint name"))
+
+    @classmethod
+    def make(cls, model_id: str, kind: CheckpointKind, name: str) -> "CheckpointRef":
+        return cls(_segment(model_id, "model_id"), CheckpointKind(kind), _segment(name, "checkpoint name"))
+
+    @property
+    def uri(self) -> str:
+        return f"{SCHEME}{self.model_id}/{self.kind.value}/{self.name}"
+
+    @property
+    def record_key(self) -> str:
+        return f"{self.kind.value}--{self.name}"
+
+    def __str__(self) -> str:
+        return self.uri
+
+
+@dataclass(frozen=True)
+class SaveTicket:
+    """What a save in flight needs: its identity, the directory to fill and
+    the counter value it was assigned (None for an ephemeral save)."""
+
+    ref: CheckpointRef
+    root: Path
+    step: Optional[int]
+
+
+# --- store -------------------------------------------------------------------
+
+class CheckpointStore:
+    def __init__(self, base: Path, metadata: MetadataStorage):
+        self.base = Path(base)
+        self.metadata = metadata
+
+    # layout ------------------------------------------------------------------
+
+    def model_dir(self, model_id: str) -> Path:
+        return self.base / _segment(model_id, "model_id")
+
+    def root(self, ref: CheckpointRef) -> Path:
+        return self.model_dir(ref.model_id) / ref.kind.value / ref.name
+
+    def native_root(self, model_id: str) -> Path:
+        """The backend's private per-model directory; created on demand."""
+        p = self.model_dir(model_id) / NATIVE_DIRNAME
+        p.mkdir(parents=True, exist_ok=True)
+        return p
+
+    # records -----------------------------------------------------------------
+
+    def get(self, ref: CheckpointRef) -> Optional[Dict[str, Any]]:
+        return self.metadata.load_checkpoint(ref.model_id, ref.record_key)
+
+    def _write(self, ref: CheckpointRef, record: Dict[str, Any]) -> None:
+        self.metadata.save_checkpoint(ref.model_id, ref.record_key, record)
+
+    def records(self, model_id: str) -> List[Dict[str, Any]]:
+        out = []
+        for rec in self.metadata.list_checkpoints(model_id, limit=100000):
+            if "kind" in rec and "name" in rec:  # this store's records only
+                out.append(rec)
+        return out
+
+    def next_step(self, model_id: str) -> int:
+        """Monotonic per model: one past the largest counter ever assigned,
+        failed and deleted saves included, so a backend's counter-named
+        native artifact is never overwritten by a later save."""
+        steps = [int(r["step"]) for r in self.records(model_id) if r.get("step") is not None]
+        return max(steps, default=0) + 1
+
+    # lifecycle ---------------------------------------------------------------
+
+    def begin_save(
+        self,
+        model_id: str,
+        kind: CheckpointKind,
+        name: str,
+        *,
+        persist: bool = True,
+        weight_version: Optional[int] = None,
+    ) -> SaveTicket:
+        """Record a pending save and hand back where to write. A name already
+        recorded for this model and kind is overwritten by the new save (the
+        API lets a client save twice under one name); its old counter value is
+        not reused."""
+        ref = CheckpointRef.make(model_id, kind, name)
+        root = self.root(ref)
+        step = self.next_step(model_id) if persist else None
+        if persist:
+            if root.exists():
+                shutil.rmtree(root)
+            root.mkdir(parents=True, exist_ok=True)
+        self._write(ref, {
+            "model_id": ref.model_id, "kind": ref.kind.value, "name": ref.name,
+            "status": CheckpointStatus.PENDING.value, "step": step, "ephemeral": not persist,
+            "weight_version": weight_version, "error": None, "completed_at": None,
+        })
+        return SaveTicket(ref=ref, root=root, step=step)
+
+    def complete(self, ref: CheckpointRef) -> None:
+        self._set_status(ref, CheckpointStatus.COMPLETED, None)
+
+    def fail(self, ref: CheckpointRef, error: str) -> None:
+        self._set_status(ref, CheckpointStatus.FAILED, error)
+
+    def _set_status(self, ref: CheckpointRef, status: CheckpointStatus, error: Optional[str]) -> None:
+        rec = self.get(ref)
+        if rec is None:
+            raise CheckpointNotFound(f"no record for {ref.uri}")
+        rec["status"] = status.value
+        rec["error"] = error
+        rec["completed_at"] = datetime.utcnow().isoformat()
+        self._write(ref, rec)
+
+    def sweep_pending(self) -> int:
+        """Boot: a save that was in flight when the process died never finished."""
+        n = 0
+        for model_dir in sorted(self.metadata.checkpoints_dir.glob("*")):
+            if not model_dir.is_dir():
+                continue
+            for rec in self.records(model_dir.name):
+                if rec.get("status") == CheckpointStatus.PENDING.value:
+                    ref = CheckpointRef.make(rec["model_id"], rec["kind"], rec["name"])
+                    self.fail(ref, "server restarted while the save was in flight")
+                    n += 1
+        return n
+
+    # reads -------------------------------------------------------------------
+
+    def require(self, ref: CheckpointRef, kind: Optional[CheckpointKind] = None) -> Path:
+        """The root of a completed checkpoint, or the error a client should see."""
+        if kind is not None and ref.kind != kind:
+            raise CheckpointKindMismatch(f"{ref.uri} is a {ref.kind.value} checkpoint; {kind.value} required")
+        rec = self.get(ref)
+        if rec is None:
+            raise CheckpointNotFound(f"Checkpoint not found: {ref.uri}")
+        status = rec.get("status")
+        if status == CheckpointStatus.PENDING.value:
+            raise CheckpointPending(f"Checkpoint is still being created: {ref.uri}")
+        if status == CheckpointStatus.FAILED.value:
+            raise CheckpointFailed(f"Checkpoint creation failed: {ref.uri}: {rec.get('error')}")
+        return self.root(ref)
+
+    def resolve_resume(self, uri: str) -> Path:
+        """The root a training resume (create_model / load_weights) may load."""
+        return self.require(CheckpointRef.parse(uri), kind=CheckpointKind.WEIGHTS)
+
+    def list(self, model_id: str, with_size: bool = True) -> List[Dict[str, Any]]:
+        """Persistent records of a model, newest first, each with its uri and
+        (optionally) the bytes under its root."""
+        out = []
+        for rec in self.records(model_id):
+            if rec.get("ephemeral"):
+                continue
+            ref = CheckpointRef.make(rec["model_id"], rec["kind"], rec["name"])
+            item = dict(rec, uri=ref.uri)
+            if with_size:
+                root = self.root(ref)
+                item["size_bytes"] = (
+                    sum(os.path.getsize(os.path.join(d, f)) for d, _, fs in os.walk(root) for f in fs)
+                    if root.is_dir() else None
+                )
+            out.append(item)
+        out.sort(key=lambda r: r.get("created_at") or "", reverse=True)
+        return out
+
+    # deletion ----------------------------------------------------------------
+
+    def delete(self, ref: CheckpointRef) -> bool:
+        """Remove the record and the bytes under the root. A backend's private
+        artifacts under native/ are not touched (the store does not know them)."""
+        if self.get(ref) is None:
+            return False
+        root = self.root(ref)
+        if root.is_dir():
+            shutil.rmtree(root, ignore_errors=True)
+        self.metadata.delete_checkpoint(ref.model_id, ref.record_key)
+        logger.info("Deleted checkpoint %s (%s)", ref.uri, root)
+        return True
+
+    def release_model(self, model_id: str) -> int:
+        """The model is gone from the server: drop its ephemeral records.
+        Persistent checkpoints and native/ stay -- a client resumes from them
+        after its training client is deleted."""
+        n = 0
+        for rec in self.records(model_id):
+            if rec.get("ephemeral"):
+                ref = CheckpointRef.make(rec["model_id"], rec["kind"], rec["name"])
+                self.metadata.delete_checkpoint(ref.model_id, ref.record_key)
+                n += 1
+        return n

--- a/training/config.py
+++ b/training/config.py
@@ -31,6 +31,10 @@ class StorageConfig(BaseModel):
         default_factory=lambda: Path(os.getenv("METADATA_DIR", "/data/metadata")),
         description="Base directory for metadata storage"
     )
+    checkpoint_base: Path = Field(
+        default_factory=lambda: Path(os.getenv("TINKERCLOUD_CHECKPOINT_BASE", "/data/checkpoints")),
+        description="Root under which every model's checkpoints and native area live",
+    )
     futures_db_name: str = Field(
         default="futures.db",
         description="SQLite database filename"

--- a/training/core/dependencies.py
+++ b/training/core/dependencies.py
@@ -16,6 +16,14 @@ def get_auth(request: Request) -> APIKeyAuth:
     return auth
 
 
+def get_checkpoint_store(request: Request):
+    """The CheckpointStore built at startup (training/checkpoints/store.py)."""
+    store = getattr(request.app.state, "checkpoint_store", None)
+    if store is None:
+        raise RuntimeError("CheckpointStore not initialized on app state")
+    return store
+
+
 async def verify_api_key_dep(
     x_api_key: Optional[str] = Header(None),
     auth: APIKeyAuth = Depends(get_auth)

--- a/training/models/responses.py
+++ b/training/models/responses.py
@@ -303,8 +303,8 @@ class SaveWeightsForSamplerResult(_Result):
     type: str = Field(default="save_weights_for_sampler", description="Response type")
     path: Optional[str] = Field(default=None, description="Tinker URI path (for persistent saves)")
     sampling_session_id: Optional[str] = Field(default=None, description="Sampling session ID (for ephemeral saves)")
-    checkpoint_path: Optional[str] = Field(default=None, description="Filesystem path")
-    step_id: Optional[int] = Field(default=None, description="Checkpoint step ID")
+    uri: Optional[str] = Field(default=None, description="Identity of the saved sampler weights, ephemeral saves included")
+    step: Optional[int] = Field(default=None, description="The store's per-model save counter (None for ephemeral)")
     name: Optional[str] = Field(default=None, description="Checkpoint name")
     status: str = Field(default="completed", description="Operation status")
 

--- a/training/routers/checkpoints.py
+++ b/training/routers/checkpoints.py
@@ -15,7 +15,8 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from ..services.checkpoint_service import CheckpointService
 from ..services.session_service import SessionService
 from ..core.task_manager import TaskManager
-from ..core.dependencies import verify_api_key_dep
+from ..core.dependencies import verify_api_key_dep, get_checkpoint_store
+from ..checkpoints import CheckpointKind, CheckpointRef, CheckpointStore
 from ..storage import MetadataStorage, FuturesStorage
 from ..models.requests import (
     LoadWeightsRequest,
@@ -116,7 +117,6 @@ async def save_weights(
             request_id=request_id,
             path=request.path,
             training_clients=training_clients,
-            metadata_storage=metadata_storage
         )
 
     # Create async task
@@ -165,7 +165,6 @@ async def save_weights_for_sampler(
             request_id=request_id,
             name=request.name,
             training_clients=training_clients,
-            metadata_storage=metadata_storage,
             path=request.path,
             sampling_session_seq_id=request.sampling_session_seq_id
         )
@@ -173,7 +172,6 @@ async def save_weights_for_sampler(
         # Register ephemeral sampler with session if sampling_session_id was created
         sampling_session_id = result.get("sampling_session_id")
         if sampling_session_id:
-            checkpoint_path = result.get("checkpoint_path")
             # BUG-015: pin the weight version at save time so pinned logprob
             # reads are not served from the live (refit-every-step) engine.
             backend_handle = client_info.get("backend_handle")
@@ -182,7 +180,7 @@ async def save_weights_for_sampler(
                 sampler_id=sampling_session_id,
                 model_id=request.model_id,
                 base_model=base_model,
-                model_path=checkpoint_path,
+                model_path=result.get("uri"),
                 pinned_version=pinned_version,
             )
 
@@ -213,6 +211,7 @@ async def load_weights(
     futures_storage: FuturesStorage = Depends(get_futures_storage),
     metadata_storage: MetadataStorage = Depends(get_metadata_storage),
     training_clients: Dict = Depends(get_training_clients),
+    store: CheckpointStore = Depends(get_checkpoint_store),
 ):
     """Load a saved training checkpoint into a model.
 
@@ -230,16 +229,13 @@ async def load_weights(
             detail=f"LoadWeights is not permitted with seq_id {request.seq_id}: the model has already "
                    "trained; create a new model with checkpoint_path instead",
         )
-    parts = request.path.removeprefix("tinker://").split("/")
-    if not request.path.startswith("tinker://") or len(parts) != 3 or parts[1] != "weights":
-        raise HTTPException(status_code=400, detail=f"path must be tinker://<run>/weights/<name>, got {request.path!r}")
-    if metadata_storage.load_checkpoint(parts[0], parts[2]) is None:
-        raise HTTPException(status_code=404, detail=f"Checkpoint not found: {request.path}")
+    ref = CheckpointRef.parse(request.path)           # 400 on a malformed path
+    store.require(ref, kind=CheckpointKind.WEIGHTS)   # 404 / 425 / 500 / wrong kind, before the future exists
     request_id = generate_request_id()
 
     async def execute():
         return await service.load_weights(
-            model_id=request.model_id, request_id=request_id, path=request.path,
+            model_id=request.model_id, request_id=request_id, ref=ref,
             optimizer=request.optimizer,
             training_clients=training_clients, metadata_storage=metadata_storage,
         )
@@ -262,13 +258,15 @@ async def list_checkpoints(
     """Checkpoints of a training run, in the SDK's CheckpointsListResponse shape."""
     if metadata_storage.load_training_run(model_id) is None:
         raise HTTPException(status_code=404, detail=f"Training run not found: {model_id}")
-    return {"checkpoints": service.list_checkpoints(model_id, metadata_storage), "cursor": None}
+    return {"checkpoints": service.list_checkpoints(model_id), "cursor": None}
 
 
-def _delete(service, metadata_storage, model_id, checkpoint_type, checkpoint_id):
-    if checkpoint_type not in ("training", "sampler"):
+def _delete(service, model_id, checkpoint_type, checkpoint_id):
+    kinds = {"training": CheckpointKind.WEIGHTS, "sampler": CheckpointKind.SAMPLER_WEIGHTS}
+    if checkpoint_type not in kinds:
         raise HTTPException(status_code=400, detail="checkpoint_type must be 'training' or 'sampler'")
-    if not service.delete_checkpoint(model_id, checkpoint_type, checkpoint_id, metadata_storage):
+    ref = CheckpointRef.make(model_id, kinds[checkpoint_type], checkpoint_id)
+    if not service.delete_checkpoint(ref):
         raise HTTPException(status_code=404, detail=f"Checkpoint not found: {checkpoint_type} {checkpoint_id} of {model_id}")
     return Response(status_code=204)
 
@@ -284,7 +282,7 @@ async def delete_checkpoint_typed(
     kinds = {"weights": "training", "sampler_weights": "sampler"}
     if kind not in kinds:
         raise HTTPException(status_code=400, detail="checkpoint path must be weights/<id> or sampler_weights/<id>")
-    return _delete(service, metadata_storage, model_id, kinds[kind], checkpoint_id)
+    return _delete(service, model_id, kinds[kind], checkpoint_id)
 
 
 @router.delete("/api/v1/training_runs/{model_id}/checkpoints/{checkpoint_id}")
@@ -298,7 +296,7 @@ async def delete_checkpoint_bare(
     if not checkpoint_type:
         raise HTTPException(status_code=400, detail="specify the kind: .../checkpoints/weights/<id>, "
                             ".../checkpoints/sampler_weights/<id>, or ?checkpoint_type=training|sampler")
-    return _delete(service, metadata_storage, model_id, checkpoint_type, checkpoint_id)
+    return _delete(service, model_id, checkpoint_type, checkpoint_id)
 
 
 @router.post("/api/v1/weights_info", response_model=WeightsInfoResponse)
@@ -306,32 +304,22 @@ async def weights_info(
     request: WeightsInfoRequest,
     _: None = Depends(verify_api_key_dep),
     training_clients: Dict = Depends(get_training_clients),
-    metadata_storage: MetadataStorage = Depends(get_metadata_storage)
+    metadata_storage: MetadataStorage = Depends(get_metadata_storage),
+    store: CheckpointStore = Depends(get_checkpoint_store),
 ):
     """
     Get weights/checkpoint info from tinker path.
     Used for loading checkpoints via create_training_client_from_state.
 
-    Parses tinker:// URI and returns model metadata needed for checkpoint loading.
-    Validates both the model exists AND the specific checkpoint is recorded.
+    The path must name a completed checkpoint of either kind (400 malformed,
+    404 unknown, 425 still being written); the model info comes from the live
+    client or the stored training run.
     """
     tinker_path = request.tinker_path
     logger.info(f"weights_info request for: {tinker_path}")
-
-    # Parse tinker:// path: tinker://model_xxx/weights/checkpoint_name
-    if not tinker_path.startswith("tinker://"):
-        raise HTTPException(status_code=400, detail=f"Invalid tinker path: {tinker_path}")
-
-    # Extract model_id and checkpoint_name from path: tinker://model_xxx/weights/checkpoint_name
-    path_parts = tinker_path[9:].split("/")  # Remove "tinker://"
-    if len(path_parts) < 1:
-        raise HTTPException(status_code=400, detail=f"Invalid tinker path format: {tinker_path}")
-
-    model_id = path_parts[0]
-    checkpoint_name = path_parts[2] if len(path_parts) >= 3 else None
-    if checkpoint_name and path_parts[1] == "sampler_weights":
-        checkpoint_name = f"sampler_{checkpoint_name}"  # metadata key used by save_weights_for_sampler
-    logger.info(f"Extracted model_id: {model_id}, checkpoint_name: {checkpoint_name}")
+    ref = CheckpointRef.parse(tinker_path)
+    store.require(ref)
+    model_id = ref.model_id
 
     # Try to find model in active training clients first
     if model_id in training_clients:
@@ -339,17 +327,6 @@ async def weights_info(
         base_model = client_info.get("base_model", "")
         lora_rank = int((client_info.get("lora_config") or {}).get("rank") or 0)
         is_lora = lora_rank > 0
-
-        # Verify checkpoint exists if name was provided
-        if checkpoint_name:
-            checkpoint_meta = metadata_storage.load_checkpoint(model_id, checkpoint_name)
-            if not checkpoint_meta:
-                logger.warning(f"Checkpoint {checkpoint_name} not found for model {model_id}")
-                raise HTTPException(
-                    status_code=404,
-                    detail=f"Checkpoint not found: {checkpoint_name} for model {model_id}"
-                )
-
         logger.info(f"Found active model: base_model={base_model}, is_lora={is_lora}, lora_rank={lora_rank}")
         return WeightsInfoResponse(
             base_model=base_model,
@@ -364,17 +341,6 @@ async def weights_info(
         lora_config = metadata.get("lora_config", {})
         lora_rank = lora_config.get("rank", 0) if lora_config else 0
         is_lora = lora_rank > 0
-
-        # Verify checkpoint exists if name was provided
-        if checkpoint_name:
-            checkpoint_meta = metadata_storage.load_checkpoint(model_id, checkpoint_name)
-            if not checkpoint_meta:
-                logger.warning(f"Checkpoint {checkpoint_name} not found for model {model_id}")
-                raise HTTPException(
-                    status_code=404,
-                    detail=f"Checkpoint not found: {checkpoint_name} for model {model_id}"
-                )
-
         logger.info(f"Found stored metadata: base_model={base_model}, is_lora={is_lora}, lora_rank={lora_rank}")
         return WeightsInfoResponse(
             base_model=base_model,

--- a/training/routers/sampling.py
+++ b/training/routers/sampling.py
@@ -13,7 +13,8 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 
 from ..services.sampling_service import SamplingService
 from ..core.task_manager import TaskManager
-from ..core.dependencies import verify_api_key_dep
+from ..core.dependencies import verify_api_key_dep, get_checkpoint_store
+from ..checkpoints import CheckpointRef, CheckpointStore
 from ..storage import FuturesStorage
 from ..models.requests import (
     ASampleRequest,
@@ -89,13 +90,15 @@ def resolve_target_model(
     sampling_session_id: Optional[str] = None,
     model_path: Optional[str] = None,
     base_model: Optional[str] = None,
+    store: Optional[CheckpointStore] = None,
 ) -> tuple:
     """Return (model_id, pinned_version) for a sampling request, or raise.
 
     A sampler names its owning model (registered at save_weights_for_sampler /
-    create_sampling_session); a bare model_path names it by URI. There is no
-    fallback to "some model": under a multi-tenant pool that serves a
-    co-tenant's adapter, and a bare base_model has no engine behind it.
+    create_sampling_session); a checkpoint model_path names it through the
+    store. There is no fallback to "some model": under a multi-tenant pool
+    that serves a co-tenant's adapter, and a bare base_model has no engine
+    behind it.
     """
     if sampling_session_id:
         info = session_service.get_sampler(sampling_session_id) if session_service is not None else None
@@ -107,18 +110,19 @@ def resolve_target_model(
             raise HTTPException(status_code=404, detail=f"Sampler {sampling_session_id}'s model {info.model_id} no longer exists")
         return info.model_id, getattr(info, "pinned_version", None)
     if model_path:
-        model_id = model_id_from_path(model_path)
-        if model_id not in training_clients:
-            raise HTTPException(status_code=404, detail=f"Model {model_id!r} from model_path {model_path!r} not found")
-        return model_id, None
+        # A checkpoint path names its model AND the weight version it was
+        # saved at: the sampler is pinned there, not served the live weights.
+        ref = CheckpointRef.parse(model_path)
+        if store is None:
+            raise RuntimeError("resolve_target_model needs the checkpoint store to resolve a model_path")
+        store.require(ref)
+        if ref.model_id not in training_clients:
+            raise HTTPException(status_code=404, detail=f"Model {ref.model_id!r} from model_path {model_path!r} not found")
+        rec = store.get(ref) or {}
+        return ref.model_id, rec.get("weight_version")
     if base_model:
         raise HTTPException(status_code=400, detail=BASE_MODEL_SAMPLING_UNSUPPORTED)
     raise HTTPException(status_code=400, detail="Provide sampling_session_id or a tinker:// model_path")
-
-
-def model_id_from_path(model_path: str) -> str:
-    """tinker://<model_id>/... -> model_id."""
-    return model_path.removeprefix("tinker://").split("/")[0]
 
 
 def _sequence_ids(request_id: str, n: int) -> List[str]:
@@ -135,6 +139,7 @@ async def asample(
     task_manager: TaskManager = Depends(get_task_manager),
     training_clients: Dict = Depends(get_training_clients),
     session_service=Depends(get_session_service),
+    store: CheckpointStore = Depends(get_checkpoint_store),
 ):
     """
     Async sampling via SGLang.
@@ -153,7 +158,7 @@ async def asample(
     model_id, pinned_version = resolve_target_model(
         training_clients, session_service,
         sampling_session_id=request.sampling_session_id,
-        model_path=request.model_path, base_model=request.base_model,
+        model_path=request.model_path, base_model=request.base_model, store=store,
     )
     target_model_id = model_id
 
@@ -202,6 +207,7 @@ async def sample(
     task_manager: TaskManager = Depends(get_task_manager),
     training_clients: Dict = Depends(get_training_clients),
     session_service=Depends(get_session_service),
+    store: CheckpointStore = Depends(get_checkpoint_store),
 ):
     """
     Synchronous sampling via SGLang.
@@ -212,7 +218,7 @@ async def sample(
     model_id, _ = resolve_target_model(
         training_clients, session_service,
         sampling_session_id=request.sampling_session_id,
-        model_path=request.model_path, base_model=request.base_model,
+        model_path=request.model_path, base_model=request.base_model, store=store,
     )
 
     async def execute():
@@ -253,6 +259,7 @@ async def create_sampling_client(
     task_manager: TaskManager = Depends(get_task_manager),
     training_clients: Dict = Depends(get_training_clients),
     session_service=Depends(get_session_service),
+    store: CheckpointStore = Depends(get_checkpoint_store),
 ):
     """
     Create sampling client bound to the model named by model_path.
@@ -262,7 +269,7 @@ async def create_sampling_client(
 
     model_id, _ = resolve_target_model(
         training_clients, session_service,
-        model_path=request.model_path, base_model=request.base_model,
+        model_path=request.model_path, base_model=request.base_model, store=store,
     )
 
     async def execute():

--- a/training/routers/session.py
+++ b/training/routers/session.py
@@ -27,7 +27,8 @@ from ..models.responses import (
     ListSessionsResponse,
     GetSamplerResponse,
 )
-from ..core.dependencies import verify_api_key_dep
+from ..core.dependencies import verify_api_key_dep, get_checkpoint_store
+from ..checkpoints import CheckpointStore
 from ..services.session_service import SessionService
 
 logger = logging.getLogger(__name__)
@@ -108,6 +109,7 @@ async def create_sampling_session(
     _: None = Depends(verify_api_key_dep),
     session_service: SessionService = Depends(get_session_service),
     training_clients: Dict = Depends(get_training_clients),
+    store: CheckpointStore = Depends(get_checkpoint_store),
 ):
     """
     Create a sampling session for inference.
@@ -125,9 +127,9 @@ async def create_sampling_session(
     # A sampler must name its owning model: a tinker:// model_path does; a bare
     # base_model has no engine behind it.
     from .sampling import resolve_target_model
-    model_id, _ = resolve_target_model(
+    model_id, pinned_version = resolve_target_model(
         training_clients, session_service,
-        model_path=request.model_path, base_model=request.base_model,
+        model_path=request.model_path, base_model=request.base_model, store=store,
     )
 
     # Generate sampling_session_id
@@ -142,6 +144,7 @@ async def create_sampling_session(
         base_model=request.base_model or training_clients[model_id].get("base_model"),
         model_path=request.model_path,
         model_id=model_id,
+        pinned_version=pinned_version,   # a checkpoint path pins the sampler at its saved version
     )
 
     logger.info(

--- a/training/services/checkpoint_service.py
+++ b/training/services/checkpoint_service.py
@@ -1,22 +1,20 @@
 """
-Checkpoint Service - Business Logic for Model Checkpointing
+Checkpoint Service - saves, loads, listing and deletion.
 
-Handles:
-- Saving model weights to disk (delegates to backend)
-- Saving weights for SGLang sampler
-- Checkpoint metadata management
+The service orchestrates: the store (training/checkpoints) decides where a
+checkpoint lives and records what happened to it; the backend writes and
+reads directories it is handed. Every save is pending from begin_save until
+the backend returns, then completed or failed.
 """
 import logging
-import os
-import shutil
 import time
 import uuid
 from datetime import datetime
 from typing import Dict, Any, Optional
 
 from ..backends.base import TrainingBackend
+from ..checkpoints import CheckpointKind, CheckpointRef, CheckpointStore
 from ..storage import MetadataStorage
-from ..backends.checkpoint_interchange import resolve_checkpoint_root
 
 logger = logging.getLogger(__name__)
 
@@ -24,130 +22,85 @@ logger = logging.getLogger(__name__)
 class CheckpointService:
     """Service for managing model checkpoints and weights."""
 
-    def __init__(self, backend: TrainingBackend):
+    def __init__(self, backend: TrainingBackend, store: CheckpointStore):
         self.backend = backend
+        self.store = store
 
     @staticmethod
-    def _next_step_id(client_info: Dict[str, Any]) -> int:
-        """Monotonic per-model save counter (the backend's iteration label)."""
-        client_info["save_counter"] = client_info.get("save_counter", 0) + 1
-        return client_info["save_counter"]
+    def _client(training_clients: Dict[str, Dict[str, Any]], model_id: str) -> Dict[str, Any]:
+        if model_id not in training_clients:
+            raise KeyError(f"Model {model_id} not found")
+        return training_clients[model_id]
+
+    async def _save(self, handle, ticket) -> None:
+        try:
+            await self.backend.save_checkpoint(
+                handle, ticket.root, step=ticket.step, persist=ticket.step is not None,
+            )
+        except Exception as e:
+            self.store.fail(ticket.ref, str(e))
+            raise
+        self.store.complete(ticket.ref)
 
     async def save_weights(
         self,
         model_id: str,
         request_id: str,
-        path: str,
+        path: Optional[str],
         training_clients: Dict[str, Dict[str, Any]],
-        metadata_storage: MetadataStorage,
     ) -> Dict[str, Any]:
-        """
-        Save model weights to disk.
-
-        Raises:
-            KeyError: If model_id not found
-        """
-        if model_id not in training_clients:
-            raise KeyError(f"Model {model_id} not found")
-
-        client_info = training_clients[model_id]
+        """Save a training checkpoint (weights + whatever optimizer state the
+        backend can write) under the name the client chose."""
+        client_info = self._client(training_clients, model_id)
         handle = client_info["backend_handle"]
-        training_run_id = client_info["training_run_id"]
-
-        # Generate checkpoint name and step_id
-        checkpoint_name = path or f"checkpoint_{int(time.time())}"
-        step_id = self._next_step_id(client_info)
-        checkpoint_path = f"tinker://{training_run_id}/weights/{checkpoint_name}"
-
-        logger.info("[%s] Saving weights for %s to %s", request_id, model_id, checkpoint_path)
-
-        # Delegate actual save to backend
-        await self.backend.save_checkpoint(handle, checkpoint_path, step_id=step_id)
-
-        # Save checkpoint metadata
-        metadata_storage.save_checkpoint(
-            model_id=model_id,
-            checkpoint_name=checkpoint_name,
-            checkpoint_data={
-                "path": checkpoint_path,
-                "created_at": datetime.now().isoformat(),
-                "type": "manual_save",
-            },
+        name = path or f"checkpoint_{int(time.time())}"
+        ticket = self.store.begin_save(
+            model_id, CheckpointKind.WEIGHTS, name,
+            weight_version=getattr(handle, "weight_version", None),
         )
-
-        logger.info("[%s] Weights saved successfully", request_id)
-
-        return {
-            "path": checkpoint_path,
-            "checkpoint_path": checkpoint_path,
-            "step_id": step_id,
-            "name": checkpoint_name,
-            "type": "save_weights",
-        }
+        logger.info("[%s] Saving weights for %s to %s (step %s)", request_id, model_id, ticket.ref.uri, ticket.step)
+        await self._save(handle, ticket)
+        logger.info("[%s] Weights saved: %s", request_id, ticket.ref.uri)
+        return {"path": ticket.ref.uri, "step": ticket.step, "name": name, "type": "save_weights"}
 
     async def load_weights(
         self,
         model_id: str,
         request_id: str,
-        path: str,
+        ref: CheckpointRef,
         training_clients: Dict[str, Dict[str, Any]],
         metadata_storage: MetadataStorage,
         optimizer: bool = False,
     ) -> Dict[str, Any]:
-        """Load a training checkpoint into a live model: weights, plus optimizer
-        state when asked (the backend refuses rather than partially resumes)."""
-        if model_id not in training_clients:
-            raise KeyError(f"Model {model_id} not found")
-        handle = training_clients[model_id]["backend_handle"]
+        """Load a completed training checkpoint into a live model: weights, plus
+        optimizer state when asked (the backend refuses rather than partially
+        resumes)."""
+        handle = self._client(training_clients, model_id)["backend_handle"]
+        root = self.store.require(ref, kind=CheckpointKind.WEIGHTS)
         logger.info("[%s] Loading %s for %s from %s", request_id,
-                    "weights + optimizer state" if optimizer else "weights", model_id, path)
-        await self.backend.load_checkpoint(handle, path, optimizer=optimizer)
+                    "weights + optimizer state" if optimizer else "weights", model_id, ref.uri)
+        await self.backend.load_checkpoint(handle, root, optimizer=optimizer)
         metadata_storage.update_training_run(
-            training_clients[model_id].get("training_run_id", model_id),
-            {"loaded_from": path, "last_request_time": datetime.now().isoformat()},
+            model_id, {"loaded_from": ref.uri, "last_request_time": datetime.now().isoformat()},
         )
-        return {"type": "load_weights", "path": path, "model_id": model_id}
+        return {"type": "load_weights", "path": ref.uri, "model_id": model_id}
 
-    @staticmethod
-    def delete_checkpoint(
-        model_id: str,
-        checkpoint_type: str,
-        checkpoint_id: str,
-        metadata_storage: MetadataStorage,
-    ) -> bool:
-        """Remove a checkpoint's metadata record and its bytes. Returns False if unknown."""
-        kind = "weights" if checkpoint_type == "training" else "sampler_weights"
-        meta_name = checkpoint_id if kind == "weights" else f"sampler_{checkpoint_id}"
-        if metadata_storage.load_checkpoint(model_id, meta_name) is None:
-            return False
-        root = resolve_checkpoint_root(f"tinker://{model_id}/{kind}/{checkpoint_id}")
-        if os.path.isdir(root):
-            shutil.rmtree(root, ignore_errors=True)
-        metadata_storage.delete_checkpoint(model_id, meta_name)
-        logger.info("Deleted %s checkpoint %s of %s (%s)", checkpoint_type, checkpoint_id, model_id, root)
-        return True
+    def delete_checkpoint(self, ref: CheckpointRef) -> bool:
+        """Remove a checkpoint's record and bytes. False if unknown."""
+        return self.store.delete(ref)
 
-    @staticmethod
-    def list_checkpoints(model_id: str, metadata_storage: MetadataStorage) -> list:
+    def list_checkpoints(self, model_id: str) -> list:
         """Tinker-shaped checkpoint records for a training run."""
         out = []
-        for rec in metadata_storage.list_checkpoints(model_id, limit=1000):
-            is_sampler = rec.get("type") == "sampler"
-            path = rec.get("tinker_uri") if is_sampler else rec.get("path")
-            if not path:
-                continue
-            name = path.removeprefix("tinker://").split("/")[-1]
-            kind = "sampler_weights" if is_sampler else "weights"
-            root = resolve_checkpoint_root(path)
-            size = None
-            if os.path.isdir(root):
-                size = sum(os.path.getsize(os.path.join(d, f)) for d, _, fs in os.walk(root) for f in fs)
+        for rec in self.store.list(model_id):
+            kind = CheckpointKind(rec["kind"])
             out.append({
-                "checkpoint_id": f"{kind}/{name}",
-                "checkpoint_type": "sampler" if is_sampler else "training",
+                "checkpoint_id": f"{kind.value}/{rec['name']}",
+                "checkpoint_type": "sampler" if kind is CheckpointKind.SAMPLER_WEIGHTS else "training",
                 "time": rec.get("created_at"),
-                "tinker_path": path,
-                "size_bytes": size,
+                "tinker_path": rec["uri"],
+                "size_bytes": rec.get("size_bytes"),
+                "status": rec.get("status"),
             })
         return out
 
@@ -157,76 +110,38 @@ class CheckpointService:
         request_id: str,
         name: Optional[str],
         training_clients: Dict[str, Dict[str, Any]],
-        metadata_storage: MetadataStorage,
         path: Optional[str] = None,
         sampling_session_seq_id: Optional[int] = None,
     ) -> Dict[str, Any]:
-        """
-        Save weights for SGLang sampler.
-
-        Raises:
-            KeyError: If model_id not found
-        """
-        if model_id not in training_clients:
-            raise KeyError(f"Model {model_id} not found")
-
-        client_info = training_clients[model_id]
+        """Save sampler weights. With a sampling_session_seq_id and no name the
+        save is ephemeral: the weights already reached the inference engine, so
+        the backend writes nothing and the record only names the sampler; the
+        client gets path=None and a sampling_session_id, as the SDK expects."""
+        client_info = self._client(training_clients, model_id)
         handle = client_info["backend_handle"]
-        training_run_id = client_info.get("training_run_id", model_id)
+        ephemeral = sampling_session_seq_id is not None and path is None and name is None
+        weight_version = getattr(handle, "weight_version", None)
 
-        # Check if this is an ephemeral save (sampling_session_seq_id provided, no path/name)
-        is_ephemeral = sampling_session_seq_id is not None and path is None and name is None
-        logger.info(
-            "[%s] save_weights_for_sampler: sampling_session_seq_id=%s, path=%r, name=%r, is_ephemeral=%s",
-            request_id, sampling_session_seq_id, path, name, is_ephemeral,
-        )
-
-        if is_ephemeral:
-            # Ephemeral save — generate sampling_session_id, don't persist path.
-            # Skip save_model: weights are already synced to SGLang via update_weights().
-            sampling_session_id = f"{model_id}_{sampling_session_seq_id}_{uuid.uuid4().hex[:8]}"
-            logger.info("[%s] Ephemeral save for sampler: %s -> %s", request_id, model_id, sampling_session_id)
-            logger.info("[%s] Skipping save_model for ephemeral save (weights already in SGLang)", request_id)
-
-            return {
-                "path": None,
-                "sampling_session_id": sampling_session_id,
-                "type": "save_weights_for_sampler",
-            }
-        else:
-            # Persistent save — use path/name
-            logger.info("[%s] Saving weights for sampler: %s", request_id, model_id)
-
-            checkpoint_name = path or name or f"sampler_{int(time.time())}"
-            step_id = self._next_step_id(client_info)
-            tinker_uri = f"tinker://{training_run_id}/sampler_weights/{checkpoint_name}"
-            # The backend resolves the URI through resolve_checkpoint_root, so the
-            # recorded filesystem path is where the bytes actually land.
-            checkpoint_path = resolve_checkpoint_root(tinker_uri)
-
-            # Delegate actual save to backend
-            await self.backend.save_checkpoint(handle, tinker_uri, step_id=step_id)
-
-            # Save checkpoint metadata
-            metadata_storage.save_checkpoint(
-                model_id=model_id,
-                checkpoint_name=f"sampler_{checkpoint_name}",
-                checkpoint_data={
-                    "path": checkpoint_path,
-                    "tinker_uri": tinker_uri,
-                    "created_at": datetime.now().isoformat(),
-                    "type": "sampler",
-                    "step_id": step_id,
-                },
+        if ephemeral:
+            name = f"{model_id}_{sampling_session_seq_id}_{uuid.uuid4().hex[:8]}"
+            ticket = self.store.begin_save(
+                model_id, CheckpointKind.SAMPLER_WEIGHTS, name, persist=False, weight_version=weight_version,
             )
-
-            logger.info("[%s] Weights saved to %s", request_id, tinker_uri)
-
+            logger.info("[%s] Ephemeral sampler save for %s: %s", request_id, model_id, ticket.ref.uri)
+            await self._save(handle, ticket)
             return {
-                "path": tinker_uri,
-                "sampling_session_id": None,
-                "checkpoint_path": checkpoint_path,
-                "step_id": step_id,
-                "name": checkpoint_name,
+                "path": None, "sampling_session_id": name, "uri": ticket.ref.uri,
                 "type": "save_weights_for_sampler",
             }
+
+        name = path or name or f"sampler_{int(time.time())}"
+        ticket = self.store.begin_save(
+            model_id, CheckpointKind.SAMPLER_WEIGHTS, name, weight_version=weight_version,
+        )
+        logger.info("[%s] Saving sampler weights for %s to %s (step %s)", request_id, model_id, ticket.ref.uri, ticket.step)
+        await self._save(handle, ticket)
+        logger.info("[%s] Sampler weights saved: %s", request_id, ticket.ref.uri)
+        return {
+            "path": ticket.ref.uri, "sampling_session_id": None, "uri": ticket.ref.uri,
+            "step": ticket.step, "name": name, "type": "save_weights_for_sampler",
+        }

--- a/training/services/model_service.py
+++ b/training/services/model_service.py
@@ -15,6 +15,7 @@ from datetime import datetime
 from typing import Dict, Any, Optional
 
 from ..backends.base import TrainingBackend, BackendHandle
+from ..checkpoints import CheckpointStore
 from ..storage import MetadataStorage
 from ..utils.model_config import extract_model_name, detect_architecture, detect_num_gpus
 
@@ -24,8 +25,9 @@ logger = logging.getLogger(__name__)
 class ModelService:
     """Service for managing ML model lifecycle and resources."""
 
-    def __init__(self, backend: TrainingBackend):
+    def __init__(self, backend: TrainingBackend, store: CheckpointStore):
         self.backend = backend
+        self.store = store
 
     async def create_model(
         self,
@@ -60,6 +62,11 @@ class ModelService:
         if parallelism_config:
             num_gpus = parallelism_config.get("num_gpus", num_gpus)
 
+        # The URI is an identity; the backend gets the resolved directory of a
+        # completed weights checkpoint, and its own private area for this model.
+        resume_from = self.store.resolve_resume(checkpoint_path) if checkpoint_path else None
+        native_root = self.store.native_root(model_id)
+
         # Delegate to backend. The objective axis (feature 004) is forwarded so
         # classification backends can stand up a classification head; LM-only
         # backends reject non-LM objectives. See specs/004-bionemo-classification.
@@ -71,7 +78,8 @@ class ModelService:
             lora_config=lora_config,
             parallelism=parallelism_config,
             debug_train_only=debug_train_only,
-            checkpoint_path=checkpoint_path,
+            resume_from=resume_from,
+            native_root=native_root,
             max_batch_size=max_batch_size,
             max_seq_len=max_seq_len,
             rlve_config=rlve_config,
@@ -159,6 +167,9 @@ class ModelService:
             self._legacy_delete(client_info)
 
         del training_clients[model_id]
+        # ephemeral sampler records die with the model; persistent checkpoints
+        # and the native area stay for a later resume
+        self.store.release_model(model_id)
 
         if "training_run_id" in client_info:
             metadata_storage.update_training_run(

--- a/training/services/session_service.py
+++ b/training/services/session_service.py
@@ -290,7 +290,8 @@ class SessionService:
         sampling_session_id: str,
         base_model: Optional[str] = None,
         model_path: Optional[str] = None,
-        model_id: Optional[str] = None
+        model_id: Optional[str] = None,
+        pinned_version: Optional[int] = None,
     ) -> bool:
         """
         Link a sampling session to a parent session.
@@ -327,6 +328,7 @@ class SessionService:
                 base_model=base_model if base_model else None,
                 model_path=model_path,
                 model_id=model_id,
+                pinned_version=pinned_version,
             )
 
             # Persist to storage

--- a/training/storage/metadata.py
+++ b/training/storage/metadata.py
@@ -205,7 +205,7 @@ class MetadataStorage:
         # Add metadata
         checkpoint_data["model_id"] = model_id
         checkpoint_data["checkpoint_name"] = checkpoint_name
-        checkpoint_data["created_at"] = datetime.utcnow().isoformat()
+        checkpoint_data.setdefault("created_at", datetime.utcnow().isoformat())
 
         # Save checkpoint metadata
         checkpoint_path = model_checkpoints_dir / f"{checkpoint_name}.json"


### PR DESCRIPTION
A `tinker://` URI is an identity, never a location. `training/checkpoints/store.py` (`CheckpointStore`) is the only code that knows the grammar (`tinker://<model>/<weights|sampler_weights>/<name>`, nothing else), the base directory (`TrainingConfig.storage.checkpoint_base`), the layout (`<base>/<model>/weights/<name>/`, `<base>/<model>/sampler_weights/<name>/`, `<base>/<model>/native/`), the per-model save counter, and the record of every save.

**ABC:** `save_checkpoint(handle, root, step, persist)`, `load_checkpoint(handle, root, optimizer)`, `create_model(..., resume_from, native_root)`. Every backend receives resolved directories and owns what it writes inside them. The URI resolution that lived in eight places under three rule sets (services, two routers, four backends, the Miles md5 `iter_*` guess) is gone; automodel and megatron_bridge, which were still handed the raw URI, cannot be any more.

**Records** hold identity, status (`pending` → `completed` | `failed`), step, ephemeral and the weight version at save — never a path. A save is pending from `begin_save` until the backend returns: `weights_info` / `load_weights` / sampling on a pending checkpoint answer 425, failed 500, unknown 404, malformed or wrong kind 400 (one exception handler in `api.py`). Pending rows left by a crash are marked failed at boot.

**Counter:** `max(step)+1` over the model's records, failed and deleted saves included, so a counter-named native artifact (Megatron `iter_*`) is never overwritten. Each Miles model saves under its own native area, which closes the shared `--save` collision.

**Sampling:** only `weights` checkpoints resume training; a `sampler_weights` path given to a sampling client pins it at the recorded version. Ephemeral sampler saves go through the same path with `persist=False` (a record and an identity, no bytes) and are dropped with the model; persistent checkpoints and `native/` outlive the model for a later resume.

`checkpoint_interchange.py` moves to `training/checkpoints/interchange.py` minus the resolver.

**Layout change, no compatibility shim:** training checkpoints move from `<base>/<model>/<name>` to `<base>/<model>/weights/<name>`; old records and bytes are not readable by this tree. Deploy with `/data/checkpoints` and `/data/metadata/checkpoints` wiped.

**Tests:** `tests/test_checkpoint_store.py`; `tests/protocol/test_checkpoints.py` gains pending → 425, admission of kind and shape, and a pinned sampler from a checkpoint path; `TestCheckpointRootContract` on the fake adapter; `test_miles_load_path.py` and `test_miles_resume_args.py` on roots and `--save`. CPU suites: 231 passed (nemorl pod), 138 passed / 13 skipped (miles8 pod). GPU: the three-phase resume acceptance (train + save, weights-only resume, with-optimizer resume) passes on nemo_rl (Qwen2.5-0.5B-Instruct) and miles (Qwen3-8B-Base) on the new layout, beside the deployed servers.