### PR TITLE
miles: ship client per-token weights beside the loss mask

### DIFF
--- a/tests/test_miles_loss_weights.py
+++ b/tests/test_miles_loss_weights.py
@@ -1,0 +1,69 @@
+"""Client per-token weights reach Miles beside the 0/1 mask, never inside it."""
+import importlib.util
+
+import pytest
+
+if importlib.util.find_spec("torch") is None:
+    pytest.skip("torch not installed", allow_module_level=True)
+
+from tinkercloud.training.backends.miles.converter import MilesDataConverter
+from tinkercloud.training.backends.miles.rollout_data import TinkerDataConverter
+
+
+def _td(vals, dtype="float32"):
+    return {"data": vals, "dtype": dtype, "shape": [len(vals)]}
+
+
+def _sft_datum(weights, T=6):
+    tokens = list(range(10, 10 + T))
+    return {"model_input": {"tokens": tokens},
+            "loss_fn_inputs": {"weights": _td(weights), "target_tokens": _td([t + 1 for t in tokens], "int64")}}
+
+
+def test_sft_weights_split_into_binary_mask_and_weights():
+    w = [0.0, 0.5, 1.0, 2.0, 0.0, 0.25]
+    rd = TinkerDataConverter().forward_backward_to_rollout([_sft_datum(w)], is_rl=False)
+    assert rd["loss_masks"][0].tolist() == [0.0, 1.0, 1.0, 1.0, 0.0, 1.0]
+    assert rd["loss_weights"][0].tolist() == w
+
+
+def test_rl_weights_split_and_trim_together():
+    T = 6
+    tokens = list(range(10, 10 + T))
+    w = [0.0, 0.0, 0.5, 1.0, 1.5, 1.0]
+    d = {"model_input": {"tokens": tokens},
+         "loss_fn_inputs": {"weights": _td(w), "logprobs": _td([-0.1] * T), "advantages": _td([1.0] * T)}}
+    rd = TinkerDataConverter().forward_backward_to_rollout([d], is_rl=True)  # no target: causal trim
+    assert rd["response_lengths"] == [T - 1]
+    assert rd["loss_masks"][0].tolist() == [0.0, 0.0, 1.0, 1.0, 1.0]
+    assert rd["loss_weights"][0].tolist() == w[:-1]
+
+
+def test_rl_without_weights_gets_unit_weights():
+    T = 4
+    d = {"model_input": {"tokens": list(range(T))},
+         "loss_fn_inputs": {"logprobs": _td([-0.1] * T), "advantages": _td([1.0] * T),
+                            "target_tokens": _td(list(range(1, T + 1)), "int64")}}
+    rd = TinkerDataConverter().forward_backward_to_rollout([d], is_rl=True)
+    assert rd["loss_weights"][0].tolist() == [1.0] * T
+    assert rd["loss_masks"][0].tolist() == [1.0] * T
+
+
+def test_forward_path_carries_weights_beside_mask():
+    w = [0.0, 0.5, 1.0, 0.0, 2.0, 1.0]
+    rd = TinkerDataConverter().forward_to_rollout([_sft_datum(w)])
+    assert rd["loss_masks"][0].tolist() == [0.0, 1.0, 1.0, 0.0, 1.0, 1.0]
+    assert rd["loss_weights"][0].tolist() == w
+
+
+def test_pad_zeroes_weights_and_merge_concatenates():
+    rd = TinkerDataConverter().forward_backward_to_rollout([_sft_datum([1.0] * 6)] * 3, is_rl=False)
+    rd["dynamic_global_batch_size"] = 3
+    n_pad = MilesDataConverter.pad_rollout_data_to_dp(rd, 2)
+    assert n_pad == 1 and len(rd["loss_weights"]) == 4
+    assert rd["loss_weights"][-1].tolist() == [0.0] * 6 and rd["loss_masks"][-1].tolist() == [0.0] * 6
+    a = TinkerDataConverter().forward_backward_to_rollout([_sft_datum([0.5] * 6)], is_rl=False)
+    b = TinkerDataConverter().forward_backward_to_rollout([_sft_datum([2.0] * 6)] * 2, is_rl=False)
+    a["dynamic_global_batch_size"], b["dynamic_global_batch_size"] = 1, 2
+    m = MilesDataConverter.merge_forward_backward_batches([a, b])
+    assert [x[0].item() for x in m["loss_weights"]] == [0.5, 2.0, 2.0]

--- a/training/backends/miles/converter.py
+++ b/training/backends/miles/converter.py
@@ -115,8 +115,8 @@ class MilesDataConverter(DataConverter):
 
         # Zeroing these is what makes a pad inert; everything else is copied so
         # the sample stays well-formed (valid token ids, consistent lengths).
-        zero_keys = {"loss_masks", "advantages", "log_probs", "rollout_log_probs",
-                     "returns", "values", "weights"}
+        zero_keys = {"loss_masks", "loss_weights", "advantages", "log_probs",
+                     "rollout_log_probs", "returns", "values", "weights"}
 
         for key, value in list(rollout_data.items()):
             if not (isinstance(value, list) and len(value) == n):

--- a/training/backends/miles/rollout_data.py
+++ b/training/backends/miles/rollout_data.py
@@ -98,6 +98,7 @@ class TinkerDataConverter:
         """
         tokens_list = []
         loss_masks_list = []
+        loss_weights_list = []
         response_lengths_list = []
 
         for datum in data:
@@ -113,12 +114,15 @@ class TinkerDataConverter:
             mask = cls._get_field(loss_fn_inputs, "mask")
             weights = cls._get_field(loss_fn_inputs, "weights")
 
+            # loss_mask is Miles' 0/1 response region; client per-token weights
+            # travel beside it as loss_weights (the loss multiplies them in).
+            loss_weights = None
+            if weights is not None:
+                loss_weights = torch.tensor(cls.extract_tensor_data(weights), dtype=torch.float32)
             if mask is not None:
-                mask_data = cls.extract_tensor_data(mask)
-                loss_mask = torch.tensor(mask_data, dtype=torch.float32)
-            elif weights is not None:
-                weights_data = cls.extract_tensor_data(weights)
-                loss_mask = torch.tensor(weights_data, dtype=torch.float32)
+                loss_mask = torch.tensor(cls.extract_tensor_data(mask), dtype=torch.float32)
+            elif loss_weights is not None:
+                loss_mask = (loss_weights != 0).to(torch.float32)
             else:
                 # Default: all ones (no masking)
                 loss_mask = torch.ones(len(tokens), dtype=torch.float32)
@@ -137,7 +141,10 @@ class TinkerDataConverter:
                 tokens_list[-1] = torch.cat([tokens_list[-1], torch.tensor(target_data[-1:], dtype=torch.long)])
             elif len(loss_mask) == len(tokens) and len(tokens) > 1:
                 loss_mask = loss_mask[:-1]  # no target on the wire: the last target is unknowable
+                if loss_weights is not None:
+                    loss_weights = loss_weights[:-1]
             loss_masks_list.append(loss_mask)
+            loss_weights_list.append(loss_weights if loss_weights is not None else torch.ones_like(loss_mask))
             response_lengths_list.append(len(loss_mask))
             # print(f"[CONVERTER DEBUG SFT] Sample {len(loss_masks_list)-1}: loss_mask sum={response_length}, len={len(loss_mask)}", flush=True)
 
@@ -148,6 +155,7 @@ class TinkerDataConverter:
         rollout_data = {
             "tokens": tokens_list,
             "loss_masks": loss_masks_list,
+            "loss_weights": loss_weights_list,
             "response_lengths": response_lengths_list,
             # Dummy fields for compatibility (not used in forward_only)
             "advantages": [torch.zeros(max_len, dtype=torch.float32) for _ in range(batch_size)],
@@ -200,6 +208,7 @@ class TinkerDataConverter:
         # print(f"[CONVERTER DEBUG SFT] forward_backward_to_rollout called with {len(data)} samples, is_rl={is_rl}", flush=True)
         tokens_list = []
         loss_masks_list = []
+        loss_weights_list = []
         response_lengths_list = []
 
         # RL-specific fields
@@ -220,6 +229,7 @@ class TinkerDataConverter:
             return {
                 "tokens": [],
                 "loss_masks": [],
+                "loss_weights": [],
                 "response_lengths": [],
                 "advantages": [] if is_rl else None,
                 "log_probs": [] if is_rl else None,
@@ -255,9 +265,10 @@ class TinkerDataConverter:
                 # (the cookbook's RL datums strip the mask and rely on zero
                 # advantages outside the response).
                 mask = cls._get_field(loss_fn_inputs, "mask")
-                if mask is None:
-                    mask = cls._get_field(loss_fn_inputs, "weights")
-                mask_data = cls.extract_tensor_data(mask) if mask is not None else None
+                weights = cls._get_field(loss_fn_inputs, "weights")
+                weights_data = cls.extract_tensor_data(weights) if weights is not None else None
+                mask_from_weights = mask is None and weights is not None
+                mask_data = cls.extract_tensor_data(mask) if mask is not None else weights_data
 
                 # Step 2: Determine response_len from mask or logprobs
                 if mask_data is not None:
@@ -301,8 +312,14 @@ class TinkerDataConverter:
                 # Step 4: Build per-token tensors (all must have length = response_len)
                 if mask_data is not None:
                     loss_mask = torch.tensor(maybe_trim(mask_data), dtype=torch.float32)
+                    if mask_from_weights:
+                        loss_mask = (loss_mask != 0).to(torch.float32)
                 else:
                     loss_mask = torch.ones(response_len, dtype=torch.float32)
+                if weights_data is not None:
+                    loss_weights_list.append(torch.tensor(maybe_trim(weights_data), dtype=torch.float32))
+                else:
+                    loss_weights_list.append(torch.ones(response_len, dtype=torch.float32))
 
                 if logprobs_data is not None:
                     logprobs_clean = [0.0 if lp is None else float(lp) for lp in logprobs_data]
@@ -376,11 +393,13 @@ class TinkerDataConverter:
                 full_tokens = torch.cat([input_tokens_tensor, target_tensor[-1:]], dim=0)
                 tokens_list[-1] = full_tokens  # Replace the one we added earlier
 
-                loss_mask = torch.tensor(weights_data, dtype=torch.float32)
+                loss_weights = torch.tensor(weights_data, dtype=torch.float32)
+                loss_mask = (loss_weights != 0).to(torch.float32)
                 response_len = len(loss_mask)
 
                 # Append to shared lists
                 loss_masks_list.append(loss_mask)
+                loss_weights_list.append(loss_weights)
                 response_lengths_list.append(response_len)
                 advantages_list.append(torch.zeros(response_len, dtype=torch.float32))
                 log_probs_list.append(torch.zeros(response_len, dtype=torch.float32))
@@ -389,6 +408,7 @@ class TinkerDataConverter:
         rollout_data = {
             "tokens": tokens_list,
             "loss_masks": loss_masks_list,
+            "loss_weights": loss_weights_list,
             "response_lengths": response_lengths_list,
             "advantages": advantages_list,
             "log_probs": log_probs_list,


### PR DESCRIPTION
The Miles converter had been placing Tinker's per-token `weights` into the sample's `loss_mask`, the only per-token slot the engine has. That slot means "response region" and is consumed as such throughout the engine, and the actor casts it to int, so fractional weights truncated to zero and any per-datum scaling of weights cancelled in the engine's per-sample mean.

`rollout_data.py` now emits `loss_weights` as its own per-sample tensor on every path (forward, RL, SFT; unit weights when the client sends none) and keeps `loss_masks` 0/1 (`weights != 0` when derived from weights). `converter.py` zeroes the new key on DP padding; co-batch merging already concatenates every per-sample list. Requires the matching seam change on the Miles side (`loss_weights` passthrough and the token-sum reducer); deploy the two together.

Tests: `tests/test_miles_loss_weights.py` (binary mask + weights on each path, causal trim applied to both, unit weights by default, padding zeroes, merge concatenates). Measured end-to-end on Qwen3-8B-Base with lr=0: weights 1/64 scale the gradient norm by exactly 1/64; 0/1 weights reproduce the token-sum result unchanged.
